### PR TITLE
Task to create admins and fix in migration

### DIFF
--- a/db/migrate/20140730104658_migrate_roles_for_cancancan.rb
+++ b/db/migrate/20140730104658_migrate_roles_for_cancancan.rb
@@ -8,6 +8,7 @@ class MigrateRolesForCancancan < ActiveRecord::Migration
         Conference.all.each do |conference|
           if role.name == 'Admin' || role.name == 'Organizer'
             user.add_role :organizer, conference
+            user.update_columns(is_admin: true)
           else
             user.add_role role.name.parameterize.underscore.to_sym, conference
           end
@@ -22,6 +23,6 @@ class MigrateRolesForCancancan < ActiveRecord::Migration
   end
 
   def down
-    raise ActiveRecord::IrreversibleMigration.new('Cannot reverse migration. Deleted events cannot be re-created')
+    raise ActiveRecord::IrreversibleMigration.new('Cannot reverse migration.')
   end
 end

--- a/lib/tasks/user.rake
+++ b/lib/tasks/user.rake
@@ -1,0 +1,17 @@
+namespace :user do
+  desc "Makes is_admin attribute true for user based on the supplied email address."
+  task :admin, [:email] => :environment do |t, args|
+
+    # Check if an email address was supplied
+    fail 'You need to define the email address of the user you want to make an admin.' unless args.email
+
+    user = User.find_by(email: args.email)
+    # Check if a user is found based on the supplied email address
+    fail "There is no user with email #{args.email}!" unless user
+
+    if user.update_columns(is_admin: true)
+      puts "User with email #{args.email} is now an admin!"
+    end
+  end
+
+end


### PR DESCRIPTION
- Alter migration so that users, with the (old) role of Admin and Organizer, become admins.
- Create task to make an admin based on user's email address
  
  Usage: rake user:admin["my@email.osem"]

I have used the update_coumns on purpose, so that 
1. we skip validations and callbals and we don't run into validation errors for the User model, which is a bit outside of the scope of this operation. 
2. In addition we do not alter the updated_at column, maintaining more accurate information of when the user altered his/her account.
