### PR TITLE
Fix sender email

### DIFF
--- a/config/initializers/devise.rb
+++ b/config/initializers/devise.rb
@@ -4,7 +4,7 @@ Devise.setup do |config|
   # ==> Mailer Configuration
   # Configure the e-mail address which will be shown in Devise::Mailer,
   # note that it will be overwritten if you use your own mailer class with default "from" parameter.
-  config.mailer_sender = "no-reply@conferences.opensuse.org"
+  config.mailer_sender = "no-reply@conference.opensuse.org"
 
   # Configure the class responsible to send e-mails.
   # config.mailer = "Devise::Mailer"


### PR DESCRIPTION
There is no domain confereces.opensuse.org and some mail server might reject such email.
