### PR TITLE
Name attribute in registration email not set

### DIFF
--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -53,6 +53,10 @@ class User < ActiveRecord::Base
             },
             presence: true
 
+  def name
+    self[:name] || username
+  end
+
   def subscribed? conference
     self.subscriptions.find_by(conference_id: conference.id).present?
   end

--- a/spec/models/user_spec.rb
+++ b/spec/models/user_spec.rb
@@ -33,6 +33,13 @@ describe User do
     expect(another_user.roles[1]).to eq(cfp_role)
   end
 
+  describe '#name' do
+    it 'returns the username as name if there is not name' do
+      user = create(:user, name: nil)
+      expect(user.name).to eq(user.username)
+    end
+  end
+
   describe '#has_role?' do
     describe 'when user has a role' do
       it 'returns true when the user has the role' do


### PR DESCRIPTION
Issues #818 and #577. Pull request #857.

I agree that it is better to override the #name attribute. I have read that `attr_accessor_with_default` is deprecated, so I think it is better not to use it. I have used `self[:name]` instead of `read_attribute(:name)` as it is preferred according to the [Rails Style Guide](https://github.com/bbatsov/rails-style-guide#read-attribute).
