### PR TITLE
Fixed scrolling issue

### DIFF
--- a/app/views/admin/users/index.html.haml
+++ b/app/views/admin/users/index.html.haml
@@ -50,7 +50,7 @@
                       = f.action :submit, :as => :button, :button_html => {:value => "Save", :class => "btn btn-primary"}
               =link_to "Modify Roles", "#", "data-toggle" => "modal", "data-target" => "#user-role-selection-#{user.id}}"
             %td
-              =link_to "Details", "#", :class => "user-details-popover", "data-trigger" => "click", "data-placement" => "bottom",
+              =link_to "Details", "javascript: void(0)", :class => "user-details-popover", "data-trigger" => "click", "data-placement" => "bottom",
                 "data-html" => "true",
                 "data-content" => user.popup_details,
                 "data-original-title" => ""


### PR DESCRIPTION
Adding `#` in the href when you click in the 'Details' it takes you 
to the top and then you should scroll down in order to see the user's Details.
Adding `javascript: void(0)` instead of `#` we fix scrolling because it doesn't take you to the top.
