### PR TITLE
replacing put requests by patch for rails 4 compatibility

### DIFF
--- a/config/routes.rb
+++ b/config/routes.rb
@@ -7,22 +7,22 @@ Osem::Application.routes.draw do
     resources :people
     resources :conference do
       get "/schedule" => "schedule#show"
-      put "/schedule" => "schedule#update"
+      patch "/schedule" => "schedule#update"
       get "/stats" => "stats#index"
       get "/registrations" => "registrations#show"
       get "/registrations/new" => "registrations#new"
-      put "/registrations/new" => "registrations#create"
+      patch "/registrations/new" => "registrations#create"
       get "/registrations/edit" => "registrations#edit"
-      put "/registrations/edit" => "registrations#update"
+      patch "/registrations/edit" => "registrations#update"
       delete "/registrations"  => "registrations#delete"
-      put "/registrations/change_field" => "registrations#change_field"
+      patch "/registrations/change_field" => "registrations#change_field"
       get "/venue" => "venue#show", :as => "venue_info"
-      put "/venue" => "venue#update", :as => "venue_update"
+      patch "/venue" => "venue#update", :as => "venue_update"
       get "/dietary_choices" => "dietchoices#show", :as => "dietary_list"
-      put "/dietary_choices" => "dietchoices#update", :as => "dietary_update"
+      patch "/dietary_choices" => "dietchoices#update", :as => "dietary_update"
       get "/volunteers_list" => "volunteers#show"
       get "/volunteers" => "volunteers#index", :as => "volunteers_info"
-      put "/volunteers" => "volunteers#update", :as => "volunteers_update"
+      patch "/volunteers" => "volunteers#update", :as => "volunteers_update"
 
       resources :difficulty_levels, only: [:show, :update, :index]
       resources :rooms, only: [:show, :update, :index]
@@ -32,13 +32,13 @@ Osem::Application.routes.draw do
       resources :supporter_levels, only: [:show, :update, :index]
       resources :emails, only: [:show, :update, :index]
       resources :callforpapers, only: [:show, :update, :index]
-      put "/questions/update_conference" => "questions#update_conference"
+      patch "/questions/update_conference" => "questions#update_conference"
       resources :questions
       resources :events do
         member do
           post :comment
-          put :update_state
-          put :update_track
+          patch :update_state
+          patch :update_track
           get :vote
         end
         resource :speaker, :only => [:edit, :update]
@@ -50,14 +50,14 @@ Osem::Application.routes.draw do
   resources :conference, :only => [] do
     resources :proposal do
       resources :event_attachment, :controller => "event_attachments"
-      put "/confirm" => "proposal#confirm"
+      patch "/confirm" => "proposal#confirm"
     end
     resource :schedule, :only => [] do
       get "/" => "schedule#index"
     end
     member do
       get "/register" => "conference_registration#register"
-      put "/register" => "conference_registration#update"
+      patch "/register" => "conference_registration#update"
       delete "/register" => "conference_registration#unregister"
     end
   end


### PR DESCRIPTION
All put requests should be replaced by patch as per rails 4 guidelines.The one which I discovered for was with updating venue for a conference, so I replaced all put requests by patch.
