### PR TITLE
Update redcarpet CVE#46916

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -328,7 +328,7 @@ GEM
       loggability (~> 0.6)
       rdoc (~> 4.0)
       yajl-ruby (~> 1.1)
-    redcarpet (3.1.2)
+    redcarpet (3.2.3)
     referer-parser (0.2.1)
     request_store (1.0.6)
     rest-client (1.7.3)


### PR DESCRIPTION
See http://www.openwall.com/lists/oss-security/2015/04/07/11
Nothing to worry too much, only admins/organizers can insert markdown.
Wasn't able to insert XSS code but observed some strange behaviour, so let's update it!