### PR TITLE
fix unless statement

### DIFF
--- a/app/views/admin/events/index.html.haml
+++ b/app/views/admin/events/index.html.haml
@@ -13,7 +13,7 @@
             %b ID
           %th
             %b Title
-          - unless @conference.call_for_papers.blank? or @conference.call_for_papers.rating > 0
+          - unless @conference.call_for_papers.blank? or !(@conference.call_for_papers.rating > 0)
             %th
               %b Rating
           %th


### PR DESCRIPTION
We want the rating column to be visible if rating > 0 
(If the rating was 0 it would mean no rating for the conference. Negative values are not possible due to validation in the call_for_papers model.)
