### PR TITLE
Remove additional whitespace around flash.

### DIFF
--- a/app/assets/stylesheets/osem.css
+++ b/app/assets/stylesheets/osem.css
@@ -10,10 +10,6 @@ body {
     padding-top: 60px;
 }
 
-body > #messages {
-    padding: 60px 15px 0;
-}
-
 #footer {
     position: absolute;
     bottom: 0;


### PR DESCRIPTION
Looking at the screenshots, it just seems excessive.

_With the padding_:
![screenshot](http://i.imgur.com/F9xjOXn.png)

_Without_:
![screenshot](http://i.imgur.com/ebNeALq.png)
