### PR TITLE
no authorization for Conference in subscriptions controller

### DIFF
--- a/app/controllers/subscriptions_controller.rb
+++ b/app/controllers/subscriptions_controller.rb
@@ -1,6 +1,6 @@
 class SubscriptionsController < ApplicationController
   before_filter :authenticate_user!
-  load_and_authorize_resource :conference, find_by: :short_title
+  load_resource :conference, find_by: :short_title
   load_and_authorize_resource only: [:create, :destroy], through: :conference
 
   def create


### PR DESCRIPTION
[Authorization in nested resources] (https://github.com/CanCanCommunity/cancancan/wiki/Nested-Resources) Conference is being authorized with read action which includes index and show actions, however action show is authorized only for Conference with public splashpage. 

Therefore Conference is not authorized and raises an exception when trying to subscribe to a conference without a public splashpage.