### PR TITLE
removed broken add user link on admin/users

### DIFF
--- a/app/views/admin/users/index.html.haml
+++ b/app/views/admin/users/index.html.haml
@@ -5,7 +5,6 @@
         Users
         - if @users
           = "(#{@users.length})"
-        = link_to 'New User', new_admin_user_path, class: 'btn btn-success pull-right'
 .row
   .col-md-12
     %table.table.table-striped.table-bordered.table-hover.datatable


### PR DESCRIPTION
I don't think we need this anymore:
![screenshot from 2015-03-09 16 32 01](https://cloud.githubusercontent.com/assets/7680662/6656263/fe0858fa-cb49-11e4-8fa4-872feb3e9287.png)
