### PR TITLE
add check in case there is a mismatch between users and people

### DIFF
--- a/db/migrate/20140610165551_migrate_data_person_to_user.rb
+++ b/db/migrate/20140610165551_migrate_data_person_to_user.rb
@@ -9,20 +9,22 @@ class MigrateDataPersonToUser < ActiveRecord::Migration
 
   def change
     TempPerson.all.each do |p|
-      user = TempUser.find(p.user_id)
-      if p.public_name.empty?
-        user.name = p.email
-      else
-        user.name = p.public_name
+      user = TempUser.where('id = ?', p.user_id).first
+      unless user.nil?
+        if p.public_name.empty?
+          user.name = p.email
+        else
+          user.name = p.public_name
+        end
+        user.biography = p.biography
+        user.nickname = p.irc_nickname
+        user.affiliation = p.company
+        user.avatar_file_name = p.avatar_file_name
+        user.avatar_content_type = p.avatar_content_type
+        user.avatar_file_size = p.avatar_file_size
+        user.avatar_updated_at = p.avatar_updated_at
+        user.save!
       end
-      user.biography = p.biography
-      user.nickname = p.irc_nickname
-      user.affiliation = p.company
-      user.avatar_file_name = p.avatar_file_name
-      user.avatar_content_type = p.avatar_content_type
-      user.avatar_file_size = p.avatar_file_size
-      user.avatar_updated_at = p.avatar_updated_at
-      user.save!
     end
   end
 end


### PR DESCRIPTION
If a user was deleted, without the corresponding person being deleted too, we should not create the user. 

The migration iterates through 'people', so we should double check that the people.user_id actually corresponds to a valid user, if not ignore that person.
