### PR TITLE
Add conference email to splashscreen

### DIFF
--- a/app/models/contact.rb
+++ b/app/models/contact.rb
@@ -9,7 +9,7 @@ class Contact < ActiveRecord::Base
             format: URI::regexp(%w(http https)), allow_blank: true
 
   def has_social_media?
-    return true if !facebook.blank? || !twitter.blank? || !googleplus.blank? || !instagram.blank?
+    return true if !facebook.blank? || !twitter.blank? || !googleplus.blank? || !instagram.blank? || !email.blank?
     false
   end
 end

--- a/app/views/conference/_social_media.html.haml
+++ b/app/views/conference/_social_media.html.haml
@@ -17,3 +17,6 @@
       - unless @conference.contact.googleplus.blank?
         = link_to "#{ @conference.contact.googleplus }" do
           %i.fa.fa-google-plus-square.fa-4x
+      - unless @conference.contact.email.blank?
+        = mail_to "#{ @conference.contact.email }" do
+          %i.fa.fa-envelope-o.fa-4x


### PR DESCRIPTION
Resolves #764 

Not displaying contact info on conference#index, only on conference#show just as @ChrisBr suggested on #764 as it'll look better.