### PR TITLE
Changed minutes to hours for target/program

### DIFF
--- a/app/controllers/admin/conference_controller.rb
+++ b/app/controllers/admin/conference_controller.rb
@@ -149,7 +149,6 @@ module Admin
       # get targets
       @registration_targets = @conference.get_targets(Target.units[:registrations])
       @submission_targets = @conference.get_targets(Target.units[:submissions])
-      @program_minutes_targets = @conference.get_targets(Target.units[:program_minutes])
 
       # get campaigns
       @campaigns = @conference.get_campaigns

--- a/app/models/target.rb
+++ b/app/models/target.rb
@@ -9,7 +9,7 @@ class Target < ActiveRecord::Base
     {
       registrations: 'Registration',
       submissions: 'Submission',
-      program_minutes: 'Program minute'
+      program_hours: 'Program hours'
     }
   end
 
@@ -33,8 +33,8 @@ class Target < ActiveRecord::Base
       numerator = conference.events.where('created_at < ?', due_date).count
     elsif unit == Target.units[:registrations]
       numerator = conference.registrations.where('created_at < ?', due_date).count
-    elsif unit == Target.units[:program_minutes]
-      numerator = conference.current_program_minutes
+    elsif unit == Target.units[:program_hours]
+      numerator = conference.current_program_hours
     end
     (numerator / target_count.to_f  * 100).round(0).to_s
   end
@@ -50,8 +50,8 @@ class Target < ActiveRecord::Base
       numerator = campaign.submissions_count
     elsif unit == Target.units[:registrations]
       numerator = campaign.registrations_count
-    elsif unit == Target.units[:program_minutes]
-      numerator = conference.current_program_minutes
+    elsif unit == Target.units[:program_hours]
+      numerator = conference.current_program_hours
     end
 
     progress = (numerator / target_count.to_f  * 100).round(0).to_s

--- a/db/migrate/20150317210343_convert_target_minutes_to_hours.rb
+++ b/db/migrate/20150317210343_convert_target_minutes_to_hours.rb
@@ -1,0 +1,22 @@
+class ConvertTargetMinutesToHours < ActiveRecord::Migration
+  class TempTarget < ActiveRecord::Base
+    self.table_name = 'targets'
+    attr_accessible :target_count, :unit
+  end
+
+  def up
+    targets = TempTarget.where(unit: 'Program minute').where.not(target_count: nil)
+    targets.each do |target|
+      new_target_count = (target.target_count / 60.to_f).round
+      target.update_attributes(target_count: new_target_count, unit: 'Program hours')
+    end
+  end
+
+  def down
+    targets = TempTarget.where(unit: 'Program hours').where.not(target_count: nil)
+    targets.each do |target|
+      new_target_count = (target.target_count * 60.to_f).round
+      target.update_attributes(target_count: new_target_count, unit: 'Program minute')
+    end
+  end
+end

--- a/spec/models/conference_spec.rb
+++ b/spec/models/conference_spec.rb
@@ -344,23 +344,23 @@ describe Conference do
       expect(subject.get_targets(Target.units[:submissions])).to eq(result)
     end
 
-    it 'returns 0 if there is no program minute' do
-      target = build(:target, target_count: 300, unit: Target.units[:program_minutes])
+    it 'returns 0 if there is no program hour' do
+      target = build(:target, target_count: 5, unit: Target.units[:program_hours])
       subject.targets = [target]
       result = {
-        "300 Program minutes by #{target.due_date}" => '0'
+        "5 Program hours by #{target.due_date}" => '0'
       }
-      expect(subject.get_targets(Target.units[:program_minutes])).to eq(result)
+      expect(subject.get_targets(Target.units[:program_hours])).to eq(result)
     end
 
-    it 'returns 10 if there is 30 program minutes of 300' do
-      target = build(:target, target_count: 300, unit: Target.units[:program_minutes])
+    it 'returns 10 if there is 1 program hour of 10' do
+      target = build(:target, target_count: 10, unit: Target.units[:program_hours])
       subject.targets = [target]
       subject.events = [create(:event)]
       result = {
-        "300 Program minutes by #{target.due_date}" => '10'
+        "10 Program hours by #{target.due_date}" => '10'
       }
-      expect(subject.get_targets(Target.units[:program_minutes])).to eq(result)
+      expect(subject.get_targets(Target.units[:program_hours])).to eq(result)
     end
   end
 

--- a/spec/models/target_spec.rb
+++ b/spec/models/target_spec.rb
@@ -73,15 +73,15 @@ describe Target do
 
     it 'returns zero if there are no program minutes' do
       conference = build(:conference)
-      target = build(:target, target_count: 10, unit: Target.units[:program_minutes])
+      target = build(:target, target_count: 10, unit: Target.units[:program_hours])
       conference.targets = [target]
 
       expect(target.get_progress).to eq('0')
     end
 
-    it 'returns 10 if there are 30 program minutes of 300' do
+    it 'returns 10 if there are 1 program hour of 10' do
       conference = create(:conference)
-      target = create(:target, target_count: 300, unit: Target.units[:program_minutes])
+      target = create(:target, target_count: 10, unit: Target.units[:program_hours])
       event = create(:event)
 
       conference.targets = [target]


### PR DESCRIPTION
Showing hours for targets, just like it is for conference now.

Something to note:  The same rounding up logic applies here. That is, 1.5 hours rounds up to 2. Like it is being done for the conference dashboard. Maybe we need a different behavior?