### PR TITLE
Follow up on update of rails and activeuuid

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -52,7 +52,7 @@ gem 'uglifier', '>= 1.3.0'
 gem 'bootstrap-sass', '~> 3.3.4.1'
 gem 'autoprefixer-rails'
 gem 'formtastic-bootstrap'
-gem 'formtastic', '~> 2.3.0.rc3'
+gem 'formtastic', '~> 3.1.1'
 gem 'cocoon'
 
 # frontend javascripts

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -166,10 +166,10 @@ GEM
     font-awesome-rails (4.1.0.0)
       railties (>= 3.2, < 5.0)
     formatador (0.2.4)
-    formtastic (2.3.0.rc3)
-      actionpack (>= 3.0)
-    formtastic-bootstrap (3.0.0)
-      formtastic (>= 2.2)
+    formtastic (3.1.3)
+      actionpack (>= 3.2.13)
+    formtastic-bootstrap (3.1.1)
+      formtastic (>= 3.0)
     geocoder (1.2.2)
     globalid (0.3.6)
       activesupport (>= 4.1.0)
@@ -504,7 +504,7 @@ DEPENDENCIES
   devise_ichain_authenticatable
   factory_girl_rails
   font-awesome-rails
-  formtastic (~> 2.3.0.rc3)
+  formtastic (~> 3.1.1)
   formtastic-bootstrap
   gravtastic
   guard-rspec (~> 4.2.8)

--- a/config/application.rb
+++ b/config/application.rb
@@ -60,5 +60,9 @@ module Osem
 
     # Version of your assets, change this if you want to expire all your assets
     config.assets.version = '1.0'
+
+    # Errors raised within `after_rollback`/`after_commit` propagate normally
+    # like in other Active Record callbacks.
+    config.active_record.raise_in_transactional_callbacks = true
   end
 end

--- a/config/environments/production.rb
+++ b/config/environments/production.rb
@@ -15,7 +15,7 @@ Osem::Application.configure do
   config.eager_load = true
 
   # Disable Rails's static asset server (Apache or nginx will already do this)
-  config.serve_static_assets = false
+  config.serve_static_files = false
   # Compress JavaScripts and CSS
   config.assets.compress = true
 

--- a/config/environments/test.rb
+++ b/config/environments/test.rb
@@ -8,7 +8,7 @@ Osem::Application.configure do
   config.cache_classes = true
 
   # Configure static asset server for tests with Cache-Control for performance
-  config.serve_static_assets = true
+  config.serve_static_files = true
   config.static_cache_control = 'public, max-age=3600'
 
   # Do not eager load code on boot.

--- a/config/initializers/formtastic.rb
+++ b/config/initializers/formtastic.rb
@@ -66,14 +66,48 @@ Formtastic::FormBuilder.required_string = proc { Formtastic::Util.html_safe(%{&n
 # specifying that class here.  Defaults to Formtastic::FormBuilder.
 # Formtastic::Helpers::FormHelper.builder = MyCustomBuilder
 
+# All formtastic forms have a class that indicates that they are just that. You
+# can change it to any class you want.
+# Formtastic::Helpers::FormHelper.default_form_class = 'formtastic'
+
+# Formtastic will infer a class name from the model, array, string ot symbol you pass to the
+# form builder. You can customize the way that class is presented by overriding
+# this proc.
+# Formtastic::Helpers::FormHelper.default_form_model_class_proc = proc { |model_class_name| model_class_name }
+
+# Allows to set a custom field_error_proc wrapper. By default this wrapper
+# is disabled since `formtastic` already adds an error class to the LI tag
+# containing the input.
+# Formtastic::Helpers::FormHelper.formtastic_field_error_proc = proc { |html_tag, instance_tag| html_tag }
+
 # You can opt-in to Formtastic's use of the HTML5 `required` attribute on `<input>`, `<select>`
-# and `<textarea>` tags by setting this to false (defaults to true).
-# Formtastic::FormBuilder.use_required_attribute = true
+# and `<textarea>` tags by setting this to true (defaults to false).
+# Formtastic::FormBuilder.use_required_attribute = false
 
 # You can opt-in to new HTML5 browser validations (for things like email and url inputs) by setting
-# this to false. Doing so will add a `novalidate` attribute to the `<form>` tag.
+# this to true. Doing so will add a `novalidate` attribute to the `<form>` tag.
 # See http://diveintohtml5.org/forms.html#validation for more info.
 Formtastic::FormBuilder.perform_browser_validations = true
 #
 Formtastic::Helpers::FormHelper.builder = FormtasticBootstrap::FormBuilder
 FormtasticBootstrap::FormBuilder.default_inline_hint_class = FormtasticBootstrap::FormBuilder.default_block_hint_class
+
+# By creating custom input class finder, you can change how input classes  are looked up.
+# For example you can make it to search for TextInputFilter instead of TextInput.
+# See # TODO: add link # for more information
+# NOTE: this behavior will be default from Formtastic 4.0
+Formtastic::FormBuilder.input_class_finder = Formtastic::InputClassFinder
+
+# Define custom namespaces in which to look up your Input classes. Default is
+# to look up in the global scope and in Formtastic::Inputs.
+# Formtastic::FormBuilder.input_namespaces = [ ::Object, ::MyInputsModule, ::Formtastic::Inputs ]
+
+# By creating custom action class finder, you can change how action classes are looked up.
+# For example you can make it to search for MyButtonAction instead of ButtonAction.
+# See # TODO: add link # for more information
+# NOTE: this behavior will be default from Formtastic 4.0
+Formtastic::FormBuilder.action_class_finder = Formtastic::ActionClassFinder
+
+# Define custom namespaces in which to look up your Action classes. Default is
+# to look up in the global scope and in Formtastic::Actions.
+# Formtastic::FormBuilder.action_namespaces = [ ::Object, ::MyActionsModule, ::Formtastic::Actions ]

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -13,8 +13,8 @@
 
 ActiveRecord::Schema.define(version: 20160201221411) do
 
-  create_table "ahoy_events", force: true do |t|
-    t.uuid     "visit_id"
+  create_table "ahoy_events", force: :cascade do |t|
+    t.uuid     "visit_id",   limit: 16
     t.integer  "user_id"
     t.string   "name"
     t.text     "properties"
@@ -25,13 +25,13 @@ ActiveRecord::Schema.define(version: 20160201221411) do
   add_index "ahoy_events", ["user_id"], name: "index_ahoy_events_on_user_id"
   add_index "ahoy_events", ["visit_id"], name: "index_ahoy_events_on_visit_id"
 
-  create_table "answers", force: true do |t|
+  create_table "answers", force: :cascade do |t|
     t.string   "title"
     t.datetime "created_at"
     t.datetime "updated_at"
   end
 
-  create_table "campaigns", force: true do |t|
+  create_table "campaigns", force: :cascade do |t|
     t.integer  "conference_id"
     t.string   "name"
     t.string   "utm_source"
@@ -43,7 +43,7 @@ ActiveRecord::Schema.define(version: 20160201221411) do
     t.datetime "updated_at"
   end
 
-  create_table "cfps", force: true do |t|
+  create_table "cfps", force: :cascade do |t|
     t.date     "start_date", null: false
     t.date     "end_date",   null: false
     t.datetime "created_at"
@@ -51,7 +51,7 @@ ActiveRecord::Schema.define(version: 20160201221411) do
     t.integer  "program_id"
   end
 
-  create_table "comments", force: true do |t|
+  create_table "comments", force: :cascade do |t|
     t.string   "title",            limit: 50, default: ""
     t.text     "body"
     t.integer  "commentable_id"
@@ -69,7 +69,7 @@ ActiveRecord::Schema.define(version: 20160201221411) do
   add_index "comments", ["commentable_type"], name: "index_comments_on_commentable_type"
   add_index "comments", ["user_id"], name: "index_comments_on_user_id"
 
-  create_table "commercials", force: true do |t|
+  create_table "commercials", force: :cascade do |t|
     t.string   "commercial_id"
     t.string   "commercial_type"
     t.integer  "commercialable_id"
@@ -79,7 +79,7 @@ ActiveRecord::Schema.define(version: 20160201221411) do
     t.string   "url"
   end
 
-  create_table "conferences", force: true do |t|
+  create_table "conferences", force: :cascade do |t|
     t.string   "guid",                                  null: false
     t.string   "title",                                 null: false
     t.string   "short_title",                           null: false
@@ -105,12 +105,12 @@ ActiveRecord::Schema.define(version: 20160201221411) do
     t.integer  "registration_limit",    default: 0
   end
 
-  create_table "conferences_questions", id: false, force: true do |t|
+  create_table "conferences_questions", id: false, force: :cascade do |t|
     t.integer "conference_id"
     t.integer "question_id"
   end
 
-  create_table "contacts", force: true do |t|
+  create_table "contacts", force: :cascade do |t|
     t.string   "social_tag"
     t.string   "email"
     t.string   "facebook"
@@ -123,7 +123,7 @@ ActiveRecord::Schema.define(version: 20160201221411) do
     t.string   "sponsor_email"
   end
 
-  create_table "delayed_jobs", force: true do |t|
+  create_table "delayed_jobs", force: :cascade do |t|
     t.integer  "priority",   default: 0, null: false
     t.integer  "attempts",   default: 0, null: false
     t.text     "handler",                null: false
@@ -139,14 +139,14 @@ ActiveRecord::Schema.define(version: 20160201221411) do
 
   add_index "delayed_jobs", ["priority", "run_at"], name: "delayed_jobs_priority"
 
-  create_table "dietary_choices", force: true do |t|
+  create_table "dietary_choices", force: :cascade do |t|
     t.integer  "conference_id"
     t.string   "title",         null: false
     t.datetime "created_at"
     t.datetime "updated_at"
   end
 
-  create_table "difficulty_levels", force: true do |t|
+  create_table "difficulty_levels", force: :cascade do |t|
     t.string   "title"
     t.text     "description"
     t.string   "color"
@@ -155,7 +155,7 @@ ActiveRecord::Schema.define(version: 20160201221411) do
     t.integer  "program_id"
   end
 
-  create_table "email_settings", force: true do |t|
+  create_table "email_settings", force: :cascade do |t|
     t.integer  "conference_id"
     t.boolean  "send_on_registration",                          default: false
     t.boolean  "send_on_accepted",                              default: false
@@ -188,7 +188,7 @@ ActiveRecord::Schema.define(version: 20160201221411) do
     t.text     "cfp_dates_updated_body"
   end
 
-  create_table "event_types", force: true do |t|
+  create_table "event_types", force: :cascade do |t|
     t.string  "title",                                 null: false
     t.integer "length",                  default: 30
     t.integer "minimum_abstract_length", default: 0
@@ -198,7 +198,7 @@ ActiveRecord::Schema.define(version: 20160201221411) do
     t.integer "program_id"
   end
 
-  create_table "event_users", force: true do |t|
+  create_table "event_users", force: :cascade do |t|
     t.integer  "user_id"
     t.integer  "event_id"
     t.string   "event_role", default: "participant", null: false
@@ -207,7 +207,7 @@ ActiveRecord::Schema.define(version: 20160201221411) do
     t.datetime "updated_at"
   end
 
-  create_table "events", force: true do |t|
+  create_table "events", force: :cascade do |t|
     t.string   "guid",                                         null: false
     t.integer  "event_type_id"
     t.string   "title",                                        null: false
@@ -236,12 +236,12 @@ ActiveRecord::Schema.define(version: 20160201221411) do
     t.integer  "program_id"
   end
 
-  create_table "events_registrations", id: false, force: true do |t|
+  create_table "events_registrations", id: false, force: :cascade do |t|
     t.integer "registration_id"
     t.integer "event_id"
   end
 
-  create_table "lodgings", force: true do |t|
+  create_table "lodgings", force: :cascade do |t|
     t.string   "name"
     t.text     "description"
     t.string   "photo_file_name"
@@ -254,7 +254,7 @@ ActiveRecord::Schema.define(version: 20160201221411) do
     t.integer  "conference_id"
   end
 
-  create_table "openids", force: true do |t|
+  create_table "openids", force: :cascade do |t|
     t.string   "provider"
     t.string   "email"
     t.string   "uid"
@@ -263,7 +263,7 @@ ActiveRecord::Schema.define(version: 20160201221411) do
     t.datetime "updated_at"
   end
 
-  create_table "photos", force: true do |t|
+  create_table "photos", force: :cascade do |t|
     t.text     "description"
     t.string   "picture_file_name"
     t.string   "picture_content_type"
@@ -274,7 +274,7 @@ ActiveRecord::Schema.define(version: 20160201221411) do
     t.datetime "updated_at"
   end
 
-  create_table "programs", force: true do |t|
+  create_table "programs", force: :cascade do |t|
     t.integer  "conference_id"
     t.integer  "rating",          default: 0
     t.boolean  "schedule_public", default: false
@@ -283,25 +283,25 @@ ActiveRecord::Schema.define(version: 20160201221411) do
     t.datetime "updated_at"
   end
 
-  create_table "qanswers", force: true do |t|
+  create_table "qanswers", force: :cascade do |t|
     t.integer  "question_id"
     t.integer  "answer_id"
     t.datetime "created_at"
     t.datetime "updated_at"
   end
 
-  create_table "qanswers_registrations", id: false, force: true do |t|
+  create_table "qanswers_registrations", id: false, force: :cascade do |t|
     t.integer "registration_id", null: false
     t.integer "qanswer_id",      null: false
   end
 
-  create_table "question_types", force: true do |t|
+  create_table "question_types", force: :cascade do |t|
     t.string   "title"
     t.datetime "created_at"
     t.datetime "updated_at"
   end
 
-  create_table "questions", force: true do |t|
+  create_table "questions", force: :cascade do |t|
     t.string   "title"
     t.integer  "question_type_id"
     t.integer  "conference_id"
@@ -310,7 +310,7 @@ ActiveRecord::Schema.define(version: 20160201221411) do
     t.datetime "updated_at"
   end
 
-  create_table "registration_periods", force: true do |t|
+  create_table "registration_periods", force: :cascade do |t|
     t.integer  "conference_id"
     t.date     "start_date"
     t.date     "end_date"
@@ -318,7 +318,7 @@ ActiveRecord::Schema.define(version: 20160201221411) do
     t.datetime "updated_at"
   end
 
-  create_table "registrations", force: true do |t|
+  create_table "registrations", force: :cascade do |t|
     t.integer  "conference_id"
     t.datetime "arrival"
     t.datetime "departure"
@@ -333,17 +333,17 @@ ActiveRecord::Schema.define(version: 20160201221411) do
     t.integer  "week"
   end
 
-  create_table "registrations_social_events", id: false, force: true do |t|
+  create_table "registrations_social_events", id: false, force: :cascade do |t|
     t.integer "registration_id"
     t.integer "social_event_id"
   end
 
-  create_table "registrations_vchoices", id: false, force: true do |t|
+  create_table "registrations_vchoices", id: false, force: :cascade do |t|
     t.integer "registration_id"
     t.integer "vchoice_id"
   end
 
-  create_table "roles", force: true do |t|
+  create_table "roles", force: :cascade do |t|
     t.string   "name"
     t.datetime "created_at"
     t.datetime "updated_at"
@@ -355,28 +355,28 @@ ActiveRecord::Schema.define(version: 20160201221411) do
   add_index "roles", ["name", "resource_type", "resource_id"], name: "index_roles_on_name_and_resource_type_and_resource_id"
   add_index "roles", ["name"], name: "index_roles_on_name"
 
-  create_table "roles_users", id: false, force: true do |t|
+  create_table "roles_users", id: false, force: :cascade do |t|
     t.integer "role_id"
     t.integer "user_id"
   end
 
   add_index "roles_users", ["user_id", "role_id"], name: "index_roles_users_on_user_id_and_role_id"
 
-  create_table "rooms", force: true do |t|
+  create_table "rooms", force: :cascade do |t|
     t.string  "guid",     null: false
     t.string  "name",     null: false
     t.integer "size"
     t.integer "venue_id", null: false
   end
 
-  create_table "social_events", force: true do |t|
+  create_table "social_events", force: :cascade do |t|
     t.integer "conference_id"
     t.string  "title"
     t.text    "description"
     t.date    "date"
   end
 
-  create_table "splashpages", force: true do |t|
+  create_table "splashpages", force: :cascade do |t|
     t.integer  "conference_id"
     t.boolean  "public"
     t.boolean  "include_tracks"
@@ -392,7 +392,7 @@ ActiveRecord::Schema.define(version: 20160201221411) do
     t.boolean  "include_cfp",           default: false
   end
 
-  create_table "sponsors", force: true do |t|
+  create_table "sponsors", force: :cascade do |t|
     t.string   "name"
     t.text     "description"
     t.string   "website_url"
@@ -406,7 +406,7 @@ ActiveRecord::Schema.define(version: 20160201221411) do
     t.datetime "updated_at"
   end
 
-  create_table "sponsorship_levels", force: true do |t|
+  create_table "sponsorship_levels", force: :cascade do |t|
     t.string   "title"
     t.integer  "conference_id"
     t.datetime "created_at"
@@ -414,14 +414,14 @@ ActiveRecord::Schema.define(version: 20160201221411) do
     t.integer  "position"
   end
 
-  create_table "subscriptions", force: true do |t|
+  create_table "subscriptions", force: :cascade do |t|
     t.integer  "user_id"
     t.integer  "conference_id"
     t.datetime "created_at"
     t.datetime "updated_at"
   end
 
-  create_table "targets", force: true do |t|
+  create_table "targets", force: :cascade do |t|
     t.integer  "conference_id"
     t.integer  "campaign_id"
     t.date     "due_date"
@@ -431,7 +431,7 @@ ActiveRecord::Schema.define(version: 20160201221411) do
     t.datetime "updated_at"
   end
 
-  create_table "ticket_purchases", force: true do |t|
+  create_table "ticket_purchases", force: :cascade do |t|
     t.integer  "ticket_id"
     t.integer  "conference_id"
     t.boolean  "paid",          default: false
@@ -440,7 +440,7 @@ ActiveRecord::Schema.define(version: 20160201221411) do
     t.integer  "user_id"
   end
 
-  create_table "tickets", force: true do |t|
+  create_table "tickets", force: :cascade do |t|
     t.integer "conference_id"
     t.string  "title",                          null: false
     t.text    "description"
@@ -448,7 +448,7 @@ ActiveRecord::Schema.define(version: 20160201221411) do
     t.string  "price_currency", default: "USD", null: false
   end
 
-  create_table "tracks", force: true do |t|
+  create_table "tracks", force: :cascade do |t|
     t.string   "guid",        null: false
     t.string   "name",        null: false
     t.text     "description"
@@ -458,7 +458,7 @@ ActiveRecord::Schema.define(version: 20160201221411) do
     t.integer  "program_id"
   end
 
-  create_table "users", force: true do |t|
+  create_table "users", force: :cascade do |t|
     t.string   "email",                  default: "",    null: false
     t.string   "encrypted_password",     default: "",    null: false
     t.string   "reset_password_token"
@@ -498,12 +498,12 @@ ActiveRecord::Schema.define(version: 20160201221411) do
   add_index "users", ["reset_password_token"], name: "index_users_on_reset_password_token", unique: true
   add_index "users", ["username"], name: "index_users_on_username", unique: true
 
-  create_table "vchoices", force: true do |t|
+  create_table "vchoices", force: :cascade do |t|
     t.integer "vday_id"
     t.integer "vposition_id"
   end
 
-  create_table "vdays", force: true do |t|
+  create_table "vdays", force: :cascade do |t|
     t.integer  "conference_id"
     t.date     "day"
     t.text     "description"
@@ -511,7 +511,7 @@ ActiveRecord::Schema.define(version: 20160201221411) do
     t.datetime "updated_at"
   end
 
-  create_table "venues", force: true do |t|
+  create_table "venues", force: :cascade do |t|
     t.string   "guid"
     t.string   "name"
     t.string   "website"
@@ -531,7 +531,7 @@ ActiveRecord::Schema.define(version: 20160201221411) do
     t.integer  "conference_id"
   end
 
-  create_table "versions", force: true do |t|
+  create_table "versions", force: :cascade do |t|
     t.string   "item_type",      null: false
     t.integer  "item_id",        null: false
     t.string   "event",          null: false
@@ -543,8 +543,8 @@ ActiveRecord::Schema.define(version: 20160201221411) do
 
   add_index "versions", ["item_type", "item_id"], name: "index_versions_on_item_type_and_item_id"
 
-  create_table "visits", force: true do |t|
-    t.uuid     "visitor_id"
+  create_table "visits", force: :cascade do |t|
+    t.uuid     "visitor_id",       limit: 16
     t.string   "ip"
     t.text     "user_agent"
     t.text     "referrer"
@@ -568,7 +568,7 @@ ActiveRecord::Schema.define(version: 20160201221411) do
 
   add_index "visits", ["user_id"], name: "index_visits_on_user_id"
 
-  create_table "votes", force: true do |t|
+  create_table "votes", force: :cascade do |t|
     t.integer  "event_id"
     t.integer  "rating"
     t.datetime "created_at"
@@ -576,7 +576,7 @@ ActiveRecord::Schema.define(version: 20160201221411) do
     t.integer  "user_id"
   end
 
-  create_table "vpositions", force: true do |t|
+  create_table "vpositions", force: :cascade do |t|
     t.integer  "conference_id"
     t.string   "title",         null: false
     t.text     "description"


### PR DESCRIPTION
* `config.serve_static_assets` has been renamed to `config.serve_static_files`
  and former will be removed in rails 5
* propagate errors raised within `after_rollback`/`after_commit` callbacks.
  Read more at: http://edgeguides.rubyonrails.org/upgrading_ruby_on_rails.html#error-handling-in-transaction-callbacks
* SchemaDumper uses force: :cascade on create_table. This makes
it possible to reload a schema when foreign keys are in place.

First two solve deprecation warning on running test (Check [travis](https://travis-ci.org/openSUSE/osem/builds/108739947#L1659-L1660)).
I am pretty sure introduction of `limit` is due to update of `acitveuuid` (they don't maintain changelog :disappointed:)

Related: #759