### PR TITLE
Ignoring two files in gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -26,3 +26,5 @@ pickle-email-*.html
 /public/assets
 /bundle
 /doc/app
+/config/secrets.yml
+/db/schema.rb


### PR DESCRIPTION
the server asks for adding secrets.yml which has nothing to do with the production app in general also on migration the schema changes which independent of the app in general.So ignoring two files in .gitignore 
config/secrets.yml and db/schema.rb
