### PR TITLE
Use recommended method for installing Shoulda Matchers with Spring.

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -151,7 +151,7 @@ group :test do
   gem 'poltergeist'
   gem 'phantomjs', :require => 'phantomjs/poltergeist'
   # Set of rails validations matchers to describe models
-  gem 'shoulda'
+  gem 'shoulda-matchers', require: false
   # Extracted from RSpec 3 stub_model and mock_model
   gem 'rspec-activemodel-mocks'
   gem 'timecop'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -376,10 +376,6 @@ GEM
       sass (~> 3.2.2)
       sprockets (~> 2.8, < 2.12)
       sprockets-rails (~> 2.0)
-    shoulda (3.5.0)
-      shoulda-context (~> 1.0, >= 1.0.1)
-      shoulda-matchers (>= 1.4.1, < 3.0)
-    shoulda-context (1.2.1)
     shoulda-matchers (2.6.1)
       activesupport (>= 3.0.0)
     simplecov (0.8.2)
@@ -496,7 +492,7 @@ DEPENDENCIES
   rspec-rails
   rubocop
   sass-rails (>= 4.0.2)
-  shoulda
+  shoulda-matchers
   spring-commands-rspec
   sqlite3
   timecop

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -13,6 +13,7 @@ ENV['RAILS_ENV'] ||= 'test'
 require File.expand_path('../../config/environment', __FILE__)
 
 require 'rspec/rails'
+require 'shoulda/matchers'
 # To avoid confusion on missed migrations - use Rails 4 checker to ensure
 # all migrations applied
 ActiveRecord::Migration.maintain_test_schema!


### PR DESCRIPTION
The tests were failing for me out of the box in the same manner as in rails/spring#209—

```console
$ git rev-parse HEAD && git status --short
2e692f7ea5f233eb42b02cab883a10bcd17d4b27

$ ruby --version
ruby 2.1.1p76 (2014-02-24 revision 45161) [x86_64-linux]

$ bundle check
The Gemfile's dependencies are satisfied

$ bundle exec guard
14:10:29 - INFO - Guard::RSpec is running
14:10:29 - INFO - Running all specs

[...]

Failures:

  1) Target validations is not valid without a due date
     Failure/Error: should validate_presence_of(:due_date)
     NoMethodError:
       undefined method `validate_presence_of' for #<RSpec::ExampleGroups::Target::Validations:0x007f47fe2d1138>

[...]

Failed examples:

rspec ./spec/models/target_spec.rb:10 # Target validations is not valid without a due date
rspec ./spec/models/target_spec.rb:14 # Target validations is not valid without a target_count
rspec ./spec/models/target_spec.rb:30 # Target validations is not valid with a target_count smaller than zero
rspec ./spec/models/target_spec.rb:26 # Target validations is not valid with a target_count equals zero
rspec ./spec/models/target_spec.rb:18 # Target validations is not valid without a unit
rspec ./spec/models/target_spec.rb:22 # Target validations is valid with a target_count greater than zero
rspec ./spec/models/conference_spec.rb:1491 # Conference validations is not valid without a title
rspec ./spec/models/conference_spec.rb:1495 # Conference validations is not valid without a short title
rspec ./spec/models/conference_spec.rb:1511 # Conference validations is valid with a short title that contains a-zA-Z0-9_-
rspec ./spec/models/conference_spec.rb:1507 # Conference validations is not valid with a duplicate short title
rspec ./spec/models/conference_spec.rb:1499 # Conference validations is not valid without a start date
rspec ./spec/models/conference_spec.rb:1503 # Conference validations is not valid without an end date
rspec ./spec/models/conference_spec.rb:1515 # Conference validations is not valid with a short title that contains special characters
rspec ./spec/models/campaign_spec.rb:10 # Campaign validations is not valid without a name
rspec ./spec/models/ticket_purchase_spec.rb:10 # TicketPurchase validations is not valid without a conference_id
rspec ./spec/models/ticket_purchase_spec.rb:14 # TicketPurchase validations is not valid without a ticket_id
rspec ./spec/models/ticket_purchase_spec.rb:30 # TicketPurchase validations is not valid with a quantity smaller than zero
rspec ./spec/models/ticket_purchase_spec.rb:26 # TicketPurchase validations is not valid with a quantity equals zero
rspec ./spec/models/ticket_purchase_spec.rb:18 # TicketPurchase validations is not valid without a user_id
rspec ./spec/models/ticket_purchase_spec.rb:22 # TicketPurchase validations is not valid without a quantity
rspec ./spec/models/ticket_purchase_spec.rb:34 # TicketPurchase validations is valid with a quantity greater than zero
rspec ./spec/models/commercial_spec.rb:5 # Commercial
rspec ./spec/models/commercial_spec.rb:6 # Commercial
rspec ./spec/models/sponsor_spec.rb:13 # Sponsor validations is not valid without a website url
rspec ./spec/models/sponsor_spec.rb:9 # Sponsor validations is not valid without a name
rspec ./spec/models/ticket_spec.rb:13 # Ticket validations is not valid without a title
rspec ./spec/models/ticket_spec.rb:17 # Ticket validations is not valid without a price_cents
rspec ./spec/models/ticket_spec.rb:33 # Ticket validations is valid with a price_cents greater than zero
rspec ./spec/models/ticket_spec.rb:29 # Ticket validations is not valid with a price_cents smaller than zero
rspec ./spec/models/ticket_spec.rb:21 # Ticket validations is not valid without a price_currency
rspec ./spec/models/ticket_spec.rb:25 # Ticket validations is not valid with a price_cents equals zero
rspec ./spec/models/sponsorship_level_spec.rb:10 # SponsorshipLevel validations is not valid without a title

Randomized with seed 18217
```

—i.e. tests passed via `rspec` but failed via `spring rspec`.

The instructions in thoughtbot/shoulda-matchers@a5623e7 resolved the problem.