### PR TITLE
Removed d3_rails gem

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -85,7 +85,6 @@ end
 gem 'bootstrap3-datetimepicker-rails', '~> 3.0.2'
 gem 'jquery-datatables-rails', '~> 2.2.1'
 # for charts
-gem 'd3_rails'
 gem 'chart-js-rails'
 
 # for user avatars

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -131,8 +131,6 @@ GEM
       term-ansicolor
       thor
     currencies (0.4.2)
-    d3_rails (3.4.6)
-      railties (>= 3.1.0)
     daemons (1.1.9)
     database_cleaner (1.3.0)
     debug_inspector (0.0.2)
@@ -496,7 +494,6 @@ DEPENDENCIES
   cocoon
   country_select!
   coveralls
-  d3_rails
   daemons
   database_cleaner
   delayed_job_active_record

--- a/app/assets/javascripts/application.js
+++ b/app/assets/javascripts/application.js
@@ -18,7 +18,6 @@
 //= require cocoon
 //= require bootstrap
 //= require Chart
-//= require d3
 //= require osem
 //= require osem-dashboard
 //= require ahoy


### PR DESCRIPTION
#694
I have extensively checked the dependency of d3_rails gem in local machine and found that it, in fact, is not needed as mentioned in the associated issue.
