### PR TITLE
Hide free of charge message

### DIFF
--- a/app/views/conference/_registration.html.haml
+++ b/app/views/conference/_registration.html.haml
@@ -6,14 +6,19 @@
   .row
     .col-md-12.text-center
       %h1 Registration
-      %p.lead
-        Going to
-        = @conference.short_title
-        is free of charge.
-      %p
-        We only ask you to register yourself until
-        = @conference.registration_period.end_date.strftime('%A, %B %-d. %Y')
-        so we can plan for the right amount of people.
+      - if @conference.tickets.empty?
+        %p.lead
+          Going to
+          = @conference.short_title
+          is free of charge.
+        %p
+          We only ask you to register yourself until
+          = @conference.registration_period.end_date.strftime('%A, %B %-d. %Y')
+          so we can plan for the right amount of people.
+      - else
+        %p
+          The registration period ends on
+          = @conference.registration_period.end_date.strftime('%A, %B %-d. %Y')
       %p.cta-button
         = link_to(new_conference_conference_registrations_path(@conference.short_title), class: 'btn btn-lg btn-success') do
           Register Now


### PR DESCRIPTION
If the conference has tickets not show the "free of charge" message. Instead, only show the registration end period.