### PR TITLE
Fixing functions for minutes to hours conversion for dashboard

### DIFF
--- a/app/models/conference.rb
+++ b/app/models/conference.rb
@@ -387,25 +387,43 @@ class Conference < ActiveRecord::Base
   end
 
   ##
-  # Calculates the overall programm hours
+  # Calculates the overall program minutes
   #
   # ====Returns
-  # * +hash+ -> Fixnum hours
-  def current_program_hours
+  # * +hash+ -> Fixnum minutes
+  def current_program_minutes
     events_grouped = events.group(:event_type_id)
     events_counted = events_grouped.count
-    calculate_program_hours(events_grouped, events_counted)
+    calculate_program_minutes(events_grouped, events_counted)
   end
 
   ##
-  # Calculates the overall programm hours since date
+  # Calculates the overall program hours
   #
   # ====Returns
-  # * +hash+ -> Fixnum hours
-  def new_program_hours(date)
+  # * +Fixnum+ -> Fixnum hours. Example: 1.5 gets rounded to 2. 1.3 gets rounded 1.
+  def current_program_hours
+    (current_program_minutes / 60.to_f).round
+  end
+
+  ##
+  # Calculates the overall program minutes since date
+  #
+  # ====Returns
+  # * +hash+ -> Fixnum minutes
+  def new_program_minutes(date)
     events_grouped = events.where('created_at > ?', date).group(:event_type_id)
     events_counted = events_grouped.count
-    calculate_program_hours(events_grouped, events_counted)
+    calculate_program_minutes(events_grouped, events_counted)
+  end
+
+  ##
+  # Calculates the overall program hours since date
+  #
+  # ====Returns
+  # * +Fixnum+ -> Fixnum hours
+  def new_program_hours(date)
+    (new_program_minutes(date) / 60.to_f).round
   end
 
   ##
@@ -812,11 +830,11 @@ class Conference < ActiveRecord::Base
   end
 
   ##
-  # Helper method to calculate the program hours.
+  # Helper method to calculate the program minutes.
   #
   # ====Returns
-  # * +Fixnums+ summed programm hours
-  def calculate_program_hours(events_grouped, events_counted)
+  # * +Fixnums+ summed program minutes
+  def calculate_program_minutes(events_grouped, events_counted)
     result = 0
     events_grouped.each do |event|
       result += events_counted[event.event_type_id] * event.event_type.length

--- a/app/models/target.rb
+++ b/app/models/target.rb
@@ -34,7 +34,7 @@ class Target < ActiveRecord::Base
     elsif unit == Target.units[:registrations]
       numerator = conference.registrations.where('created_at < ?', due_date).count
     elsif unit == Target.units[:program_minutes]
-      numerator = conference.current_program_hours
+      numerator = conference.current_program_minutes
     end
     (numerator / target_count.to_f  * 100).round(0).to_s
   end
@@ -51,7 +51,7 @@ class Target < ActiveRecord::Base
     elsif unit == Target.units[:registrations]
       numerator = campaign.registrations_count
     elsif unit == Target.units[:program_minutes]
-      numerator = conference.current_program_hours
+      numerator = conference.current_program_minutes
     end
 
     progress = (numerator / target_count.to_f  * 100).round(0).to_s

--- a/spec/models/conference_spec.rb
+++ b/spec/models/conference_spec.rb
@@ -364,41 +364,47 @@ describe Conference do
     end
   end
 
-  describe 'program hours' do
+  describe 'program hours and minutes' do
     before(:each) do
       @long = create(:event_type, length: 100)
       @short = create(:event_type, length: 10)
     end
 
-    describe '#actual_program_hours' do
+    describe '#actual_program_minutes' do
       it 'calculates correct values with events' do
         create(:event, conference: subject, event_type: @long)
         create(:event, conference: subject, event_type: @long)
         create(:event, conference: subject, event_type: @short)
         create(:event, conference: subject, event_type: @short)
-        result = 220
-        expect(subject.current_program_hours).to eq(result)
+        result_in_hours = 4
+        result_in_minutes = 220
+        expect(subject.current_program_hours).to eq(result_in_hours)
+        expect(subject.current_program_minutes).to eq(result_in_minutes)
       end
 
       it 'calculates correct values without events' do
         result = 0
+        expect(subject.current_program_minutes).to eq(result)
         expect(subject.current_program_hours).to eq(result)
       end
     end
 
-    describe '#new_program_hours' do
+    describe '#new_program_minutes' do
       it 'calculates correct values with events' do
 
         create(:event, conference: subject, event_type: @long, created_at: Time.now - 3.days)
         create(:event, conference: subject, event_type: @long)
         create(:event, conference: subject, event_type: @short, created_at: Time.now - 3.days)
         create(:event, conference: subject, event_type: @short)
-        result = 110
-        expect(subject.new_program_hours(Time.now - 5.minutes)).to eq(result)
+        result_in_hours = 2
+        result_in_minutes = 110
+        expect(subject.new_program_hours(Time.now - 5.minutes)).to eq(result_in_hours)
+        expect(subject.new_program_minutes(Time.now - 5.minutes)).to eq(result_in_minutes)
       end
 
       it 'calculates correct values without events' do
         result = 0
+        expect(subject.new_program_minutes(Time.now - 5.minutes)).to eq(result)
         expect(subject.new_program_hours(Time.now - 5.minutes)).to eq(result)
       end
     end


### PR DESCRIPTION
This solves https://github.com/openSUSE/osem/issues/519

* Rounding the minute conversion to the nearest hour. So ```1.5 hours``` becomes ```2 hours```. Where as ```1.3 hours``` becomes ```1 hour```.
* Changed some naming conventions in ```conference.rb```. So that the method names sound more accurate.
 - Changed previously ```current_program_hours``` to ```current_program_minutes```. Added ```current_program_hours``` which is deriving rounded hours from ```current_program_minutes``` now.
 - Changed previous ```new_program_hours``` to ```new_program_minutes```. Added ```new_program_hours``` which is deriving rounded hours from ```new_program_minutes``` now.
 - Changed ```calculate_program_hours``` to ```calculate_program_minutes``` because it was returning minutes in the first place.
* Changed ```current_program_hours``` to ```current_program_minutes``` in ```target.rb```. Naming changed, rest stays same.
* Updated test (```conference_spec.rb```) to test against the closes hour conversion and not minute.

Maybe we would need tweak more things around or undo previous one. Looking forward to comments/feedback.