### PR TITLE
Do not add rubocop config

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -28,3 +28,4 @@ pickle-email-*.html
 /bundle
 /doc/app
 .ruby-version
+rubocop.yml


### PR DESCRIPTION
This will allow one to run rubocop locally to speed up turnaround.
