### PR TITLE
Rework bootstrapSwitch

### DIFF
--- a/app/assets/javascripts/osem-switch.js
+++ b/app/assets/javascripts/osem-switch.js
@@ -1,16 +1,14 @@
 $(function () {
-  $(document).ready(function() {
-    $("[class='switch-checkbox']").bootstrapSwitch();
+  $("[class='switch-checkbox']").bootstrapSwitch();
 
-    $('input[class="switch-checkbox"]').on('switchChange.bootstrapSwitch', function(event, state) {
-      url = "/admin/conference/" + this.name + "/events/" + this.value
+  $('input[class="switch-checkbox"]').on('switchChange.bootstrapSwitch', function(event, state) {
+    var url = $(this).attr('url') + state;
+    var method = $(this).attr('method');
 
-      $.ajax({
-        url: url,
-        type: 'PATCH',
-        data: { event: { is_highlight: state } },
-        dataType: 'script'
-      });
+    $.ajax({
+      url: url,
+      type: method,
+      dataType: 'script'
     });
   });
 });

--- a/app/views/admin/events/_proposal.html.haml
+++ b/app/views/admin/events/_proposal.html.haml
@@ -5,7 +5,7 @@
       %br
       %small
         = @event.subtitle
-      = link_to "Edit", edit_admin_conference_event_path(@conference.short_title, @event), :class => "btn btn-mini btn-default pull-right"
+      = link_to 'Edit', edit_admin_conference_event_path(@conference.short_title, @event), class: 'btn btn-mini btn-primary pull-right'
 
 .row
   .col-md-12
@@ -15,12 +15,12 @@
           %b Type
         %td
           .dropdown
-            = link_to "#", :class => "dropdown-toggle", :id => "type-dropdown" do
+            = link_to '#', class: 'dropdown-toggle', id: 'type-dropdown' do
               - if @event.event_type.nil?
                 Event Type
               - else
                 = @event.event_type.title
-              <b class="caret"></b>
+              <b class='caret'></b>
             %ul.dropdown-menu
               - @event_types.each do |type|
                 %li= link_to type.title,
@@ -32,20 +32,21 @@
         %td
           %b Highlight
         %td
-          = check_box_tag @conference.short_title, @event.id, @event.is_highlight, class: 'switch-checkbox',
-            data: { size: "small",
-                    off_color: 'warning',
-                    on_text: 'Yes',
-                    off_text: 'No' }
+          = check_box_tag @conference.short_title, @event.id, @event.is_highlight,
+            method: :patch, url: "/admin/conference/#{@conference.short_title}/events/#{@event.id}?event[is_highlight]=",
+            class: 'switch-checkbox', data: { size: 'small',
+                                              off_color: 'warning',
+                                              on_text: 'Yes',
+                                              off_text: 'No' }
 
       %tr
         %td
           %b State
         %td
           .dropdown
-            = link_to "#", :class => "dropdown-toggle" do
+            = link_to '#', class: 'dropdown-toggle' do
               = @event.state.humanize
-              <b class="caret"></b>
+              <b class='caret'></b>
             %ul.dropdown-menu
               = render 'change_state_dropdown', event: @event
       %tr
@@ -53,7 +54,7 @@
           %b Track
         %td
           .dropdown
-            = link_to "#", :class => "dropdown-toggle", :id => "track-dropdown" do
+            = link_to '#', class: 'dropdown-toggle', id: 'track-dropdown' do
               - if @event.track.nil?
                 Track
               - else
@@ -71,7 +72,7 @@
           %b Difficulty
         %td
           .dropdown
-            = link_to "#", :class => "dropdown-toggle", :id => "difficulty-dropdown" do
+            = link_to '#', class: 'dropdown-toggle', id: 'difficulty-dropdown' do
               - if @event.difficulty_level.nil?
                 Difficulty Level
               - else
@@ -83,6 +84,17 @@
                                             @event,
                                             event: { difficulty_level_id: difficulty.id }),
                 method: :patch
+      %tr
+        %td
+          %b Requires Registration
+        %td
+          = check_box_tag @conference.short_title, @event.id, @event.require_registration,
+            method: :patch, url: "/admin/conference/#{@conference.short_title}/events/#{@event.id}?event[require_registration]=",
+            class: 'switch-checkbox', data: { size: 'small',
+                                              off_color: 'warning',
+                                              on_text: 'Yes',
+                                              off_text: 'No' }
+
       - if !@event.room.nil?
         %tr
           %td
@@ -126,18 +138,18 @@
         %td= simple_format(@event.description)
 
       - if @conference.call_for_paper && @conference.call_for_paper.rating && @conference.call_for_paper.rating > 0
-        = render :partial => "voting"
+        = render partial: 'voting'
 
 .row
-  = link_to "Comments (#{@comment_count})", "#", :id => "event-comment-link"
+  = link_to "Comments (#{@comment_count})", '#', id: 'event-comment-link'
   #comments-div
     %hr
     %ul.media
       %div
         .row-fluid
-          = form_tag(comment_admin_conference_event_path(@conference.short_title, @event.id), :method => :post) do
-            = text_area_tag(:comment, "")
-            = submit_tag "Add Comment", :class => "btn btn-primary pull-right"
+          = form_tag(comment_admin_conference_event_path(@conference.short_title, @event.id), method: :post) do
+            = text_area_tag(:comment, '')
+            = submit_tag 'Add Comment', class: 'btn btn-primary pull-right'
         %br
         - @comments.each do |comment|
           %div

--- a/app/views/admin/events/index.html.haml
+++ b/app/views/admin/events/index.html.haml
@@ -23,6 +23,8 @@
         %th
           %b Speaker
         %th
+          %b Pre-registration
+        %th
           %b Highlight
         %th
           %b Type
@@ -72,12 +74,22 @@
               = link_to speaker.name, admin_user_path(speaker)
             - else
               Unknown speaker
+
+          %td{'data-order' => "#{event.require_registration}"}
+            = check_box_tag @conference.short_title, event.id, event.require_registration,
+              method: :patch, url: "/admin/conference/#{@conference.short_title}/events/#{event.id}?event[require_registration]=",
+              class: 'switch-checkbox', data: { size: 'small',
+                                                off_color: 'warning',
+                                                on_text: 'Yes',
+                                                off_text: 'No' }
+
           %td{'data-order' => "#{event.is_highlight}"}
-            = check_box_tag @conference.short_title, event.id, event.is_highlight, class: 'switch-checkbox',
-            data: { size: "small",
-                    off_color: 'warning',
-                    on_text: 'Yes',
-                    off_text: 'No' }
+            = check_box_tag @conference.short_title, event.id, event.is_highlight,
+              method: :patch, url: "/admin/conference/#{@conference.short_title}/events/#{event.id}?event[is_highlight]=",
+              class: 'switch-checkbox', data: { size: 'small',
+                                                off_color: 'warning',
+                                                on_text: 'Yes',
+                                                off_text: 'No' }
 
           %td
             .btn-group

--- a/spec/views/admin/events/index.html.haml_spec.rb
+++ b/spec/views/admin/events/index.html.haml_spec.rb
@@ -1,0 +1,35 @@
+require 'spec_helper'
+
+describe 'admin/events/index' do
+  let!(:conference) { create(:conference) }
+  let!(:event1) { create(:event, conference: conference, title: 'event1') }
+  let!(:event2) { create(:event, conference: conference, title: 'event2') }
+
+  it 'renders all conference events' do
+    assign(:conference, conference)
+    assign(:events, [ event1, event2 ])
+    assign(:event_types, [ create(:event_type, conference: conference), create(:event_type, conference: conference) ])
+    assign(:tracks, [ create(:track, conference: conference), create(:track, conference: conference) ])
+    assign(:difficulty_levels, [ create(:difficulty_level, conference: conference), create(:difficulty_level, conference: conference) ])
+
+    render
+
+    expect(rendered).to have_selector('table thead th:nth-of-type(1)', text: 'ID')
+    expect(rendered).to have_selector('table thead th:nth-of-type(2)', text: 'Title')
+    expect(rendered).to have_selector('table thead th:nth-of-type(3)', text: 'Submitter')
+    expect(rendered).to have_selector('table thead th:nth-of-type(4)', text: 'Speaker')
+    expect(rendered).to have_selector('table thead th:nth-of-type(5)', text: 'Pre-registration')
+    expect(rendered).to have_selector('table thead th:nth-of-type(6)', text: 'Highlight')
+    expect(rendered).to have_selector('table thead th:nth-of-type(7)', text: 'Type')
+    expect(rendered).to have_selector('table thead th:nth-of-type(8)', text: 'Track')
+    expect(rendered).to have_selector('table thead th:nth-of-type(9)', text: 'Difficulty')
+    expect(rendered).to have_selector('table thead th:nth-of-type(10)', text: 'State')
+
+    expect(conference.events.count).to eq 2
+    expect(rendered).to have_selector('table tr:nth-of-type(1) td:nth-of-type(1)', text: event1.id)
+    expect(rendered).to have_selector('table tr:nth-of-type(1) td:nth-of-type(2)', text: 'event1')
+
+    expect(rendered).to have_selector('table tr:nth-of-type(2) td:nth-of-type(1)', text: event2.id)
+    expect(rendered).to have_selector('table tr:nth-of-type(2) td:nth-of-type(2)', text: 'event2')
+  end
+end


### PR DESCRIPTION
I am moving the js code for switch outside of the $(document).ready function, which results in us not being able to click on the switch button in events#index, but that's not necessarily a problem, since index page is not supposed to change stuff anyway.
event#edit works fine.

I have also re-written the js code for switch so that it can be used in any place, for any model.
When the switch-checkbox is introduced in the view, one needs to pass a method and a url (where the switch should redirect to). If we have all the data given into that URL, the switch can work regrdless of the model or attribute that is being changed.