### PR TITLE
Admin sidebar: show schedule instead of edit

### DIFF
--- a/app/controllers/admin/schedules_controller.rb
+++ b/app/controllers/admin/schedules_controller.rb
@@ -4,7 +4,7 @@ module Admin
     skip_before_filter :verify_authenticity_token, only: [:update]
     layout 'schedule'
 
-    def show
+    def edit
       if @conference.nil?
         redirect_to admin_conference_index_path
         return

--- a/app/controllers/schedule_controller.rb
+++ b/app/controllers/schedule_controller.rb
@@ -1,18 +1,17 @@
 class ScheduleController < ApplicationController
+  layout 'application'
 
-  layout "application"
-  
   def index
-    @conference = Conference.includes(:rooms, {:events => [:speakers, :track, :event_type]}).where("conferences.short_title" => params[:conference_id]).first
+    @conference = Conference.includes(:rooms, events: [:speakers, :track, :event_type]).
+                  where('conferences.short_title' => params[:conference_id]).first
     @rooms = @conference.rooms
     @events = @conference.events
     @dates = @conference.start_date..@conference.end_date
 
     if @dates === Date.current
-      @today = Date.current.strftime("%Y-%m-%d")
+      @today = Date.current.strftime('%Y-%m-%d')
     else
-      @today = @conference.start_date.strftime("%Y-%m-%d")
+      @today = @conference.start_date.strftime('%Y-%m-%d')
     end
   end
-
 end

--- a/app/views/admin/schedules/edit.html.haml
+++ b/app/views/admin/schedules/edit.html.haml
@@ -1,6 +1,7 @@
 .schedule-content
   %h2
-    = "Schedule for #{@conference.title}"
+    = "Edit schedule for #{@conference.title} or go back to"
+    = link_to 'schedule', conference_schedule_path(@conference.short_title)
   #unscheduled.unscheduled
     .unscheduled-header
       Unscheduled Events

--- a/app/views/layouts/_admin_sidebar.html.haml
+++ b/app/views/layouts/_admin_sidebar.html.haml
@@ -32,8 +32,8 @@
     = link_to(admin_conference_registrations_path(@conference.short_title)) do
       %span.glyphicon.glyphicon-user
       Registrations
-  %li{class: active_nav_li(admin_conference_schedule_path(@conference.short_title))}
-    = link_to(admin_conference_schedule_path(@conference.short_title), target: '_blank') do
+  %li{class: active_nav_li(conference_schedule_path(@conference.short_title))}
+    = link_to(conference_schedule_path(@conference.short_title), target: '_blank') do
       %span.glyphicon.glyphicon-calendar
       Schedule
   %li{class: active_nav_li(admin_conference_campaigns_path(@conference.short_title))}

--- a/app/views/schedule/index.html.erb
+++ b/app/views/schedule/index.html.erb
@@ -1,5 +1,9 @@
 <div id="schedule-content">
-  <h2> Schedule for <%= @conference.title %></h2>
+  <h2> Schedule for <%= @conference.title %>
+    <% if has_role?(current_user, 'Admin')%>
+      <%= link_to "Edit", edit_admin_conference_schedule_path(@conference.short_title), :class => "btn btn-mini btn-primary pull-right"%>
+    <% end %>
+  </h2>
   <ul class="nav nav-tabs">
     <% @dates.each do |date| %>
       <li <%= "class=active" if @dates.first == date %>>
@@ -94,18 +98,18 @@
   </div>
 
 <%= javascript_tag do %>
-  jQuery( function($) { 
-    $('tbody tr td[data-href]').addClass('clickable').mouseup(function(e) { 
+  jQuery( function($) {
+    $('tbody tr td[data-href]').addClass('clickable').mouseup(function(e) {
       if(e.which===1)
       {
-        window.location = $(this).attr('data-href'); 
+        window.location = $(this).attr('data-href');
       }
       else if(e.which===2)
       {
       window.open($(this).attr('data-href'), '_blank');
       }
-    }); 
-}); 
+    });
+});
 
 $(function() {
   // add a hash to the URL when the user clicks on a tab

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -10,7 +10,7 @@ Osem::Application.routes.draw do
     resources :users
     resources :people
     resources :conference do
-      resource :schedule, only: [:show, :update]
+      resource :schedule, only: [:edit, :update]
       get '/stats' => 'stats#index'
       get '/venue' => 'venue#show', as: 'venue_info'
       patch '/venue' => 'venue#update', as: 'venue_update'
@@ -58,7 +58,7 @@ Osem::Application.routes.draw do
         end
       end
 
-      patch "/questions/update_conference" => "questions#update_conference"
+      patch '/questions/update_conference' => 'questions#update_conference'
       resources :questions
 
       resources :events do
@@ -72,7 +72,7 @@ Osem::Application.routes.draw do
           patch :restart
           get :vote
         end
-        resource :speaker, :only => [:edit, :update]
+        resource :speaker, only: [:edit, :update]
       end
 
       resources :supporters
@@ -81,12 +81,12 @@ Osem::Application.routes.draw do
 
   resources :conference, only: [:show] do
     resources :proposal do
-      resources :event_attachment, :controller => "event_attachments"
+      resources :event_attachment, controller: 'event_attachments'
       patch '/confirm' => 'proposal#confirm'
       patch '/restart' => 'proposal#restart'
     end
-    resource :schedule, :only => [] do
-      get "/" => "schedule#index"
+    resource :schedule, only: [] do
+      get '/' => 'schedule#index'
     end
     member do
       get "/register" => "conference_registration#register"
@@ -96,23 +96,23 @@ Osem::Application.routes.draw do
     end
   end
 
-  namespace :api, defaults: {format: 'json'} do
+  namespace :api, defaults: { format: 'json' } do
     namespace :v1 do
-      resources :conferences, :only => :index do
-        resources :conferences, :only => :index
-        resources :rooms, :only => :index
-        resources :tracks, :only => :index
-        resources :speakers, :only => :index
-        resources :events, :only => :index
+      resources :conferences, only: :index do
+        resources :conferences, only: :index
+        resources :rooms, only: :index
+        resources :tracks, only: :index
+        resources :speakers, only: :index
+        resources :events, only: :index
       end
-      resources :rooms, :only => :index
-      resources :tracks, :only => :index
-      resources :speakers, :only => :index
-      resources :events, :only => :index
+      resources :rooms, only: :index
+      resources :tracks, only: :index
+      resources :speakers, only: :index
+      resources :events, only: :index
     end
   end
 
-  get "/admin" => redirect("/admin/conference")
+  get '/admin' => redirect('/admin/conference')
 
   root to: 'home#index', via: [:get, :options]
 end


### PR DESCRIPTION
@henne is that what you had in mind for https://github.com/openSUSE/osem/issues/159 ?

admin/schedules holds the edit option for the schedule.
routes are configured respectively only with actions :edit and :update
