### PR TITLE
Add more images to venue

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -127,6 +127,9 @@ gem 'bootstrap-switch-rails', '~> 3.0.0'
 
 gem 'ruby-oembed'
 
+# for zoom in images
+gem 'fancybox2-rails'
+
 # Use guard and spring for testing in development
 group :development do
   # rspec Guard rules

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -159,6 +159,8 @@ GEM
     factory_girl_rails (4.6.0)
       factory_girl (~> 4.5.0)
       railties (>= 3.0.0)
+    fancybox2-rails (0.2.8)
+      railties (>= 3.1.0, < 5.0)
     faraday (0.9.0)
       multipart-post (>= 1.2, < 3)
     ffi (1.9.3)
@@ -491,6 +493,7 @@ DEPENDENCIES
   devise
   devise_ichain_authenticatable
   factory_girl_rails
+  fancybox2-rails
   font-awesome-rails
   formtastic (~> 2.3.0.rc3)
   formtastic-bootstrap

--- a/app/assets/javascripts/application.js
+++ b/app/assets/javascripts/application.js
@@ -38,9 +38,14 @@
 //= require osem-switch
 //= require osem-bootstrap
 //= require osem-commercials
+//= require fancybox
 
 $(document).ready(function() {
     $('a[disabled=disabled]').click(function(event){
         return false;
     });
+});
+
+$(document).ready(function() {
+  $("a.fancybox").fancybox();
 });

--- a/app/assets/stylesheets/application.css
+++ b/app/assets/stylesheets/application.css
@@ -14,4 +14,5 @@
  *= require bootstrap-datetimepicker
  *= require leaflet
  *= require bootstrap3-switch
+ *= require fancybox
 */

--- a/app/assets/stylesheets/osem-splash.css.scss
+++ b/app/assets/stylesheets/osem-splash.css.scss
@@ -39,7 +39,7 @@
       }
     }
   }
-  
+
   #program {
     h3 {
       padding-left: 5px;
@@ -51,7 +51,7 @@
       background-color: #F0FFFF;
     }
   }
-  
+
   #callforpapers {
     .timer-box{
       width: 130px;
@@ -60,10 +60,9 @@
       border:4px solid #989797;
     }
   }
-  
+
   #venue {
     padding-top: 0px;
-    padding-bottom: 0px;
   }
 
   #lodging {
@@ -89,7 +88,7 @@
       }
     }
   }
-  
+
   #sponsors {
     .img-sponsor {
       max-height: 100px;
@@ -133,7 +132,7 @@
       }
     }
   }
-  
+
   .scroll-top-wrapper {
     position: fixed;
     opacity: 0;

--- a/app/controllers/admin/venue_photos_controller.rb
+++ b/app/controllers/admin/venue_photos_controller.rb
@@ -1,0 +1,15 @@
+module Admin
+  class VenuePhotosController < Admin::BaseController
+    load_and_authorize_resource :conference, find_by: :short_title
+    load_and_authorize_resource :venue, through: :conference, singleton: true
+
+    def destroy
+      photo = @venue.venue_photos.find(params[:id])
+      if photo.destroy
+        redirect_to  edit_admin_conference_venue_path(@conference.short_title), notice: 'Photo deleted'
+      else
+        redirect_to  edit_admin_conference_venue_path(@conference.short_title), alert: 'Photo not deleted'
+      end
+    end
+  end
+end

--- a/app/controllers/admin/venues_controller.rb
+++ b/app/controllers/admin/venues_controller.rb
@@ -15,6 +15,9 @@ module Admin
       @venue = @conference.build_venue(venue_params)
 
       if @venue.save
+        if params[:venue_photos]
+          create_additional_photos(@venue, params[:venue_photos])
+        end
         redirect_to admin_conference_venue_path,
                     notice: 'Venue was successfully created.'
       else
@@ -24,6 +27,9 @@ module Admin
 
     def update
       if @venue.update_attributes(venue_params)
+        if params[:venue_photos]
+          create_additional_photos(@venue, params[:venue_photos])
+        end
         redirect_to(admin_conference_venue_path(conference_id: @conference.short_title),
                     notice: 'Venue was successfully updated.')
       else
@@ -45,6 +51,12 @@ module Admin
 
     def venue_params
       params.require(:venue).permit(:name, :street, :postalcode, :city, :country, :longitude, :latitude, :description, :website, :photo, :lodgings_attributes, :conference_id)
+    end
+
+    def create_additional_photos(venue, photos)
+      photos.each { |photo|
+        venue.venue_photos.create(photo: photo )
+      }
     end
   end
 end

--- a/app/models/venue.rb
+++ b/app/models/venue.rb
@@ -1,6 +1,7 @@
 class Venue < ActiveRecord::Base
   belongs_to :conference
   has_many :rooms, dependent: :destroy
+  has_many :venue_photos, dependent: :destroy
   before_create :generate_guid
 
   validates :name, :street, :city, :country, presence: true

--- a/app/models/venue_photo.rb
+++ b/app/models/venue_photo.rb
@@ -1,0 +1,9 @@
+class VenuePhoto < ActiveRecord::Base
+  belongs_to :venue
+
+  has_attached_file :photo,
+                    styles: { thumb: '100x100>', large: '300x300>' }
+  validates_attachment_content_type :photo,
+                                    content_type: [/jpg/, /jpeg/, /png/, /gif/],
+                                    size: { in: 0..500.kilobytes }
+end

--- a/app/views/admin/venues/_form.html.haml
+++ b/app/views/admin/venues/_form.html.haml
@@ -11,4 +11,15 @@
       - unless @venue.photo.blank?
         = image_tag @venue.photo(:thumb)
       = f.input :photo
+      %label
+        Additional photos
+      - @venue.venue_photos.in_groups_of(4, false).each do |photo_group|
+        .row
+          - photo_group.each do |photo|
+            .col-md-3
+              = image_tag photo.photo(:thumb)
+              = link_to "Delete", admin_conference_venue_photo_path(@conference.short_title, photo), method: :delete, class: 'btn btn-default', data: { confirm: 'really delete this photo ?' }
+      %br
+      = file_field_tag "venue_photos[]", type: :file, multiple: true
+      %br
       = f.action :submit, as: :button, button_html: { class: 'btn btn-primary' }

--- a/app/views/conference/_venue.html.haml
+++ b/app/views/conference/_venue.html.haml
@@ -60,3 +60,8 @@
           - if @conference.venue.website
             %br
             =link_to @conference.venue.website, @conference.venue.website
+    - @conference.venue.venue_photos.in_groups_of(4, false).each do |photo_group|
+      .row
+        - photo_group.each do |photo|
+          .col-md-3
+            = link_to image_tag(photo.photo(:thumb), class: 'img-rounded'), photo.photo(:large), class: 'fancybox'

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -46,6 +46,7 @@ Osem::Application.routes.draw do
       resource :splashpage
       resource :venue do
         resources :rooms, except: [:show]
+        resources :venue_photos, only: [:destroy], as: :photos
       end
       resource :registration_period
       resource :program do

--- a/db/migrate/20160212231923_create_venue_photos.rb
+++ b/db/migrate/20160212231923_create_venue_photos.rb
@@ -1,0 +1,13 @@
+class CreateVenuePhotos < ActiveRecord::Migration
+  def change
+    create_table :venue_photos do |t|
+      t.integer :venue_id
+      t.string :photo_file_name
+      t.string :photo_content_type
+      t.integer :photo_file_size
+      t.datetime :photo_updated_at
+
+      t.timestamps null: false
+    end
+  end
+end


### PR DESCRIPTION
Add venue_photos model and venue_photos admin controller in order to add more images to Venues and allow to delete it from the venue form.

Show the additional photos in splashscreen. Added fancybox gem for zoom when click on the additional photo.

fix #777