### PR TITLE
Fix admin first setup, email and password in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -77,14 +77,9 @@ bundle exec rake db:seed
 
 7. Connect to osem.example.org and register your first user. Make also sure that Postfix is installed and configured on the system for the confirmation mail to pass through.
 
-<!-- 8. To make the first registered user an admin:
-```
-rails console
-User.all
-me = User.find('1')
-me.role_ids=[3]
-``` -->
-8. Login as Admin with email:admin@opensuse.org and password:admin1234
+8. Just sign up as a new user and you will be automatically assigned as admin role.
+
+
 
 Caveats
 =======

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -10,7 +10,7 @@ class User < ActiveRecord::Base
   has_and_belongs_to_many :roles
   has_one :person, :inverse_of => :user
 
-  attr_accessible :email, :password, :password_confirmation, :remember_me, :role_id, :role_ids, :person_attributes,:confirmed_at
+  attr_accessible :email, :password, :password_confirmation, :remember_me, :role_id, :role_ids, :person_attributes
   accepts_nested_attributes_for :person
   accepts_nested_attributes_for :roles
 
@@ -27,9 +27,13 @@ class User < ActiveRecord::Base
   end
 
   def setup_role
+    if self.id == 1
+      self.role_ids = [3]
+    end
+    
     if self.role_ids.empty?
       self.role_ids = [1]
-      end
+    end
   end
 
   def popup_details

--- a/db/seeds.rb
+++ b/db/seeds.rb
@@ -9,9 +9,6 @@ Role.create(:name => "Participant")
 Role.create(:name => "Organizer")
 Role.create(:name => "Admin")
 
-#For first admin setup 
-User.create(email:"admin@opensuse.org", password:"admin1234", password_confirmation:"admin1234",role_ids:[3],confirmed_at:Time.now) 
-
 qtype_yesno = QuestionType.create(:title => "Yes/No")
 qtype_single = QuestionType.create(:title => "Single Choice")
 qtype_multiple = QuestionType.create(:title => "Multiple Choice")


### PR DESCRIPTION
Sample user will be automatically created on rake db:seed with email:admin@opensuse.org and password:admin1234, this is mentioned in README for documentation.User then won't have to create a user explicitly and set the role as admin.
