### PR TITLE
If the conference has only one day, not put the day twice in splashpage

### DIFF
--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -71,6 +71,8 @@ class ApplicationController < ActionController::Base
   ##
   # Returns a string build from the start and end date of the given conference.
   #
+  # If the conference is only one day long
+  # * %B %d %Y (January 17 2014)
   # If the conference starts and ends in the same month and year
   # * %B %d - %d, %Y (January 17 - 21 2014)
   # If the conference ends in another month but in the same year
@@ -82,8 +84,13 @@ class ApplicationController < ActionController::Base
     endstr = 'Unknown'
     # When the conference  in the same month
     if start_date.month == end_date.month && start_date.year == end_date.year
-      startstr = start_date.strftime('%B %d - ')
-      endstr = end_date.strftime('%d, %Y')
+      if start_date.day == end_date.day
+        startstr = start_date.strftime('%B %d')
+        endstr = end_date.strftime(' %Y')
+      else
+        startstr = start_date.strftime('%B %d - ')
+        endstr = end_date.strftime('%d, %Y')
+      end
     elsif start_date.month != end_date.month && start_date.year == end_date.year
       startstr = start_date.strftime('%B %d - ')
       endstr = end_date.strftime('%B %d, %Y')


### PR DESCRIPTION
If the conference has only one day, not put the day twice in splashpage