### PR TITLE
Conference title in conference show view. fix #751

### DIFF
--- a/app/views/conference/show.html.haml
+++ b/app/views/conference/show.html.haml
@@ -1,3 +1,6 @@
+= content_for :title do
+  = @conference.title
+
 #splash
   - if @conference.splashpage
     #banner


### PR DESCRIPTION
Show the conference title in the page title in conference show view.