### PR TITLE
Update routes.rb

### DIFF
--- a/config/routes.rb
+++ b/config/routes.rb
@@ -27,7 +27,6 @@ Osem::Application.routes.draw do
       resource :schedule, only: [:show, :update]
       get 'commercials/render_commercial' => 'commercials#render_commercial'
       resources :commercials, only: [:index, :create, :update, :destroy]
-      get '/stats' => 'stats#index'
       get '/dietary_choices' => 'dietchoices#show', as: 'dietary_list'
       patch '/dietary_choices' => 'dietchoices#update', as: 'dietary_update'
       get '/volunteers_list' => 'volunteers#show'


### PR DESCRIPTION
removed index get '/stats' => 'stats#index' as it references to a non-existent statscontroller