### PR TITLE
show schedule in home page only if it is set as public

### DIFF
--- a/app/models/call_for_papers.rb
+++ b/app/models/call_for_papers.rb
@@ -1,5 +1,5 @@
 class CallForPapers < ActiveRecord::Base
-  attr_accessible :start_date, :end_date, :hard_deadline, :description, :schedule_changes, :rating, :rating_desc
+  attr_accessible :start_date, :end_date, :hard_deadline, :description, :schedule_changes, :rating, :rating_desc, :schedule_public
   belongs_to :conference
 
   validates_presence_of :start_date, :end_date, :hard_deadline

--- a/app/views/admin/callforpapers/show.html.haml
+++ b/app/views/admin/callforpapers/show.html.haml
@@ -8,6 +8,7 @@
       = f.input :hard_deadline, :as => :string, :input_html => { :id => "cfp-hard-datepicker", :readonly => "readonly"  }
       = f.input :description, :hint => "Welcome text for the Call for Papers"
       = f.input :schedule_changes
+      = f.input :schedule_public
       = f.input :rating, :hint => "Enter the number of different rating levels you want to have for voting on proposals. Enter 0 if you do not want to vote on proposals."
       = f.input :rating_desc, :label => "Rating Description", :hint => "Enter comments about voting process.", :input_html => {:value => "1 is for 'I don't like this proposal',\n2 is for 'I am ok with this proposal.',\n3 is for 'I love this proposal!'", :rows => 5, :class => "span6"}
       = f.action :submit, :as => :button, :button_html => {:class => "btn btn-primary"}

--- a/app/views/home/index.html.haml
+++ b/app/views/home/index.html.haml
@@ -29,7 +29,7 @@
                   = link_to "Modify Registration", register_conference_path(conference.short_title), :class =>"btn btn-default"
                 - else
                   = link_to "Register", register_conference_path(conference.short_title), :class =>"btn btn-success"
-              = link_to "Schedule", conference_schedule_path(conference.short_title), :class =>"btn btn-default"
+              = link_to "Schedule", conference_schedule_path(conference.short_title), :class =>"btn btn-default" if conference.call_for_papers and conference.call_for_papers.schedule_public
               - if !current_user.nil? && current_user.person.proposal_count(conference) > 0
                 = link_to "View My Proposals", conference_proposal_index_path(conference.short_title), :class =>"btn btn-default"
               - elsif conference.cfp_open?

--- a/db/migrate/20140401094729_add_schedule_public_to_call_for_papers.rb
+++ b/db/migrate/20140401094729_add_schedule_public_to_call_for_papers.rb
@@ -1,0 +1,5 @@
+class AddSchedulePublicToCallForPapers < ActiveRecord::Migration
+  def change
+    add_column :call_for_papers, :schedule_public, :boolean
+  end
+end


### PR DESCRIPTION
Do you think we should link people to the schedule only after we have finalized it (and set it as public) ?
