### PR TITLE
Send notif only for build on canonical repo and enable build on all branches

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -5,9 +5,6 @@ rvm:
 before_install:
   - "echo 'gem: --no-ri --no-rdoc' > ~/.gemrc"
   - "echo `phantomjs -v`"
-branches:
-  only:
-    - master
 notifications:
   email:
     on_success: change
@@ -17,6 +14,8 @@ notifications:
       - "chat.freenode.net#osem"
     on_success: change
     on_failure: change
+  repos:
+    - openSUSE/osem
 before_script:
   - cp config/database.yml.example config/database.yml
   - cp config/config.yml.example config/config.yml


### PR DESCRIPTION
There is no point of sending notification for build on forks.
Also, a contributor would expect that travis builds all the branches. Usual workflow is that they create a new branch for the feature/fix they are working on.