### PR TITLE
change start_week.year to start_date.year

### DIFF
--- a/app/models/call_for_papers.rb
+++ b/app/models/call_for_papers.rb
@@ -14,7 +14,7 @@ class CallForPapers < ActiveRecord::Base
   # * +Integer+ -> start week
   def weeks
     result = end_week - start_week + 1
-    weeks = Date.new(start_week.year, 12, 31).strftime('%W').to_i
+    weeks = Date.new(start_date.year, 12, 31).strftime('%W').to_i
     result < 0 ? result + weeks : result
   end
 


### PR DESCRIPTION
Test in my master fails at this line. 

start_week seems to be number 52 in our testing and start_week.year gives us     52 years
start_date.year gives us what we are looking for, which is the year of the first week that the cfp is open.
