### PR TITLE
Updates nio4r to 1.1

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -225,7 +225,7 @@ GEM
     multi_xml (0.5.5)
     multipart-post (2.0.0)
     mysql2 (0.3.16)
-    nio4r (1.0.0)
+    nio4r (1.1.0)
     nokogiri (1.6.2.1)
       mini_portile (= 0.6.0)
     oauth2 (0.9.4)


### PR DESCRIPTION
Updated nio4r to 1.1 because I was unable to install 1.0 under openSUSE 13.2