### PR TITLE
[Bugfix] Confirmed / Unconfirmed events over time for conference dashboard

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -98,6 +98,9 @@ gem 'factory_girl_rails'
 gem 'ahoy_matey'
 gem 'activeuuid'
 
+# We use whenever for recurring jobs
+gem 'whenever', :require => false
+
 # Use guard and spring for testing in development
 group :development do
   # rspec Guard rules

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -75,6 +75,7 @@ GEM
       nio4r (>= 0.5.0)
     chart-js-rails (0.0.6)
       railties (> 3.1)
+    chronic (0.10.2)
     climate_control (0.0.3)
       activesupport (>= 3.0)
     cliver (0.3.2)
@@ -374,6 +375,9 @@ GEM
     warden (1.2.3)
       rack (>= 1.0)
     websocket-driver (0.3.3)
+    whenever (0.9.2)
+      activesupport (>= 2.3.4)
+      chronic (>= 0.6.3)
     xpath (2.0.0)
       nokogiri (~> 1.3)
     yajl-ruby (1.2.0)
@@ -435,3 +439,4 @@ DEPENDENCIES
   transitions
   turbolinks
   uglifier (>= 1.3.0)
+  whenever

--- a/app/controllers/admin/conference_controller.rb
+++ b/app/controllers/admin/conference_controller.rb
@@ -113,19 +113,12 @@ class Admin::ConferenceController < ApplicationController
     @submissions = Conference.get_event_state_line_colors
 
     @submissions_data = {}
-    @cfp_weeks = [0]
-    @submissions_data['Submitted'] = @conference.get_submissions_per_week
-    @cfp_weeks.push(@submissions_data['Submitted'].length)
-
-    @submissions_data['Confirmed'] = @conference.get_submissions_per_week_by_status('confirmed')
-    @cfp_weeks.push(@submissions_data['Confirmed'].length)
-
-    @submissions_data['Unconfirmed'] = @conference.get_submissions_per_week_by_status('unconfirmed')
-    @cfp_weeks.push(@submissions_data['Unconfirmed'].length)
-
-    @cfp_weeks = @cfp_weeks.max
-    @submissions_data = normalize_array_length(@submissions_data, @cfp_weeks)
-    @cfp_weeks = @cfp_weeks > 0 ? (1..@cfp_weeks).to_a : 1
+    @submissions_data = @conference.get_submissions_data
+    @cfp_weeks = 0
+    if @submissions_data['Weeks']
+      @cfp_weeks = @submissions_data['Weeks']
+      @submissions_data = @submissions_data.except('Weeks')
+    end
 
     # Doughnut charts
     @event_type_distribution = @conference.event_type_distribution

--- a/app/models/conference.rb
+++ b/app/models/conference.rb
@@ -3,6 +3,7 @@
 
 class Conference < ActiveRecord::Base
   require 'uri'
+  serialize :events_per_week, Hash
 
   attr_accessible :title, :short_title, :social_tag, :contact_email, :timezone, :html_export_path,
                   :start_date, :end_date, :rooms_attributes, :tracks_attributes,
@@ -185,18 +186,28 @@ class Conference < ActiveRecord::Base
   end
 
   ##
-  # Returns an array with the summarized event submissions per week.
+  # Returns an hash with submitted, confirmed and unconfirmed event submissions
+  # per week.
   #
   # ====Returns
-  #  * +Array+ -> e.g. [0, 3, 3, 5] -> first week 0 events, second week 3 events.
-  def get_submissions_per_week_by_status(state)
-    result = []
-
+  #  * +Array+ -> e.g. 'Submitted' => [0, 3, 3, 5]  -> first week 0 events, second week 3 events.
+  def get_submissions_data
+    result = {}
     if call_for_papers && events
-      submissions = events.where('state = ?', state).group(:week).count
+      result = get_events_per_week_by_state
+
       start_week = call_for_papers.start_week
-      weeks = call_for_papers.weeks
-      result = calculate_items_per_week(start_week, weeks, submissions)
+      end_week = end_date.strftime('%W').to_i
+      weeks = weeks(start_week, end_week)
+
+      result.each do |state, values|
+        if state == 'Submitted'
+          result['Submitted'] = pad_array_left_kumulative(start_week, values)
+        else
+          result[state] = pad_array_left_not_kumulative(start_week, values)
+        end
+      end
+      result['Weeks'] =  weeks > 0 ? (1..weeks).to_a : 0
     end
     result
   end
@@ -487,7 +498,141 @@ class Conference < ActiveRecord::Base
     result
   end
 
+  ##
+  # Writes an snapshot of the actual event distribution to the database
+  # Triggered each every Sunday 11:55 pm form whenever (config/schedule.rb).
+  #
+  def self.write_event_distribution_to_db
+    week = DateTime.now.end_of_week
+
+    Conference.where('end_date > ?', Date.today).each do |conference|
+      result = {}
+      Event.state_machine.states.each do |state|
+        count = conference.events.where('state = ?', state.name).count
+        result[state.name] = count
+      end
+
+      if !conference.events_per_week
+        conference.events_per_week = {}
+      end
+
+      # Write to database
+      conference.events_per_week[week] = result
+      conference.save!
+    end
+  end
+
   private
+
+  ##
+  # Calculates the weeks from a start and a end week.
+  #
+  # ====Returns
+  # * +Fixnum+ -> weeks
+  def weeks(start_week, end_week)
+    weeks = end_week - start_week + 1
+    weeks_of_year = Date.new(start_date.year, 12, 31).strftime('%W').to_i
+    weeks < 0 ? weeks + weeks_of_year : weeks
+  end
+
+  ##
+  # Returns a Hash with the events with the state confirmend / unconfirmed per week.
+  #
+  # ====Returns
+  # * +Hash+ -> e.g. 'Confirmed' => { 3 => 5, 4 => 6 }
+  def get_events_per_week_by_state
+    result = {
+      'Submitted' => {},
+      'Confirmed' => {},
+      'Unconfirmed' => {}
+    }
+
+    # Completed weeks
+    events_per_week.each do |week, values|
+      values.each do |state, value|
+        if [:confirmed, :unconfirmed].include?(state)
+          if !result[state.to_s.capitalize]
+            result[state.to_s.capitalize] = {}
+          end
+          result[state.to_s.capitalize][week.strftime('%W').to_i] = value
+        end
+      end
+    end
+
+    # Actual week
+    this_week = Date.today.end_of_week.strftime('%W').to_i
+    result['Confirmed'][this_week] = events.where('state = ?', :confirmed).count
+    result['Unconfirmed'][this_week] = events.where('state = ?', :unconfirmed).count
+    result['Submitted'] = events.group(:week).count
+    result['Submitted'][this_week] = events.where(week: this_week).count
+    result
+  end
+
+  ##
+  # Returns an array from the hash values with left padding.
+  #
+  # ====Returns
+  # * +Array+ -> [0, 0, 1, 2, 3, 0, 0]
+  def pad_array_left_not_kumulative(start_week, hash)
+    hash = assert_keys_are_continuously(hash)
+
+    first_week = hash.keys[0]
+    left = pad_left(first_week, start_week)
+    left + hash.values
+  end
+
+  ##
+  # Returns an array from the hash values with left padding.
+  #
+  # ====Returns
+  # * +Array+ -> [0, 0, 1, 2, 3, 3, 3]
+  def pad_array_left_kumulative(start_week, hash)
+    hash = assert_keys_are_continuously(hash)
+    result = cumulative_sum(hash.values)
+
+    first_week = hash.keys[0]
+    left = pad_left(first_week, start_week)
+    left + result
+  end
+
+  ##
+  # Cumulative sums an array.
+  #
+  # ====Returns
+  # * +Array+ -> [1, 2, 3, 4] --> [1, 3, 7, 11]
+  def cumulative_sum(array)
+    sum = 0
+    array.map { |x| sum += x }
+  end
+
+  ##
+  # Returns the left padding.
+  #
+  # ====Returns
+  # * +Array+
+  def pad_left(first_week, start_week)
+    left = []
+    if first_week > start_week
+      left = Array.new(first_week - start_week - 1, 0)
+    end
+    left
+  end
+
+  ##
+  # Asserts that all keys in the hash are continuously.
+  # If not, the missing key is inserted with value 0.
+  #
+  # ====Returns
+  # * +Hash+  { 1 => 1, 2 => 0, 3 => 0, 4 => 3 }
+  def assert_keys_are_continuously(hash)
+    keys = hash.keys
+    (keys.min..keys.max).each do |key|
+      if !hash[key]
+        hash[key] = 0
+      end
+    end
+    hash.sort.to_h
+  end
 
   ##
   # Returns the progress of the set up conference list in percent

--- a/app/models/event.rb
+++ b/app/models/event.rb
@@ -30,6 +30,7 @@ class Event < ActiveRecord::Base
   before_create :generate_guid
 
   validate :abstract_limit
+  validate :before_end_of_conference
   validate :biography_exists
   validates :title, presence: true
   validates :abstract, presence: true
@@ -206,5 +207,11 @@ class Event < ActiveRecord::Base
   def set_week
     self.week = created_at.strftime('%W')
     save!
+  end
+
+  def before_end_of_conference
+    errors.
+        add(:created_at, "can't be after the conference end date!") if conference.end_date &&
+        (Date.today > conference.end_date)
   end
 end

--- a/config/schedule.rb
+++ b/config/schedule.rb
@@ -1,0 +1,24 @@
+# Use this file to easily define all of your cron jobs.
+#
+# It's helpful, but not entirely necessary to understand cron before proceeding.
+# http://en.wikipedia.org/wiki/Cron
+
+# Example:
+#
+# set :output, "/path/to/my/cron_log.log"
+#
+# every 2.hours do
+#   command "/usr/bin/some_great_command"
+#   runner "MyModel.some_method"
+#   rake "some:great:rake:task"
+# end
+#
+# every 4.days do
+#   runner "AnotherModel.prune_old_records"
+# end
+
+# Learn more: http://github.com/javan/whenever
+
+every :sunday, at: '23:55 pm' do
+  runner 'Conference.write_event_distribution_to_db'
+end

--- a/db/migrate/20140701123203_add_events_per_week_to_conference.rb
+++ b/db/migrate/20140701123203_add_events_per_week_to_conference.rb
@@ -1,0 +1,90 @@
+class AddEventsPerWeekToConference < ActiveRecord::Migration
+  class TempVersion < ActiveRecord::Base
+    self.table_name = 'versions'
+    serialize :object_changes, HashWithIndifferentAccess
+  end
+
+  class TempEvent < ActiveRecord::Base
+    self.table_name = 'events'
+  end
+
+  class TempConference < ActiveRecord::Base
+    self.table_name = 'conferences'
+    serialize :events_per_week, Hash
+  end
+
+  def up
+    add_column :conferences, :events_per_week, :text
+
+    TempVersion.where(item_type: 'Event').each do |event_version|
+      event = TempEvent.find(event_version.item_id)
+      conference = TempConference.find(event.conference_id)
+      week = event_version.created_at.end_of_week
+
+      no_events = {
+        new: 0,
+        withdrawn: 0,
+        unconfirmed: 0,
+        confirmed: 0,
+        canceled: 0,
+        rejected: 0,
+      }
+
+      if !conference.events_per_week
+        conference.events_per_week = {
+          week => no_events
+        }
+      elsif !conference.events_per_week[week]
+        conference.events_per_week[week] = no_events
+      end
+
+      if event_version.object_changes &&
+          event_version.event == 'create'
+
+        # Increment the new state
+        conference.events_per_week[week][:new] += 1
+      elsif event_version.object_changes &&
+          event_version.object_changes[:state]
+
+        prev_state = event_version.object_changes[:state][0].to_sym
+        next_state = event_version.object_changes[:state][1].to_sym
+
+        # Backward compatibility: deprecated state :review now :new
+        if prev_state == :review
+          prev_state = :new
+        elsif  next_state == :review
+          next_state = :new
+        end
+
+        # Increment the next state
+        conference.events_per_week[week][next_state] += 1
+
+        # Decrement the previous state
+        conference.events_per_week[week][prev_state] -= 1
+      end
+      conference.save
+    end
+
+
+    # Cumulate the previous weeks to get a snapshot
+    TempConference.all.each do |conference|
+      hash = conference.events_per_week.sort.to_h
+      previous = nil
+
+      hash.each do |week, values|
+        if previous
+          values.each do |state, value|
+            hash[week][state] += previous[state]
+          end
+        end
+        previous = values
+      end
+      conference.events_per_week = hash
+      conference.save
+    end
+  end
+
+  def down
+    remove_column :conferences, :events_per_week
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -11,7 +11,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 20140627165718) do
+ActiveRecord::Schema.define(version: 20140701123203) do
 
   create_table "ahoy_events", force: true do |t|
     t.uuid     "visit_id"
@@ -125,6 +125,7 @@ ActiveRecord::Schema.define(version: 20140627165718) do
     t.datetime "banner_photo_updated_at"
     t.boolean  "include_banner_in_splash",        default: false
     t.string   "instagram_url"
+    t.text     "events_per_week"
   end
 
   create_table "conferences_questions", id: false, force: true do |t|


### PR DESCRIPTION
This is a bugfix for the confirmed / unconfirmed events over time chart on the conference instance dashboard!

To get the old information it was necessary to write a migration that iterates through all versions of events and increments / decrements the states!

The states getting now saved each week to the events_per_week column of events.

@hennevogel I remove the right padding from the other charts in a separate PR.
