### PR TITLE
Show Users link in drop down menu

### DIFF
--- a/app/views/layouts/_user_menu.html.haml
+++ b/app/views/layouts/_user_menu.html.haml
@@ -27,3 +27,8 @@
           %span.fa.fa-cog
           Manage
           = @conference.short_title
+- if can? :index, User
+  %li
+    = link_to(admin_users_path) do
+      %span.fa.fa-user
+      Users


### PR DESCRIPTION
New instances of OSEM do not have conferences already and the drop down shows only the option to Create a new Conference, so navigation to the management area is not possible.

The lack of conferences should not limit the view of users list though.
So adding the option to navigate to Users in the drop down.
