### PR TITLE
Destroying tickets after user unregisters from a conference

### DIFF
--- a/app/controllers/conference_registrations_controller.rb
+++ b/app/controllers/conference_registrations_controller.rb
@@ -85,7 +85,7 @@ class ConferenceRegistrationsController < ApplicationController
   end
 
   def destroy
-    tickets_purchased = TicketPurchase.find_by(conference_id: @registration.conference_id)
+    tickets_purchased = TicketPurchase.where(conference_id: @registration.conference_id)
     if @registration.destroy
       if tickets_purchased
         tickets_purchased.destroy

--- a/app/controllers/conference_registrations_controller.rb
+++ b/app/controllers/conference_registrations_controller.rb
@@ -87,7 +87,9 @@ class ConferenceRegistrationsController < ApplicationController
   def destroy
     tickets_purchased = TicketPurchase.find_by(conference_id: @registration.conference_id)
     if @registration.destroy
-      tickets_purchased.destroy
+      if tickets_purchased
+        tickets_purchased.destroy
+      end
       redirect_to root_path,
                   notice: "You are not registered for #{@conference.title} anymore!"
     else

--- a/app/controllers/conference_registrations_controller.rb
+++ b/app/controllers/conference_registrations_controller.rb
@@ -87,7 +87,7 @@ class ConferenceRegistrationsController < ApplicationController
   def destroy
     tickets_purchased = TicketPurchase.find_by(conference_id: @registration.conference_id)
     if @registration.destroy
-      ticket_purchase.destroy
+      tickets_purchased.destroy
       redirect_to root_path,
                   notice: "You are not registered for #{@conference.title} anymore!"
     else

--- a/app/controllers/conference_registrations_controller.rb
+++ b/app/controllers/conference_registrations_controller.rb
@@ -85,7 +85,9 @@ class ConferenceRegistrationsController < ApplicationController
   end
 
   def destroy
+    tickets_purchased = TicketPurchase.find_by(conference_id: @registration.conference_id)
     if @registration.destroy
+      ticket_purchase.destroy
       redirect_to root_path,
                   notice: "You are not registered for #{@conference.title} anymore!"
     else

--- a/spec/controllers/admin/registration_periods_controller_spec.rb
+++ b/spec/controllers/admin/registration_periods_controller_spec.rb
@@ -145,6 +145,9 @@ describe Admin::RegistrationPeriodsController do
       it 'it deletes the registration period' do
         expect { delete :destroy, conference_id: conference.short_title }.to change(RegistrationPeriod, :count).by(-1)
       end
+      it 'it deletes the conference tickets' do
+        expect { delete :destroy, conference_id: conference.short_title }.to change(TicketPurchase, :count).by(-1)
+      end
       it 'redirects to users#show' do
         delete :destroy, conference_id: conference.short_title
         expect(response).to redirect_to admin_conference_registration_period_path


### PR DESCRIPTION
once a user unregisters from a conference, the tickets he purchased should be destroyed.
fixing #821 .