### PR TITLE
OpenID mocks

### DIFF
--- a/config/environments/development.rb
+++ b/config/environments/development.rb
@@ -68,17 +68,17 @@ Osem::Application.configure do
                               }
                             )
 
-  OmniAuth.config.mock_auth[:novell] =
+  OmniAuth.config.mock_auth[:suse] =
       OmniAuth::AuthHash.new(
-                              provider: 'novell',
-                              uid: 'novell-test-uid-1',
+                              provider: 'suse',
+                              uid: 'suse-test-uid-1',
                               info: {
                                 name: 'another user',
                                 email: 'user1@email.com'
                               },
                               credentials: {
-                                token: 'novell_mock_token',
-                                secret: 'novell_mock_secret'
+                                token: 'suse_mock_token',
+                                secret: 'suse_mock_secret'
                               }
                             )
 

--- a/config/secrets.yml.example
+++ b/config/secrets.yml.example
@@ -10,6 +10,23 @@ defaults: &defaults
   # Your errbit API key
   # errbit_key: '12345'
 
+development:
+  <<: *defaults
+  # Sample data so that mocks work
+  google_key: 'sample'
+  google_secret: 'sample'
+
+  facebook_key: 'sample'
+  facebook_secret: 'sample'
+
+  suse_key: 'sample'
+  suse_secret: 'sample'
+
+test:
+  <<: *defaults
+
+production:
+  <<: *defaults
   # Leave the variables' names empty, unless you use the providers, in which case you need to
   # register your applicaton and add the actual keys.
 
@@ -24,17 +41,12 @@ defaults: &defaults
   facebook_secret: ''
 
   # Developers do not need to register their application for suse account to work.
-  # You must, however, leave the sample data there, for the login option to appear.
-  suse_key: 'sample data'
-  suse_secret: 'sample data'
+  # You must, however, add some sample value to the variables, for the login option to appear.
+  # For example:
+  #suse_key: 'sample data'
+  #suse_secret: 'sample data'
+
+  suse_key: ''
+  suse_secret: ''
 
   # If you add more providers that do not require a key, you still have to create the 2 variables with sample data
-
-development:
-  <<: *defaults
-
-test:
-  <<: *defaults
-
-production:
-  <<: *defaults


### PR DESCRIPTION
Enable openids in development by default.
Do not show openID header unless keys are set.

https://github.com/openSUSE/osem/pull/378
