### PR TITLE
Add test for conference registration controller show and destroy action

### DIFF
--- a/app/controllers/conference_registrations_controller.rb
+++ b/app/controllers/conference_registrations_controller.rb
@@ -90,8 +90,8 @@ class ConferenceRegistrationsController < ApplicationController
       redirect_to root_path,
                   notice: "You are not registered for #{@conference.title} anymore!"
     else
-      redirect_to root_path,
-                  error: "Could not update your registration for #{@conference.title}: "\
+      redirect_to conference_conference_registrations_path(@conference.short_title),
+                  error: "Could not delete your registration for #{@conference.title}: "\
                   "#{@registration.errors.full_messages.join('. ')}."
     end
   end

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -106,6 +106,7 @@ Osem::Application.routes.draw do
       end
     end
 
+    # TODO: change conference_registrations to singular resource
     resource :conference_registrations, path: 'register'
     resources :tickets, only: [:index]
     resources :ticket_purchases, only: [:create, :destroy]

--- a/spec/controllers/conference_registration_controller_spec.rb
+++ b/spec/controllers/conference_registration_controller_spec.rb
@@ -7,6 +7,54 @@ describe ConferenceRegistrationsController, type: :controller do
   context 'user is signed in' do
     before { sign_in(user) }
 
+    describe 'GET #show' do
+      before do
+        @registration = create(:registration, conference: conference, user: user)
+      end
+
+      context 'successful request' do
+        before do
+          get :show, conference_id: conference.short_title
+        end
+
+        it 'assigns conference, registration and workshops variables' do
+          expect(assigns(:conference)).to eq conference
+          expect(assigns(:registration)).to eq @registration
+          expect(assigns(:workshops)).to eq @registration.workshops
+        end
+
+        it 'renders the show template' do
+          expect(response).to render_template('show')
+        end
+      end
+
+      context 'user has purchased a ticket' do
+        before do
+          @ticket = create(:ticket, conference: conference)
+          @purchased_ticket = create(:ticket_purchase, conference: conference,
+                                                       user: user,
+                                                       ticket: @ticket)
+          get :show, conference_id: conference.short_title
+        end
+
+        it 'assigns price of purchased tickets to total_price and purchased tickets to tickets' do
+          expect(assigns(:total_price)).to eq Money.new(10000, 'USD')
+          expect(assigns(:tickets)).to match_array [@purchased_ticket]
+        end
+      end
+
+      context 'user has not purchased any ticket' do
+        before do
+          get :show, conference_id: conference.short_title
+        end
+
+        it 'assigns 0 dollars to total_price and empty array to tickets variables' do
+          expect(assigns(:total_price)).to eq Money.new(0, 'USD')
+          expect(assigns(:tickets)).to match_array []
+        end
+      end
+    end
+
     describe 'GET #edit' do
       before do
         @registration = create(:registration, conference: conference, user: user)
@@ -69,6 +117,51 @@ describe ConferenceRegistrationsController, type: :controller do
         it 'does not update the registration' do
           @registration.reload
           expect(@registration.arrival).to eq Date.new(2014, 04, 25)
+        end
+      end
+    end
+
+    describe 'DELETE #destroy' do
+      before do
+        @registration = create(:registration, conference: conference, user: user)
+      end
+
+      context 'deletes successfully' do
+        before(:each, run: true) do
+          delete :destroy, conference_id: conference.short_title
+        end
+
+        it 'redirects to root path', run: true do
+          expect(response).to redirect_to root_path
+        end
+
+        it 'shows success message in flash notice', run: true do
+          expect(flash[:notice]).to match('You are not registered for The dog and pony show anymore!')
+        end
+
+        it 'deletes the registration' do
+          expect do
+            delete :destroy, conference_id: conference.short_title
+          end.to change{ Registration.count }.from(1).to(0)
+        end
+      end
+
+      context 'delete fails' do
+        before do
+          allow_any_instance_of(Registration).to receive(:destroy).and_return(false)
+          delete :destroy, conference_id: conference.short_title
+        end
+
+        it 'redirects to registration show path' do
+          expect(response).to redirect_to conference_conference_registrations_path(conference.short_title)
+        end
+
+        it 'shows error in flash message' do
+          expect(flash[:error]).to match "Could not delete your registration for The dog and pony show: #{@registration.errors.full_messages.join('. ')}."
+        end
+
+        it 'does not delete the registration' do
+          expect(assigns(:registration)).to eq @registration
         end
       end
     end


### PR DESCRIPTION
After failed delete, user should be redirected to registration show and not
root.
A conference can have only one registration corresponding to each user, hence:
TODO (in a different PR):  change conference_registrations to singular resource