### PR TITLE
Fix devise secret key by assigning some random string

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,7 +19,13 @@ git clone https://github.com/openSUSE/osem.git
 bundle install
 ```
 3. Install ImageMagick from your distribution repository
-4. Copy the sample configuration files and adapt them
+4. Generate secret key for devise and the rails app with 
+```
+rake secret
+```
+Look at config/config.yml.example.
+
+5. Copy the sample configuration files and adapt them
 ```
 cp config/config.yml.example config/config.yml
 cp config/database.yml.example config/database.yml
@@ -28,6 +34,7 @@ cp config/database.yml.example config/database.yml
 ```
 bundle exec rake db:setup
 ```
+
 7. Run OSEM
 ```
 rails server

--- a/config/initializers/devise.rb
+++ b/config/initializers/devise.rb
@@ -2,7 +2,7 @@
 # Many of these configuration options can be set straight in your model.
 Devise.setup do |config|
   # ==> Secret key, generate one with `rake secret`
-  config.secret_key = 'somesecretkey1234'
+  config.secret_key = CONFIG['devise_secret_key']
 
   # ==> Mailer Configuration
   # Configure the e-mail address which will be shown in Devise::Mailer,


### PR DESCRIPTION
The devise secret is assigned a random string so as to remove the error "can't convert fixnum to string" 
