### PR TITLE
Removed public scope from event_atachment model

### DIFF
--- a/app/models/event_attachment.rb
+++ b/app/models/event_attachment.rb
@@ -2,7 +2,6 @@ class EventAttachment < ActiveRecord::Base
   has_paper_trail
 
   belongs_to :event
-  scope :public, where(:public => true)
   attr_accessible :public, :attachment, :event_id, :title
 
   has_attached_file :attachment, :path => ":rails_root/storage/:rails_env/attachments/:id/:style/:basename.:extension"


### PR DESCRIPTION
Should fix openSUSE/osem#87
