### PR TITLE
media_type not nil

### DIFF
--- a/db/migrate/20140328144310_add_youtube_to_media_type.rb
+++ b/db/migrate/20140328144310_add_youtube_to_media_type.rb
@@ -1,0 +1,8 @@
+class AddYoutubeToMediaType < ActiveRecord::Migration
+  def up    
+    Event.where(:media_type => nil).each do |e|
+      e.media_type = "YouTube"
+      e.save(:validate => false)
+    end
+  end
+end


### PR DESCRIPTION
Validation of media_type in Event model, introduced in https://github.com/openSUSE/osem/pull/46, fails for older Event submissions, for which media_type is nil. 

For new submissions the media_type is YouTube, unless the submitter chooses something different from the drop down.
