### PR TITLE
Mark Events without a room as unscheduled events

### DIFF
--- a/public/javascripts/schedule/schedule.js
+++ b/public/javascripts/schedule/schedule.js
@@ -89,7 +89,7 @@ var Schedule = {
             snapMode: "inner",
             zIndex: 2
         });
-        if (date == "none") {
+        if (date == "none" || vars["room_id"] == null) {
             $('#unscheduled').append(newEvent);
         } else {
             if (!scheduleDayEvents.hasOwnProperty(date)) {


### PR DESCRIPTION
Fixes #912 
Scheduling an event sets the start_time and room model attrs of that event record.
Room has_many events with dependent set to nullify.So on deleting a room, it'll nullify the room attr of associated events but start_time would still be set.
But in schedule page, events are marked as unscheduled events by checking if start_time is not null.
I've changed this to mark events as unscheduled events if they don't have a room.