### PR TITLE
Move common views to partial

### DIFF
--- a/app/controllers/conference_registrations_controller.rb
+++ b/app/controllers/conference_registrations_controller.rb
@@ -21,6 +21,8 @@ class ConferenceRegistrationsController < ApplicationController
     end
 
     @registration = Registration.new
+
+    # @user variable needs to be set so that _sign_up_form_embedded works properly
     @user = @registration.build_user
   end
 
@@ -34,7 +36,15 @@ class ConferenceRegistrationsController < ApplicationController
 
   def create
     @registration = @conference.registrations.new(registration_params)
-    @registration.user = current_user || ( @user = @registration.build_user(user_params))
+
+    if current_user == nil
+      # @user variable needs to be set so that _sign_up_form_embedded works properly
+      @user = @registration.build_user(user_params)
+    else
+      @user = current_user
+    end
+
+    @registration.user = @user
 
     if @registration.save
       # Trigger ahoy event

--- a/app/controllers/conference_registrations_controller.rb
+++ b/app/controllers/conference_registrations_controller.rb
@@ -14,8 +14,14 @@ class ConferenceRegistrationsController < ApplicationController
       redirect_to root_path, alert: 'You need to sign in or sign up before continuing.'
       return
     end
+
+    # avoid openid sign_in to redirect to register/new when the sign_in user had already a registration
+    if current_user && @conference.user_registered?(current_user)
+      redirect_to edit_conference_conference_registrations_path(@conference.short_title)
+    end
+
     @registration = Registration.new
-    @registration.build_user
+    @user = @registration.build_user
   end
 
   def show
@@ -27,9 +33,8 @@ class ConferenceRegistrationsController < ApplicationController
   def edit; end
 
   def create
-    @registration = Registration.new(registration_params)
-    @registration.conference = @conference
-    @registration.user = current_user if current_user
+    @registration = @conference.registrations.new(registration_params)
+    @registration.user = current_user || ( @user = @registration.build_user(user_params) )
 
     if @registration.save
       # Trigger ahoy event
@@ -47,7 +52,7 @@ class ConferenceRegistrationsController < ApplicationController
         redirect_to  conference_conference_registrations_path(@conference.short_title)
       end
     else
-      flash[:error] = "An error prohibited the registration for #{@conference.title}: "\
+      flash[:error] = "Could not create your registration for #{@conference.title}: "\
                         "#{@registration.errors.full_messages.join('. ')}."
       render :new
     end
@@ -58,7 +63,7 @@ class ConferenceRegistrationsController < ApplicationController
       redirect_to  conference_conference_registrations_path(@conference.short_title),
                    notice: 'Registration was successfully updated.'
     else
-      flash[:error] = "An error prohibited the registration for #{@conference.title}: "\
+      flash[:error] = "Could not update your registration for #{@conference.title}: "\
                         "#{@registration.errors.full_messages.join('. ')}."
       render :edit
     end
@@ -70,7 +75,7 @@ class ConferenceRegistrationsController < ApplicationController
                   notice: "You are not registered for #{@conference.title} anymore!"
     else
       redirect_to root_path,
-                  error: "An error prohibited deleting the registration for #{@conference.title}: "\
+                  error: "Could not update your registration for #{@conference.title}: "\
                   "#{@registration.errors.full_messages.join('. ')}."
     end
   end
@@ -83,6 +88,10 @@ class ConferenceRegistrationsController < ApplicationController
       flash[:alert] = "Can't find a registration for #{@conference.title} for you. Please register."
       redirect_to new_conference_conference_registrations_path(@conference.short_title)
     end
+  end
+
+  def user_params
+    params.require(:user).permit(:username, :email, :name, :password, :password_confirmation)
   end
 
   def registration_params

--- a/app/controllers/conference_registrations_controller.rb
+++ b/app/controllers/conference_registrations_controller.rb
@@ -37,7 +37,7 @@ class ConferenceRegistrationsController < ApplicationController
   def create
     @registration = @conference.registrations.new(registration_params)
 
-    if current_user == nil
+    if current_user.nil?
       # @user variable needs to be set so that _sign_up_form_embedded works properly
       @user = @registration.build_user(user_params)
     else

--- a/app/controllers/conference_registrations_controller.rb
+++ b/app/controllers/conference_registrations_controller.rb
@@ -34,7 +34,7 @@ class ConferenceRegistrationsController < ApplicationController
 
   def create
     @registration = @conference.registrations.new(registration_params)
-    @registration.user = current_user || ( @user = @registration.build_user(user_params) )
+    @registration.user = current_user || ( @user = @registration.build_user(user_params))
 
     if @registration.save
       # Trigger ahoy event

--- a/app/helpers/application_helper.rb
+++ b/app/helpers/application_helper.rb
@@ -1,8 +1,10 @@
 module ApplicationHelper
+  # Set resource_name for devise so that we can call the devise help links (views/devise/shared/_links) from anywhere (eg sign_up form in proposal#new)
   def resource_name
     :user
   end
 
+  # Set devise_mapping for devise so that we can call the devise help links (views/devise/shared/_links) from anywhere (eg sign_up form in proposal#new)
   def devise_mapping
     @devise_mapping ||= Devise.mappings[:user]
   end

--- a/app/helpers/application_helper.rb
+++ b/app/helpers/application_helper.rb
@@ -1,4 +1,12 @@
 module ApplicationHelper
+  def resource_name
+    :user
+  end
+
+  def devise_mapping
+    @devise_mapping ||= Devise.mappings[:user]
+  end
+
   def pluralize_without_count(count, noun, text = nil)
     if count != 0
       count == 1 ? "#{noun}#{text}" : "#{noun.pluralize}#{text}"

--- a/app/models/registration.rb
+++ b/app/models/registration.rb
@@ -1,7 +1,5 @@
 class Registration < ActiveRecord::Base
   belongs_to :user
-  validates :user, presence: true
-  accepts_nested_attributes_for :user
   belongs_to :conference
   belongs_to :dietary_choice
 
@@ -28,6 +26,8 @@ class Registration < ActiveRecord::Base
   delegate :username, to: :user
 
   alias_attribute :other_needs, :other_special_needs
+
+  validates :user, presence: true
 
   validates_uniqueness_of :user_id, scope: :conference_id, message: 'already Registered!'
 

--- a/app/views/conference_registrations/_form.html.haml
+++ b/app/views/conference_registrations/_form.html.haml
@@ -19,9 +19,8 @@
       .tab-content
         .tab-pane.active{role: 'tabpanel', id: 'signup'}
           = semantic_form_for(@registration, url: conference_conference_registrations_path(@conference.short_title)) do |f|
-            - if !current_user
-              = f.fields_for :user do |u|
-                = render partial: 'devise/shared/sign_up_fields', locals: { u: u}
+            = render partial: 'devise/shared/sign_up_form_embedded'
+
             - if @conference.questions.any?
               = render partial: 'questions', locals: { f: f }
             - if @conference.events.workshops.any?
@@ -38,29 +37,4 @@
                   - else
                     =f.action :submit, button_html: { value: 'Register', class: 'btn btn-primary', id: 'register' }
         .tab-pane{role: 'tabpanel', id: 'signin'}
-          - if !CONFIG['authentication']['ichain']['enabled']
-            = form_tag(new_user_session_path, class: 'form-horizontal') do
-              %legend
-                %span
-                  Sign In
-              .form-group
-                %label{for: "user[login]", class: 'col-sm-2 control-label'}
-                  Username
-                .col-sm-10
-                  = text_field_tag 'user[login]', nil, placeholder: 'Username', class: 'form-control', required: 'required'
-              .form-group
-                %label{for: "user[password]", class: 'col-sm-2 control-label'}
-                  Password
-                .col-sm-10
-                  = password_field_tag 'user[password]', nil, placeholder: 'Password', class: 'form-control', required: 'required'
-              .form-group
-                .col-sm-12
-                  %button.btn.btn-success.pull-right
-                    Sign in
-              - unless omniauth_configured.empty?
-                .form-group
-                  %hr
-                  %p.text-center
-                    or sign in using
-                  .text-center
-                    = render 'devise/shared/openid'
+          = render partial: 'devise/shared/sign_in_form_embedded'

--- a/app/views/devise/confirmations/new.html.haml
+++ b/app/views/devise/confirmations/new.html.haml
@@ -1,0 +1,14 @@
+.container
+  .row
+    .col-md-6.col-md-offset-3
+      .panel.panel-default
+        .panel-heading
+          %h3.panel-title
+            Resend confirmation instructions
+        .panel-body
+          = semantic_form_for(resource, as: resource_name, url: confirmation_path(resource_name), method: :post) do |f|
+            = f.input :email, input_html: { autofocus: true, required: true }
+            %p.text-right
+              = f.action :submit, as: :button, label: 'Submit', button_html: { class: 'btn btn-success' }
+
+          = render partial: 'devise/shared/help'

--- a/app/views/devise/passwords/edit.html.haml
+++ b/app/views/devise/passwords/edit.html.haml
@@ -1,0 +1,16 @@
+.container
+  .row
+    .col-md-6.col-md-offset-3
+      .panel.panel-default
+        .panel-heading
+          %h3.panel-title
+            Change your password
+        .panel-body
+          = semantic_form_for(resource, as: resource_name, url: password_path(resource_name), html: { method: :put }) do |f|
+            = f.hidden_field :reset_password_token
+            = f.input :password, input_html: { autofocus: true, required: true, autocomplete: "off"}, label: 'New password'
+            = f.input :password_confirmation, input_html: { required: true, autocomplete: "off" }, label: 'New password confirmation'
+            %p.text-right
+              = f.action :submit, as: :button, label: 'Change my password', button_html: { class: 'btn btn-success' }
+
+          = render partial: 'devise/shared/help'

--- a/app/views/devise/passwords/new.html.haml
+++ b/app/views/devise/passwords/new.html.haml
@@ -1,0 +1,14 @@
+.container
+  .row
+    .col-md-6.col-md-offset-3
+      .panel.panel-default
+        .panel-heading
+          %h3.panel-title
+            Forgot your password?
+        .panel-body
+          = semantic_form_for(resource, as: resource_name, url: password_path(resource_name), html: { method: :post }) do |f|
+            = f.input :email, input_html: { autofocus: true, required: true}
+            %p.text-right
+              = f.action :submit, as: :button, label: 'Send me reset password instructions', button_html: { class: 'btn btn-success' }
+              
+          = render partial: 'devise/shared/help'

--- a/app/views/devise/registrations/edit.html.haml
+++ b/app/views/devise/registrations/edit.html.haml
@@ -21,7 +21,7 @@
             openID while logged in to OSEM
           - if User.omniauth_providers.present?
             #openidlinks
-              = render 'devise/shared/openid'
+              = render 'devise/shared/openid_links'
         = f.inputs name: 'Confirmation' do
           = f.input :current_password, input_html: {autocomplete: 'off'},
                     hint: '(we need your current password to confirm password, email or username changes)'

--- a/app/views/devise/registrations/new.html.haml
+++ b/app/views/devise/registrations/new.html.haml
@@ -10,21 +10,6 @@
             = render partial: 'devise/shared/sign_up_fields', locals: { u: f}
             %p.text-right
               = f.action :submit, as: :button, label: 'Sign Up', button_html: {class: 'btn btn-success' }
-          - unless omniauth_configured.empty?
-            .row
-              .col-md-4
-                %hr
-              .col-md-4
-                %h4.text-center
-                  or sign up using
-              .col-md-4
-                %hr
-            .row
-              .col-md-12
-                #openidlinks
-                  = render 'devise/shared/openid'
-                %p.text-right
-                  %a.small{"data-toggle" => "collapse", "data-target" =>  "#devise-help"}
-                    Need Help?
-                  #devise-help.collapse
-                    = render 'devise/shared/links'
+
+          = render partial: 'devise/shared/openid'
+          = render partial: 'devise/shared/help'

--- a/app/views/devise/registrations/new.html.haml
+++ b/app/views/devise/registrations/new.html.haml
@@ -7,7 +7,11 @@
             Sign Up
         .panel-body
           = semantic_form_for(resource, as: resource_name, url: registration_path(resource_name)) do |f|
-            = render partial: 'devise/shared/sign_up_fields', locals: { u: f}
+            = f.input :username, required: true
+            = f.input :email
+            = f.input :name, required: true
+            = f.input :password
+            = f.input :password_confirmation
             %p.text-right
               = f.action :submit, as: :button, label: 'Sign Up', button_html: {class: 'btn btn-success' }
 

--- a/app/views/devise/registrations/new.html.haml
+++ b/app/views/devise/registrations/new.html.haml
@@ -7,13 +7,13 @@
             Sign Up
         .panel-body
           = semantic_form_for(resource, as: resource_name, url: registration_path(resource_name)) do |f|
-            = f.input :username, required: true
-            = f.input :email
-            = f.input :name, required: true
-            = f.input :password
-            = f.input :password_confirmation
+            = f.input :username, input_html: { required: true }
+            = f.input :email, input_html: { required: true }
+            = f.input :name, input_html: { required: true }
+            = f.input :password, input_html: { required: true }
+            = f.input :password_confirmation, input_html: { required: true }
             %p.text-right
-              = f.action :submit, as: :button, label: 'Sign Up', button_html: {class: 'btn btn-success' }
+              = f.action :submit, as: :button, label: 'Sign Up', button_html: { class: 'btn btn-success' }
 
           = render partial: 'devise/shared/openid'
           = render partial: 'devise/shared/help'

--- a/app/views/devise/sessions/new.html.haml
+++ b/app/views/devise/sessions/new.html.haml
@@ -14,21 +14,5 @@
               = f.check_box :remember_me
           %p.text-right
             = f.action :submit, as: :button, label: 'Sign In', button_html: {class: 'btn btn-success'}
-        - unless omniauth_configured.empty?
-          .row
-            .col-md-4
-              %hr
-            .col-md-4
-              %h4.text-center
-                or sign in using
-            .col-md-4
-              %hr
-          .row
-            .col-md-12
-              #openidlinks
-                = render 'devise/shared/openid'
-              %p.text-right
-                %a.small{"data-toggle" => "collapse", "data-target" =>  "#devise-help"}
-                  Need Help?
-                #devise-help.collapse
-                  = render 'devise/shared/links'
+        = render partial: 'devise/shared/openid'
+        = render partial: 'devise/shared/help'

--- a/app/views/devise/sessions/new.html.haml
+++ b/app/views/devise/sessions/new.html.haml
@@ -1,18 +1,19 @@
-.row
-  .col-md-6.col-md-offset-3
-    .panel.panel-default
-      .panel-heading
-        %h3.panel-title
-          Sign In
-      .panel-body
-        = semantic_form_for(resource, as: resource_name, url: session_path(resource_name)) do |f|
-          = f.input :login
-          = f.input :password
-          - if devise_mapping.rememberable?
-            %p.text-right.small
-              = f.label 'Remember me'
-              = f.check_box :remember_me
-          %p.text-right
-            = f.action :submit, as: :button, label: 'Sign In', button_html: {class: 'btn btn-success'}
-        = render partial: 'devise/shared/openid'
-        = render partial: 'devise/shared/help'
+.container
+  .row
+    .col-md-6.col-md-offset-3
+      .panel.panel-default
+        .panel-heading
+          %h3.panel-title
+            Sign In
+        .panel-body
+          = semantic_form_for(resource, as: resource_name, url: session_path(resource_name)) do |f|
+            = f.input :login
+            = f.input :password
+            - if devise_mapping.rememberable?
+              %p.text-right.small
+                = f.label 'Remember me'
+                = f.check_box :remember_me
+            %p.text-right
+              = f.action :submit, as: :button, label: 'Sign In', button_html: {class: 'btn btn-success'}
+          = render partial: 'devise/shared/openid'
+          = render partial: 'devise/shared/help'

--- a/app/views/devise/shared/_help.html.haml
+++ b/app/views/devise/shared/_help.html.haml
@@ -1,0 +1,5 @@
+%p.text-right
+  %a.small.btn.btn-default{"data-toggle" => "collapse", "data-target" =>  "#devise-help"}
+    Need Help?
+#devise-help.collapse
+  = render 'devise/shared/links'

--- a/app/views/devise/shared/_help.html.haml
+++ b/app/views/devise/shared/_help.html.haml
@@ -1,5 +1,5 @@
 %p.text-right
-  %a.small.btn.btn-default{"data-toggle" => "collapse", "data-target" =>  "#devise-help"}
+  %a.small.btn.btn-default.btn-xs{"data-toggle" => "collapse", "data-target" =>  "#devise-help"}
     Need Help?
 #devise-help.collapse
   = render 'devise/shared/links'

--- a/app/views/devise/shared/_links.html.haml
+++ b/app/views/devise/shared/_links.html.haml
@@ -2,7 +2,7 @@
   = link_to "Forgot your password?", new_password_path(resource_name)
   %br
 
-- if devise_mapping.confirmable? && controller_name != 'confirmations' && controller_name == 'passwords'
+- if devise_mapping.confirmable? && controller_name != 'confirmations'
   = link_to "Didn't receive confirmation instructions?", new_confirmation_path(resource_name)
   %br
 

--- a/app/views/devise/shared/_openid.html.haml
+++ b/app/views/devise/shared/_openid.html.haml
@@ -1,7 +1,13 @@
-.btn-group.btn-group-lg
-  - omniauth_configured.each do |provider|
-    = link_to user_omniauth_authorize_path(provider),
-                                      class: "btn btn-success btn-lg",
-                                      id: "omniauth-#{provider}",
-                                      title: "Your #{provider} login" do
-      %i{:class => "fa fa-#{provider}"}
+- unless omniauth_configured.empty?
+  .row
+    .col-md-4
+      %hr
+    .col-md-4
+      %h4.text-center
+        or sign in using
+    .col-md-4
+      %hr
+  .row
+    .col-md-12
+      #openidlinks
+        = render partial: 'devise/shared/openid_links'

--- a/app/views/devise/shared/_openid_links.html.haml
+++ b/app/views/devise/shared/_openid_links.html.haml
@@ -1,0 +1,7 @@
+.text-center
+  .btn-group.btn-group-lg
+    - omniauth_configured.each do |provider|
+      = link_to user_omniauth_authorize_path(provider), class: "btn btn-success btn-lg",
+                                                        id: "omniauth-#{provider}",
+                                                        title: "Your #{provider} login" do
+        %i{:class => "fa fa-#{provider}"}

--- a/app/views/devise/shared/_sign_in_form_embedded.html.haml
+++ b/app/views/devise/shared/_sign_in_form_embedded.html.haml
@@ -1,0 +1,25 @@
+- if !CONFIG['authentication']['ichain']['enabled']
+  = form_tag(new_user_session_path, class: 'form-horizontal') do
+    %legend
+      %span
+        Sign In
+    .form-group
+      %label{for: "user[login]", class: 'col-sm-2 control-label'}
+        Username
+      .col-sm-10
+        = text_field_tag 'user[login]', nil, placeholder: 'Username', class: 'form-control', required: 'required'
+    .form-group
+      %label{for: "user[password]", class: 'col-sm-2 control-label'}
+        Password
+      .col-sm-10
+        = password_field_tag 'user[password]', nil, placeholder: 'Password', class: 'form-control', required: 'required'
+    .form-group
+      .col-sm-12
+        %button.btn.btn-success.pull-right
+          Sign in
+    = render partial: 'devise/shared/openid'
+    %p.text-right
+      %a.small.btn.btn-default{"data-toggle" => "collapse", "data-target" =>  "#devise-help-sign-in"}
+        Need Help?
+      #devise-help-sign-in.collapse
+        = render partial: 'devise/shared/links'

--- a/app/views/devise/shared/_sign_up_fields.html.haml
+++ b/app/views/devise/shared/_sign_up_fields.html.haml
@@ -1,4 +1,0 @@
-= u.input :username, input_html: {required: 'required', autocomplete: 'off'}
-= u.input :email, input_html: {required: 'required', autocomplete: 'off'}
-= u.input :password, input_html: {required: 'required', autocomplete: 'off', id: 'password_inline'}
-= u.input :password_confirmation, :required => true, input_html: {required: 'required', autocomplete: 'off'}

--- a/app/views/devise/shared/_sign_up_form_embedded.html.haml
+++ b/app/views/devise/shared/_sign_up_form_embedded.html.haml
@@ -1,0 +1,8 @@
+- unless current_user
+  = semantic_fields_for @user do |u|
+    = u.input :username, input_html: { required: 'required', autocomplete: 'off' }
+    = u.input :email, input_html: { required: 'required', autocomplete: 'off' }
+    = u.input :password, input_html: { required: 'required', autocomplete: 'off', id: 'password_inline' }
+    = u.input :password_confirmation, input_html: { required: 'required', autocomplete: 'off' }
+  = render partial: 'devise/shared/openid'
+  = render partial: 'devise/shared/help'

--- a/app/views/layouts/_navigation.html.haml
+++ b/app/views/layouts/_navigation.html.haml
@@ -60,11 +60,12 @@
                     .divider
                     %h6.text-center
                       or
-                    = render 'devise/shared/openid'
+                    = render 'devise/shared/openid_links'
                   %p.text-right
-                    %a.small{"data-toggle" => "collapse", "data-target" =>  "#navbar-devise-help"}
+                    %br
+                    %a.small.btn.btn-xs.btn-default{"data-toggle" => "collapse", "data-target" =>  "#navbar-devise-help"}
                       Need Help?
                     #navbar-devise-help.collapse
-                      = link_to "Forgot your password?", new_password_path(User.new)
+                      = render 'devise/shared/links'
                   %li.hidden-lg
                     = link_to('Sign In', new_user_session_path)

--- a/app/views/proposal/new.html.haml
+++ b/app/views/proposal/new.html.haml
@@ -22,9 +22,8 @@
 
           = semantic_form_for(@event, url: @url) do |f|
 
-            - unless current_user
-              = semantic_fields_for @user do |u|
-                = render partial: 'devise/shared/sign_up_fields', locals: { u: u }
+            = render partial: 'devise/shared/sign_up_form_embedded'
+
             = f.inputs name: 'Proposal Information' do
               = f.input :title, as: :string, required: true
               = f.input :event_type_id, as: :select,
@@ -64,30 +63,4 @@
             %p.text-right
               = f.action :submit, :as => :button, :button_html => {:class => "btn btn-success"}, label: 'Create Proposal'
         .tab-pane{role: 'tabpanel', id: 'signin'}
-          - if !CONFIG['authentication']['ichain']['enabled']
-            = form_tag(new_user_session_path, class: 'form-horizontal') do
-              %legend
-                %span
-                  Sign In
-              .form-group
-                %label{for: "user[login]", class: 'col-sm-2 control-label'}
-                  Username
-                .col-sm-10
-                  = text_field_tag 'user[login]', nil, placeholder: 'Username', class: 'form-control', required: 'required'
-              .form-group
-                %label{for: "user[password]", class: 'col-sm-2 control-label'}
-                  Password
-                .col-sm-10
-                  = password_field_tag 'user[password]', nil, placeholder: 'Password', class: 'form-control', required: 'required'
-              .form-group
-                .col-sm-12
-                  %button.btn.btn-success.pull-right
-                    Sign in
-              - unless omniauth_configured.empty?
-                .form-group
-                  %hr
-                  %p.text-center
-                    or sign in using
-                  .text-center
-                    = render 'devise/shared/openid'
-
+          = render partial: 'devise/shared/sign_in_form_embedded'


### PR DESCRIPTION
https://github.com/openSUSE/osem/issues/625
We ended up with a lot of common code in multiple sections of the app, such as 
* sign_in form (embedded in conference_registration and proposal)
* sign_up form (embedded in conference_registration and proposal)
* help link for devise links
* openid sign_in

Moreover in some places the code was slightly different for no actual reason.
I gathered them in partials so that we have 1 single point of reference for doing the exact same thing.