### PR TITLE
Fix overflow of proposal edit in admin area

### DIFF
--- a/app/views/proposal/_form.html.haml
+++ b/app/views/proposal/_form.html.haml
@@ -1,45 +1,42 @@
-.container
-  .row
-    .col-md-12
-      .tabbable
-        %ul.nav.nav-tabs
-          %li.active
-            = link_to 'Proposal', '#proposal-content', 'data-toggle' => 'tab'
-          %li
-            = link_to 'Commercials', '#commercials-content', 'data-toggle' => 'tab'
-        .tab-content
-          #proposal-content.tab-pane.active
-            = render 'proposal/proposal_form'
-          #commercials-content.tab-pane
-            %p.text-muted
-              You can add commercials for your proposal. These commercials will be displayed on the
-              = link_to 'public proposal page.', conference_program_proposal_path(@conference.short_title, @event)
-              If you don't add a commercial, the conference commercial will be displayed!
-            - if can? :create, @event.commercials.new
-              .row
-                .col-md-6
-                  #resource-content
-                  #resource-placeholder{ style: 'background-color:#d3d3d3; float: left; width: 400px; height: 250px; margin: 5px; border-width: 1px; border-style: solid; border-color: rgba(0,0,0,.2);' }
-              .row
-                .col-md-6
-                  = semantic_form_for(@event.commercials.build, url: conference_program_proposal_commercials_path(conference_id: @conference.short_title, proposal_id: @event)) do |f|
-                    = f.input :url, label: 'URL', as: :string, input_html: { required: 'required', type: 'url' },
-                    hint: 'Just paste the url of your video/photo provider. Currently supported: YouTube, Vimeo, SpeakerDeck, SlideShare, Instagram, Flickr.'
-                    = f.action :submit, as: :button, button_html: { class: 'btn btn-primary pull-right', disabled: true }
-              %hr
-            - @event.commercials.each_slice(3) do |slice|
-              .row
-                - slice.each do |commercial|
-                  - if commercial.persisted?
-                    .col-md-4
-                      .thumbnail
-                        .flexvideo{ id: "resource-content-#{commercial.id}"}
-                          = render partial: 'shared/media_item', locals: { commercial: commercial }
-                        .caption
-                          - if can? :update, commercial
-                            = semantic_form_for commercial, url: conference_program_proposal_commercial_path(conference_id: @conference.short_title, proposal_id: @event, id: commercial) do |f|
-                              = f.input :url, label: 'URL', as: :string, input_html: { id: "commercial_url_#{commercial.id}", required: 'required', type: 'url' }
-                              = f.action :submit, as: :button, button_html: { class: 'btn btn-success' }, label: 'Update'
-                              - if can? :destroy, commercial
-                                = link_to 'Delete', conference_program_proposal_commercial_path(@conference.short_title, @event.id, commercial.id),
-                                :method => :delete, :data => { :confirm => 'Are you sure?' }, class: 'btn btn-danger'
+.tabbable
+  %ul.nav.nav-tabs
+    %li.active
+      = link_to 'Proposal', '#proposal-content', 'data-toggle' => 'tab'
+    %li
+      = link_to 'Commercials', '#commercials-content', 'data-toggle' => 'tab'
+  .tab-content
+    #proposal-content.tab-pane.active
+      = render 'proposal/proposal_form'
+    #commercials-content.tab-pane
+      %p.text-muted
+        You can add commercials for your proposal. These commercials will be displayed on the
+        = link_to 'public proposal page.', conference_program_proposal_path(@conference.short_title, @event)
+        If you don't add a commercial, the conference commercial will be displayed!
+      - if can? :create, @event.commercials.new
+        .row
+          .col-md-6
+            #resource-content
+            #resource-placeholder{ style: 'background-color:#d3d3d3; float: left; width: 400px; height: 250px; margin: 5px; border-width: 1px; border-style: solid; border-color: rgba(0,0,0,.2);' }
+        .row
+          .col-md-6
+            = semantic_form_for(@event.commercials.build, url: conference_program_proposal_commercials_path(conference_id: @conference.short_title, proposal_id: @event)) do |f|
+              = f.input :url, label: 'URL', as: :string, input_html: { required: 'required', type: 'url' },
+              hint: 'Just paste the url of your video/photo provider. Currently supported: YouTube, Vimeo, SpeakerDeck, SlideShare, Instagram, Flickr.'
+              = f.action :submit, as: :button, button_html: { class: 'btn btn-primary pull-right', disabled: true }
+        %hr
+      - @event.commercials.each_slice(3) do |slice|
+        .row
+          - slice.each do |commercial|
+            - if commercial.persisted?
+              .col-md-4
+                .thumbnail
+                  .flexvideo{ id: "resource-content-#{commercial.id}"}
+                    = render partial: 'shared/media_item', locals: { commercial: commercial }
+                  .caption
+                    - if can? :update, commercial
+                      = semantic_form_for commercial, url: conference_program_proposal_commercial_path(conference_id: @conference.short_title, proposal_id: @event, id: commercial) do |f|
+                        = f.input :url, label: 'URL', as: :string, input_html: { id: "commercial_url_#{commercial.id}", required: 'required', type: 'url' }
+                        = f.action :submit, as: :button, button_html: { class: 'btn btn-success' }, label: 'Update'
+                        - if can? :destroy, commercial
+                          = link_to 'Delete', conference_program_proposal_commercial_path(@conference.short_title, @event.id, commercial.id),
+                          :method => :delete, :data => { :confirm => 'Are you sure?' }, class: 'btn btn-danger'

--- a/app/views/proposal/edit.html.haml
+++ b/app/views/proposal/edit.html.haml
@@ -1,1 +1,4 @@
-= render 'form'
+.container
+  .row
+    .col-md-12
+      = render 'form'


### PR DESCRIPTION
Edit of proposal in admin area is reusing partial `proposal/form`.
This PR changes:
![screenshot from 2016-03-10 17-40-21](https://cloud.githubusercontent.com/assets/7680662/13669257/4c1ac324-e6e8-11e5-87e0-ada2518674dd.png)

to:
![screenshot from 2016-03-10 17-47-46](https://cloud.githubusercontent.com/assets/7680662/13669265/56f54526-e6e8-11e5-81f4-da81fd2964bc.png)
