### PR TITLE
Validations for start and end date

### DIFF
--- a/app/models/conference.rb
+++ b/app/models/conference.rb
@@ -51,7 +51,9 @@ class Conference < ActiveRecord::Base
 
   validates_presence_of :title,
                         :short_title,
-                        :social_tag
+                        :social_tag,
+                        :start_date,
+                        :end_date
   validates_uniqueness_of :short_title
   validates_format_of :short_title, :with => /^[a-zA-Z0-9_-]*$/
    


### PR DESCRIPTION
Validations for start and end dates are not mentioned in the model.So there is an error when a admin submits the new conference without specifying the start and end dates, this is fixed  by applying validations for both of them in the conference model.
