### PR TITLE
Add rubocop to Gemfile

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -15,6 +15,8 @@ In particular, this community seeks the following types of contributions:
 * One of the OSEM maintainers will review your pull-request 
   * If you are already a contributor (means you're in the [group osem-committers](https://github.com/orgs/openSUSE/teams/osem-committers)) and you get a positive review, you can merge your pull-request yourself
   * If you are not a contributor already please request a merge via the pull-request comments
+* Run rubocop locally for fixes according to HoundCI comments
+  * https://github.com/openSUSE/osem/wiki/Houndci-and-rubocop
 
 # Conduct
 OSEM is part of the openSUSE project. We follow all the [openSUSE Guiding

--- a/Gemfile
+++ b/Gemfile
@@ -96,6 +96,8 @@ group :development do
   # rspec Guard rules
   gem 'guard-rspec', '~> 4.2.8'
   gem 'spring-commands-rspec'
+  # Get HoundCi comments locally
+  gem 'rubocop'
   # Silence rack assests messages
   gem 'quiet_assets'
   # Use sqlite3 as the database in development

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -35,6 +35,7 @@ GEM
       awesome_nested_set (>= 2.0)
     addressable (2.3.6)
     arel (5.0.1.20140414130214)
+    ast (2.0.0)
     awesome_nested_set (2.1.6)
       activerecord (>= 3.0.0)
     axlsx (2.0.1)
@@ -174,8 +175,12 @@ GEM
       activesupport (>= 3.0.0)
       cocaine (~> 0.5.3)
       mime-types
+    parser (2.1.9)
+      ast (>= 1.1, < 3.0)
+      slop (~> 3.4, >= 3.4.5)
     pdf-core (0.2.5)
     polyglot (0.3.4)
+    powerpack (0.0.9)
     prawn (1.0.0)
       pdf-core (~> 0.2.2)
       ttfunk (~> 1.1.1)
@@ -210,6 +215,7 @@ GEM
       activesupport (= 4.1.0)
       rake (>= 0.8.7)
       thor (>= 0.18.1, < 2.0)
+    rainbow (2.0.0)
     rake (10.3.1)
     rb-fsevent (0.9.4)
     rb-inotify (0.9.4)
@@ -247,6 +253,13 @@ GEM
       rspec-mocks (= 3.0.0.beta2)
       rspec-support (= 3.0.0.beta2)
     rspec-support (3.0.0.beta2)
+    rubocop (0.22.0)
+      json (>= 1.7.7, < 2)
+      parser (~> 2.1.9)
+      powerpack (~> 0.0.6)
+      rainbow (>= 1.99.1, < 3.0)
+      ruby-progressbar (~> 1.4)
+    ruby-progressbar (1.5.1)
     rubyzip (1.0.0)
     sass (3.2.19)
     sass-rails (4.0.3)
@@ -343,6 +356,7 @@ DEPENDENCIES
   rdoc-generator-fivefish
   rspec (>= 3.0.0.beta)
   rspec-rails (>= 3.0.0.beta)
+  rubocop
   sass-rails (>= 4.0.2)
   shoulda
   spring-commands-rspec


### PR DESCRIPTION
Following up https://github.com/openSUSE/osem/pull/248
I get an error that rubocop has to be in the Gemfile.
