### PR TITLE
Enable Bundler caching on travis

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,4 +1,5 @@
 language: ruby
+cache: bundler
 rvm:
   - 2.1.1
 before_install:


### PR DESCRIPTION
Read more about it here: https://docs.travis-ci.com/user/caching/#Bundler
closes: #350

Travis will use cached gems on builds following this one.