### PR TITLE
schedule route

### DIFF
--- a/config/routes.rb
+++ b/config/routes.rb
@@ -9,7 +9,8 @@ Osem::Application.routes.draw do
     resources :people
     resources :conference do
       get "/schedule" => "schedule#show"
-      patch "/schedule" => "schedule#update"
+      # FIXME 'Patch' route for schedule does not work
+      put "/schedule" => "schedule#update"
       get "/stats" => "stats#index"
       get "/venue" => "venue#show", :as => "venue_info"
       patch "/venue" => "venue#update", :as => "venue_update"


### PR DESCRIPTION
Schedule does not route to patch, it still routes to put and raises error. I am not sure how to fix this.

Log of the routing error (No route matches [PUT]) I get:
http://paste.opensuse.org/92030904

Shall we leave it as PUT for the time being, so that things can work, until we properly fix it?
