### PR TITLE
Add letter_opener_web

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -163,6 +163,8 @@ group :development do
   gem 'sqlite3'
   # Use letter_opener to open mails in development
   gem 'letter_opener'
+  # Use letter_opener_web to open mails in browser (e.g. necessary for Vagrant)
+  gem 'letter_opener_web'
   # mina is a blazing fast deployment system
   gem 'mina'
   gem 'web-console', '~> 2.0'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -211,6 +211,10 @@ GEM
       addressable (~> 2.3)
     letter_opener (1.2.0)
       launchy (~> 2.2)
+    letter_opener_web (1.3.0)
+      actionmailer (>= 3.2)
+      letter_opener (~> 1.0)
+      railties (>= 3.2)
     listen (2.7.2)
       celluloid (>= 0.15.2)
       celluloid-io (>= 0.15.0)
@@ -518,6 +522,7 @@ DEPENDENCIES
   jquery-datatables-rails (~> 2.2.1)
   jquery-rails
   letter_opener
+  letter_opener_web
   mina
   money-rails
   mysql2

--- a/INSTALL.md
+++ b/INSTALL.md
@@ -47,6 +47,11 @@ You can access the app [localhost:3000](http://localhost:3000). Whatever you cha
     vagrant ssh
     ```
 
+**Note**: We use [letter_opener](https://github.com/ryanb/letter_opener) in development environment.
+However, letter_opener uses launchy to present the emails in your browser which doesn't work in combination with Vagrant.
+Therefore we use [letter_open_web](https://github.com/fgrehm/letter_opener_web).
+You can check out your mails by visiting [localhost:3000/letter_opener](http://localhost:3000/letter_opener) if you use Vagrant.
+
 ### Run OSEM in production
 We recommend to run OSEM in production with [mod_passenger](https://www.phusionpassenger.com/download/#open_source)
 and the [apache web-server](https://www.apache.org/). There are tons of guides on how to deploy rails apps on various

--- a/config/environments/development.rb
+++ b/config/environments/development.rb
@@ -4,6 +4,9 @@ Osem::Application.configure do
   # Use letter_opener
   config.action_mailer.delivery_method = :letter_opener
 
+  # Use letter_opener_web for Vagrant (launchy won't work)
+  config.action_mailer.delivery_method = ENV['USER'] == 'vagrant' ? :letter_opener_web : :letter_opener
+
   # In the development environment your application's code is reloaded on
   # every request. This slows down response time but is perfect for development
   # since you don't have to restart the web server when you make code changes.

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -10,6 +10,11 @@ Osem::Application.routes.draw do
                path: 'accounts'
   end
 
+  # Use letter_opener_web to open mails in browser (e.g. necessary for Vagrant)
+  if Rails.env.development?
+    mount LetterOpenerWeb::Engine, at: "/letter_opener"
+  end
+
   resources :users, except: [:new, :index, :create, :destroy]
 
   namespace :admin do


### PR DESCRIPTION
to present emails in the browser in development mode.
Using letter_opener in combination with Vagrant does not work
because it's not possible to launch a web browser in your
Vagrant box. Fixes #817.