### PR TITLE
add js code for live translation feature of transifex

### DIFF
--- a/app/assets/javascripts/application.js
+++ b/app/assets/javascripts/application.js
@@ -30,7 +30,6 @@
 //= require osem-datepickers
 //= require osem-datatables
 //= require osem-tickets
-//= require transifex-live
 
 $(document).ready(function() {
     $('a[disabled=disabled]').click(function(event){

--- a/app/assets/javascripts/transifex-live.js
+++ b/app/assets/javascripts/transifex-live.js
@@ -1,6 +1,0 @@
-window.liveSettings = {
-  api_key: CONFIG['transifex_live_api_key'],
-  picker: "bottom-right",
-  detectlang: true,
-  autocollect: true
-};

--- a/app/views/layouts/application.html.haml
+++ b/app/views/layouts/application.html.haml
@@ -8,14 +8,22 @@
     = stylesheet_link_tag "application", :media => "all"
     = stylesheet_link_tag "splash" if content_for :splash
     = javascript_include_tag "application"
-    = javascript_include_tag "//cdn.transifex.com/live.js"
     = csrf_meta_tags
     :javascript
+      window.liveSettings = {
+        api_key: "<%= CONFIG['transifex_live_api_key'] %>",
+        picker: "bottom-right",
+        detectlang: true,
+        autocollect: true
+      };
+
       $(function() {
         $('.dropdown input, .dropdown label').click(function(e) {
         e.stopPropagation();
         });
       });
+
+    = javascript_include_tag "//cdn.transifex.com/live.js"
     = yield(:head)
   %body{ data: (content_for?(:splash_nav) ? {spy: 'scroll', offset: 0, target: 'splash-nav'} : {} ) }
     = render 'layouts/navigation'


### PR DESCRIPTION
https://github.com/openSUSE/osem/issues/99

All sub-pages of the app need to be scanned and then strings found need to be translated in the editor:
https://www.transifex.com/projects/p/osem/live/#en/events.opensuse.org

As soon as translations are published (gear icon in top right corner -> Take Live -> Publish) they automatically appear in the app.

Introduces a language selector on bottom-right corner.
![screenshot-osem - chromium-6](https://cloud.githubusercontent.com/assets/4322737/4222046/9756688a-390f-11e4-9b18-375aa75648ba.png)
