### PR TITLE
Allow a proposal to be created with a Subtitle and Difficulty Level.

### DIFF
--- a/app/views/proposal/_proposal_form.html.haml
+++ b/app/views/proposal/_proposal_form.html.haml
@@ -1,4 +1,8 @@
 = semantic_form_for(@event, url: @url) do |f|
+
+  - if current_user.nil?
+    = render partial: 'devise/shared/sign_up_form_embedded'
+
   = f.inputs name: 'Proposal Information' do
     = f.input :title, as: :string, required: true
 
@@ -39,8 +43,10 @@
 
     = f.input :require_registration, label: 'Require participants to register to your event'
 
-    - if current_user.has_any_role? :admin, { name: :organizer, resource: @conference }, { name: :cfp, resource: @conference }
-      = f.input :is_highlight
+    -# We have to verify current_user in this context as this partial form is used both for new proposals and editing existing proposals
+    - if current_user
+      - if current_user.has_any_role? :admin, { name: :organizer, resource: @conference }, { name: :cfp, resource: @conference }
+        = f.input :is_highlight
 
     %p.text-right
       = link_to '#description',  "data-toggle"=>"collapse" do
@@ -48,6 +54,5 @@
     .collapse#description
       = f.input :description, input_html: { rows: 5 }, label: 'Requirements', placeholder: 'Eg. Whiteboard, printer, or something like that.'
 
-
   %p.text-right
-    = f.action :submit, :as => :button, :button_html => {:class => "btn btn-success"}, label: 'Update Proposal'
+    = f.action :submit, :as => :button, :button_html => {:class => "btn btn-success"}, label: @event.new_record? ? 'Create Proposal' : 'Update Proposal'

--- a/app/views/proposal/new.html.haml
+++ b/app/views/proposal/new.html.haml
@@ -7,7 +7,7 @@
     .col-md-12
       = render partial: 'encouragement_text'
   .row
-    .col-md-8
+    .col-md-12
       - if !current_user
         %legend
           %span
@@ -19,48 +19,7 @@
               Already have an account?
       .tab-content
         .tab-pane.active{role: 'tabpanel', id: 'signup'}
+          = render partial: 'proposal_form'
 
-          = semantic_form_for(@event, url: @url) do |f|
-
-            = render partial: 'devise/shared/sign_up_form_embedded'
-
-            = f.inputs name: 'Proposal Information' do
-              = f.input :title, as: :string, required: true
-              = f.input :event_type_id, as: :select,
-                collection: @conference.event_types.map {|type| ["#{type.title} - #{show_time(type.length)}", type.id,
-                data: { min_words: type.minimum_abstract_length, max_words: type.maximum_abstract_length }]},
-                include_blank: false, label: 'Type', input_html: { class: 'select-help-toggle' }
-
-              - @conference.event_types.each do |event_type|
-                %span{ class: 'help-block event_event_type_id collapse', id: "#{event_type.id}-help" }
-                  = event_type.description
-
-              :javascript
-                $("##{@conference.event_types.first.id}-help").collapse('show');
-
-              = f.input :abstract, input_html: { rows: 5 },
-                required: true, hint: link_to('Tips to improve your presentations', 'http://blog.hubspot.com/blog/tabid/6307/bid/5975/10-Rules-to-Instantly-Improve-Your-Presentations.aspx')
-
-              %p
-                You have used
-                %span#abstract-count #{@event.abstract_word_count}
-                words.  Abstracts must be between
-                %span#abstract-minimum-word-count
-                  0
-                and
-                %span#abstract-maximum-word-count
-                  250
-                words.
-
-              = f.input :require_registration, label: 'Require participants to register to your event'
-
-              %p.text-right
-                = link_to '#description',  "data-toggle"=>"collapse", id: 'description_link' do
-                  Do you require something special?
-              .collapse#description
-                = f.input :description, input_html: { rows: 5 }, label: 'Requirements', placeholder: 'Eg. Whiteboard, printer, or something like that.'
-
-            %p.text-right
-              = f.action :submit, :as => :button, :button_html => {:class => "btn btn-success"}, label: 'Create Proposal'
         .tab-pane{role: 'tabpanel', id: 'signin'}
           = render partial: 'devise/shared/sign_in_form_embedded'

--- a/spec/features/proposal_spec.rb
+++ b/spec/features/proposal_spec.rb
@@ -114,7 +114,7 @@ feature Event do
       select('Example Event Type', from: 'event[event_type_id]')
 
       fill_in 'event_abstract', with: 'Lorem ipsum abstract'
-      click_link 'description_link'
+      click_link 'Do you require something special?'
       fill_in 'event_description', with: 'Lorem ipsum description'
 
       click_button 'Create Proposal'


### PR DESCRIPTION
When a proposal is being submitted, we want to allow the submitter to
fill out the form once with all the required data. This change unifies
the forms for both editing and creating proposals. This allows us to
ensure that features are added in parallel to both workflows.

We also reduce the number of duplicate lines by removing duplicates
from the new.html.haml file.

We also increase the column size in css to have both pages show the
same width forms.