### PR TITLE
fixing ticket description editor #811

### DIFF
--- a/app/views/admin/tickets/_form.html.haml
+++ b/app/views/admin/tickets/_form.html.haml
@@ -10,7 +10,7 @@
   .col-md-8
     = semantic_form_for(@ticket, :url => (@ticket.new_record? ? admin_conference_tickets_path : admin_conference_ticket_path(@conference.short_title, @ticket))) do |f|
       = f.input :title
-      = f.input :description, input_html: { rows: 5, data: { provide: "markdown-editable" } }
+      = f.input :description, input_html: { rows: 5, data: { provide: "markdown" } }
       = f.input :price
       = f.input :price_currency, as: :select, class: 'form-control', collection: ['USD', 'EUR', 'GBP', 'INR', 'CNY'], include_blank: false
       %p.text-right

--- a/vendor/assets/javascripts/bootstrap-markdown.js
+++ b/vendor/assets/javascripts/bootstrap-markdown.js
@@ -143,8 +143,9 @@
       this.$textarea
         .on('focus',    $.proxy(this.focus, this))
         .on('keypress', $.proxy(this.keypress, this))
-        .on('keyup',    $.proxy(this.keyup, this))
-        .on('change',   $.proxy(this.change, this))
+        /* options muted to repair markdown editable issue */
+        //.on('keyup',    $.proxy(this.keyup, this))
+        //.on('change',   $.proxy(this.change, this))
 
       if (this.eventSupported('keydown')) {
         this.$textarea.on('keydown', $.proxy(this.keydown, this))


### PR DESCRIPTION
Muting Bootstrap Markdown Options in vendor script which make markdown editor header get stuck in a loop and gets populated repeatedly.
Ticket Description Working.
Issue #811