### PR TITLE
Remove link to change speaker in Events list

### DIFF
--- a/app/views/admin/events/index.html.haml
+++ b/app/views/admin/events/index.html.haml
@@ -70,8 +70,6 @@
               = link_to speaker.name, admin_user_path(speaker)
             - else
               Unknown speaker
-            - l = link_to "Change", edit_admin_conference_event_speaker_path(@conference.short_title, event), :remote => true
-            = "(#{l})".html_safe
           %td
             .btn-group
               %button{:type=>"button", :class=>"btn btn-link dropdown-toggle", "data-toggle"=>"dropdown"}


### PR DESCRIPTION
Leftovers after https://github.com/openSUSE/osem/pull/548

But I am not at all sure we actually want to _not_ be able to change the speaker of an event.

@hennevogel what are your thoughts?
