### PR TITLE
Fix the abstrct count on the proposal create and edit pages

### DIFF
--- a/app/assets/javascripts/osem.js
+++ b/app/assets/javascripts/osem.js
@@ -157,24 +157,27 @@ function word_count(text, divId, maxcount) {
     }
 };
 
-/* Set the minimum and maximum proposal abstract word length */
-$("#event_event_type_id").change(function () {
-    var $selected = $("#event_event_type_id option:selected")
-    var max = $selected.data("max-words");
-    var min = $selected.data("min-words");
+/* Wait for the DOM to be ready before attaching events to the elements */
+$( document ).ready(function() {
+    /* Set the minimum and maximum proposal abstract word length */
+    $("#event_event_type_id").change(function () {
+        var $selected = $("#event_event_type_id option:selected")
+        var max = $selected.data("max-words");
+        var min = $selected.data("min-words");
 
-    $("#abstract-maximum-word-count").text(max);
-    $("#abstract-minimum-word-count").text(min);
-    word_count($('#event_abstract').get(0), 'abstract-count', max);
-})
-    .trigger('change');
+        $("#abstract-maximum-word-count").text(max);
+        $("#abstract-minimum-word-count").text(min);
+        word_count($('#event_abstract').get(0), 'abstract-count', max);
+    })
+        .trigger('change');
 
-/* Count the proposal abstract length */
-$("#event_abstract").bind('keyup', function() {
-    var $selected = $("#event_event_type_id option:selected")
-    var max = $selected.data("max-words");
-    word_count(this, 'abstract-count', max);
-} );
+    /* Count the proposal abstract length */
+    $("#event_abstract").bind('change keyup paste input', function() {
+        var $selected = $("#event_event_type_id option:selected")
+        var max = $selected.data("max-words");
+        word_count(this, 'abstract-count', max);
+    } );
+});
 
 /* Set the defaults for DataTables initialisation */
 $.extend( true, $.fn.dataTable.defaults, {


### PR DESCRIPTION
Due to the DOM not being ready when osem.js is executed, the
bind statements do not actually bind on the correct elements.
We just wrap the binds in a document ready event which allows
the elements to fully load and the events to fire correctly.

I also bind on more then just keyup, to catch times when people
paste content into the field. The input event is only supported
by newer browsers, but is entirely a noop for older browsers.