### PR TITLE
Remove therubyracer because of the following reasons:

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -82,9 +82,6 @@ gem 'font-awesome-rails'
 #Use Redcarpet for Markdown in description
 gem 'redcarpet'
 
-# Rubyracer is JavaScript Runtime of choice
-gem 'therubyracer'
-
 # FIXME: We should use http://weblog.rubyonrails.org/2012/3/21/strong-parameters/
 gem 'protected_attributes'
 

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -164,7 +164,6 @@ GEM
       addressable (~> 2.3)
     letter_opener (1.2.0)
       launchy (~> 2.2)
-    libv8 (3.16.14.3)
     listen (2.7.2)
       celluloid (>= 0.15.2)
       celluloid-io (>= 0.15.0)
@@ -282,7 +281,6 @@ GEM
       rdoc (~> 4.0)
       yajl-ruby (~> 1.1)
     redcarpet (3.1.2)
-    ref (1.0.5)
     referer-parser (0.2.1)
     request_store (1.0.6)
     rest-client (1.6.7)
@@ -353,9 +351,6 @@ GEM
     sqlite3 (1.3.9)
     term-ansicolor (1.3.0)
       tins (~> 1.0)
-    therubyracer (0.12.1)
-      libv8 (~> 3.16.14.0)
-      ref
     thor (0.19.1)
     thread_safe (0.3.4)
     tilt (1.4.1)
@@ -436,7 +431,6 @@ DEPENDENCIES
   shoulda
   spring-commands-rspec
   sqlite3
-  therubyracer
   transitions
   turbolinks
   uglifier (>= 1.3.0)


### PR DESCRIPTION
- therubyracer is unstable between platforms, platform versions, ruby interpreters and even ruby versons.
  Pretty much everytime there's native extension compilation issue, it is therubyracer.
- therubyracer is officially discouraged by heroku as it uses lot of memory. On the other hand node.js advertises itself as very lightweight.
- using therubyracer on server is just like installing Node that can be used only by ruby apps (you're using v8 anyway)
- btw. node.js is necessary only on Windows and Ubuntu development, on Mac development ExecJS is using JavaScriptCore.

catched from https://github.com/sheerun/rails4-bootstrap/issues/18
