### PR TITLE
Remove datatable functionality from Roles index table.

### DIFF
--- a/app/views/admin/roles/index.html.haml
+++ b/app/views/admin/roles/index.html.haml
@@ -7,7 +7,7 @@
       The available roles for the conference
 
   .col-md-12
-    %table.table.table-bordered.table-striped.table-hover.datatable#roles
+    %table.table.table-bordered.table-striped.table-hover#roles
       %thead
         %th ID
         %th Name


### PR DESCRIPTION
The table in roles#index view has no need of datatable features as the number of roles is just 4..

![roles_datatabe_without](https://cloud.githubusercontent.com/assets/7537349/13804185/e953b1a0-eb70-11e5-8ac3-7bcb336f27c4.png)
![roles_datatable_with](https://cloud.githubusercontent.com/assets/7537349/13804186/e9559614-eb70-11e5-9fee-6a0f5a5c49b7.png)