### PR TITLE
Speed up test boot time

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -179,6 +179,8 @@ group :test do
   # Extracted from RSpec 3 stub_model and mock_model
   gem 'rspec-activemodel-mocks'
   gem 'timecop'
+  # Mock external requests
+  gem 'webmock'
 end
 
 group :development, :test do

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -130,6 +130,8 @@ GEM
       simplecov (>= 0.7)
       term-ansicolor
       thor
+    crack (0.4.2)
+      safe_yaml (~> 1.0.0)
     currencies (0.4.2)
     daemons (1.1.9)
     database_cleaner (1.3.0)
@@ -409,6 +411,7 @@ GEM
     ruby-openid (2.5.0)
     ruby-progressbar (1.7.5)
     rubyzip (1.0.0)
+    safe_yaml (1.0.4)
     sass (3.2.19)
     sass-rails (4.0.4)
       railties (>= 4.0.0, < 5.0)
@@ -464,6 +467,9 @@ GEM
       binding_of_caller (>= 0.7.2)
       railties (>= 4.0)
       sprockets-rails (>= 2.0, < 4.0)
+    webmock (1.20.4)
+      addressable (>= 2.3.6)
+      crack (>= 0.3.2)
     websocket-driver (0.3.3)
     whenever (0.9.2)
       activesupport (>= 2.3.4)
@@ -553,6 +559,7 @@ DEPENDENCIES
   turbolinks
   uglifier (>= 1.3.0)
   web-console (~> 2.0)
+  webmock
   whenever
 
 BUNDLED WITH

--- a/config/config.yml.example
+++ b/config/config.yml.example
@@ -15,6 +15,10 @@ defaults: &defaults
     ichain:
       enabled: false
 
+  # Set it to false if you don't want FactoryGirl lint to run before every test suit.
+  # You can run lint manually with: bundle exec rake factory_girl:lint
+  factory_girl_lint: true
+
 development:
   <<: *defaults
 

--- a/lib/tasks/factory_girl.rake
+++ b/lib/tasks/factory_girl.rake
@@ -1,0 +1,15 @@
+namespace :factory_girl do
+  desc "Verify that all FactoryGirl factories are valid"
+  task lint: :environment do
+    if Rails.env.test?
+      begin
+        DatabaseCleaner.start
+        FactoryGirl.lint
+      ensure
+        DatabaseCleaner.clean
+      end
+    else
+      system("bundle exec rake factory_girl:lint RAILS_ENV='test'")
+    end
+  end
+end

--- a/lib/tasks/factory_girl.rake
+++ b/lib/tasks/factory_girl.rake
@@ -1,9 +1,12 @@
+require_relative '../../spec/support/external_request'
+
 namespace :factory_girl do
   desc "Verify that all FactoryGirl factories are valid"
   task lint: :environment do
     if Rails.env.test?
       begin
         DatabaseCleaner.start
+        mock_commercial_request
         FactoryGirl.lint
       ensure
         DatabaseCleaner.clean

--- a/spec/support/external_request.rb
+++ b/spec/support/external_request.rb
@@ -1,0 +1,29 @@
+# Mock external requests to youtube
+require 'webmock/rspec'
+WebMock.disable_net_connect!(allow_localhost: true)
+
+RSpec.configure do |config|
+  config.before(:each) do
+    mock_commercial_request
+  end
+end
+
+def mock_commercial_request
+  response = {
+    author_name: 'Confreaks',
+    html: '<iframe width=\'560\' height=\'315\' src=\'https://www.youtube.com/embed/BTTygyxuGj8?feature=oembed\' frameborder=\'0\' allowfullscreen></iframe>',
+    thumbnail_width: 480,
+    thumbnail_url: 'https://i.ytimg.com/vi/BTTygyxuGj8/hqdefault.jpg',
+    provider_name: 'YouTube',
+    width: 459,
+    type: 'video',
+    provider_url: 'http://www.youtube.com/',
+    version: '1.0',
+    thumbnail_height: 360,
+    title: 'RailsConf 2014 - Closing Keynote by Aaron Patterson',
+    author_url: 'https://www.youtube.com/user/Confreaks',
+    height: 344
+  }
+  WebMock.stub_request(:get, /.*youtube.*/).
+    to_return(status: 200, body: response.to_json, headers: {})
+end

--- a/spec/support/factory_girl.rb
+++ b/spec/support/factory_girl.rb
@@ -1,0 +1,7 @@
+RSpec.configure do |config|
+
+  config.before(:suite) do
+    FactoryGirl.lint if CONFIG['factory_girl_lint']
+  end
+
+end

--- a/spec/support/factory_girl.rb
+++ b/spec/support/factory_girl.rb
@@ -1,7 +1,12 @@
+require_relative 'external_request'
+
 RSpec.configure do |config|
 
   config.before(:suite) do
-    FactoryGirl.lint if CONFIG['factory_girl_lint']
+    if CONFIG['factory_girl_lint']
+      mock_commercial_request
+      FactoryGirl.lint
+    end
   end
 
 end

--- a/spec/support/factory_girl.rb
+++ b/spec/support/factory_girl.rb
@@ -1,7 +1,0 @@
-RSpec.configure do |config|
-
-  config.before(:suite) do
-    FactoryGirl.lint
-  end
-
-end


### PR DESCRIPTION
This significantly improves start time of tests. It is also the recommended
way: https://github.com/thoughtbot/factory_girl/blob/master/GETTING_STARTED.md#linting-factories

Read more at: thoughtbot/factory_girl#772

lint was going out to internet to check for links validity. I got following error from lint when I was offline:
> The following factories are invalid: (FactoryGirl::InvalidFactoryError)
* event_commercial - Validation failed: Network is unreachable - connect(2) for "www.youtube.com" port 80 (ActiveRecord::RecordInvalid)


For me it brings down time of running `rspec  spec/controllers/conference_controller_spec.rb` form 30+ sec to 4.33 sec (without spring in both cases)

EDIT:
- [x]  Add the rake lint task
- [x] Make it possible to disable running FactoryGirl.lint 
- [x] Mock the external request