### PR TITLE
Use a single entry for navigation branding:

### DIFF
--- a/app/helpers/application_helper.rb
+++ b/app/helpers/application_helper.rb
@@ -1,5 +1,4 @@
 module ApplicationHelper
-
   def bootstrap_class_for(flash_type)
     logger.debug "flash_type is #{flash_type}"
     case flash_type
@@ -31,7 +30,7 @@ module ApplicationHelper
       registration.send(field.to_sym).strftime("%d %b %H:%M") if registration.send(field.to_sym)
     end
   end
-  
+
   def getdate(var)
     if var.kind_of?(String)
       DateTime.parse(var).strftime("%a, %d %b")
@@ -111,5 +110,24 @@ module ApplicationHelper
     end
 
     result
+  end
+
+  def default_brand
+    link_to CONFIG['name'], root_path,
+            class: 'navbar-brand',
+            title: 'Open Source Event Manager'
+  end
+
+  def short_title_brand(conference)
+    link_to conference.short_title, conference_path(conference.short_title),
+            class: 'navbar-brand',
+            title: conference.title
+  end
+
+  def brand
+    content_for(:brand) ||
+    (default_brand if controller.class.parent == Admin) ||
+    (short_title_brand(@conference) if @conference) ||
+    default_brand
   end
 end

--- a/app/views/conference/show.html.haml
+++ b/app/views/conference/show.html.haml
@@ -1,3 +1,3 @@
-= content_for :splash_logo do 
-  = link_to @conference.title, "#", :class => 'navbar-brand'
+= content_for :brand do
+  = link_to @conference.title, conference_url(@conference.short_title), class: 'navbar-brand'
 = render :partial => "home/conference_details", :locals => {:conference => @conference}

--- a/app/views/layouts/_navigation.html.haml
+++ b/app/views/layouts/_navigation.html.haml
@@ -7,20 +7,15 @@
         %span.icon-bar
         %span.icon-bar
         %span.icon-bar
-      = yield(:splash_logo) 
-      = link_to CONFIG['name'], root_path, :class => 'navbar-brand', :title => "Open Source Event Manager"
+      = brand
     .collapse.navbar-collapse
-      = yield(:splash_header)
-      - if @conference && !@conference.short_title.nil?
-        %p.navbar-text
-          = @conference.short_title
       -if user_signed_in?
         %ul.nav.navbar-nav.navbar-right
           %li.dropdown
             %a.dropdown-toggle{"data-toggle" => "dropdown", :href => "#", id: "current-user-detail"}
               - if not current_user.person.public_name.empty?
                 #{current_user.person.public_name}
-              -else 
+              -else
                 #{current_user.email}
               = image_tag(current_user.person.gravatar_url(size: '18'), title: "Yo #{current_user.person.public_name}!", :alt => '')
               %b.caret
@@ -37,7 +32,7 @@
             %li
               = link_to(new_registration_path('user')) do
                 %span.glyphicon.glyphicon-heart
-                Sign Up  
+                Sign Up
             %li.dropdown.visible-desktop
               %a.dropdown-toggle{"data-toggle" => "dropdown", :href => "#"}
                 %span.glyphicon.glyphicon-user


### PR DESCRIPTION
Allow a view to override the brand (esp. for conference splash pages),
Use the app name link for the admin control panel,
use the conference short title for end user content within a conference,
fall back to the app name link.

Visually, there are two substantial changes:
(1) the conference title (or short title) serves as the brand when viewing
conference content;
(2) the short title isn't shown redundantly on the navbar and the top of the
sidebar when editing a conf.
