### PR TITLE
Defined time constraints for Registration Period, Conference start/end date ,arrival/departure dates for attending conference

### DIFF
--- a/app/assets/javascripts/osem-datepickers.js
+++ b/app/assets/javascripts/osem-datepickers.js
@@ -1,3 +1,5 @@
+// get current_date
+var today = new Date().toISOString().slice(0, 10);
 $(function () {
   $("#registration-arrival-datepicker").datetimepicker({
       pickTime: true,
@@ -5,7 +7,10 @@ $(function () {
       minuteStepping: 15,
       sideBySide: true,
       format: "YYYY-MM-DD HH:mm",
-      defaultDate :   $("#registration-arrival-datepicker").attr('start_date')
+      // current_date <= arrival_date <= end_date
+      maxDate : $("#registration-arrival-datepicker").attr('end_date'),
+      minDate : today,
+      defaultDate :   $("#registration-arrival-datepicker").attr('start_date'),
   });
   $("#registration-departure-datepicker").datetimepicker({
       pickTime: true,
@@ -13,14 +18,27 @@ $(function () {
       minuteStepping: 15,
       sideBySide: true,
       format: "YYYY-MM-DD HH:mm",
-      defaultDate :   $("#registration-arrival-datepicker").attr('end_date')
+      // departure_date > start_date
+      minDate : $("#registration-arrival-datepicker").attr('start_date'),
+      defaultDate :   $("#registration-arrival-datepicker").attr('end_date'),
   });
 
   $("#registration-arrival-datepicker").on("dp.change",function (e) {
-      console.log (e.date)
-      $('#registration-departure-datepicker').data("DateTimePicker").setDate(e.date);
-      $('#registration-departure-datepicker').data("DateTimePicker").setMinDate(e.date);
+    //   $('#registration-departure-datepicker').data("DateTimePicker").setDate(e.date);
+    // console.log(new Date(e.date).getTime() ,new Date($("#registration-arrival-datepicker").attr('start_date')).getTime())
+
+    // departure_date > start_date,arrival_date
+    if ((new Date(e.date).getTime()) > (new Date($("#registration-arrival-datepicker").attr('start_date')).getTime())){
+            // console.log (e.date, "arrival")
+          $('#registration-departure-datepicker').data("DateTimePicker").setMinDate(e.date);
+    }
+    else{
+        //   console.log ($("#registration-arrival-datepicker").attr('start_date'),"start_date")
+        $('#registration-departure-datepicker').data("DateTimePicker").setMinDate($("#registration-arrival-datepicker").attr('start_date'));
+    }
+
   });
+  
   $("#conference-end-datepicker").on("dp.change",function (e) {
       $('#registration-arrival-datepicker').data("DateTimePicker").setMaxDate(e.date);
   });

--- a/app/assets/javascripts/osem-datepickers.js
+++ b/app/assets/javascripts/osem-datepickers.js
@@ -24,16 +24,13 @@ $(function () {
   });
 
   $("#registration-arrival-datepicker").on("dp.change",function (e) {
-    //   $('#registration-departure-datepicker').data("DateTimePicker").setDate(e.date);
-    // console.log(new Date(e.date).getTime() ,new Date($("#registration-arrival-datepicker").attr('start_date')).getTime())
-
     // departure_date > start_date,arrival_date
     if ((new Date(e.date).getTime()) > (new Date($("#registration-arrival-datepicker").attr('start_date')).getTime())){
-            // console.log (e.date, "arrival")
+            console.log (e.date, "arrival")
           $('#registration-departure-datepicker').data("DateTimePicker").setMinDate(e.date);
     }
     else{
-        //   console.log ($("#registration-arrival-datepicker").attr('start_date'),"start_date")
+          console.log ($("#registration-arrival-datepicker").attr('start_date'),"start_date")
         $('#registration-departure-datepicker').data("DateTimePicker").setMinDate($("#registration-arrival-datepicker").attr('start_date'));
     }
 
@@ -41,9 +38,7 @@ $(function () {
   
   // departure_date >= arrival_date
    $("#registration-departure-datepicker").on("dp.change",function (e) {
-
        $('#registration-arrival-datepicker').data("DateTimePicker").setMaxDate(e.date);
-
    });
   
   $("#conference-start-datepicker").datetimepicker({
@@ -68,7 +63,6 @@ $(function () {
       format: "YYYY-MM-DD",
       minDate : today,
       maxDate : $("#registration-period-start-datepicker").attr('end_date'),
-    //   defaultDate : today,
   });
   
   $("#registration-period-end-datepicker").datetimepicker({
@@ -77,7 +71,6 @@ $(function () {
       format: "YYYY-MM-DD",
       minDate: today,
       maxDate : $("#registration-period-start-datepicker").attr('end_date'),
-    //   defaultDate : $("#registration-period-start-datepicker").attr('end_date'),
   });
 
   //   end_date_conference >= registration-period-Start_date >= Current_date
@@ -101,7 +94,6 @@ $(function () {
 
   $("#conference-start-datepicker").on("dp.change",function (e) {
       console.log (e.date)
-    //   $('#conference-end-datepicker').data("DateTimePicker").setDate(e.date);
       $('#conference-end-datepicker').data("DateTimePicker").setMinDate(e.date);
   });
   $("#conference-end-datepicker").on("dp.change",function (e) {
@@ -110,7 +102,6 @@ $(function () {
 
   $("#registration-period-start-datepicker").on("dp.change",function (e) {
       console.log (e.date)
-    //   $('#registration-period-end-datepicker').data("DateTimePicker").setDate(e.date);
       $('#registration-period-end-datepicker').data("DateTimePicker").setMinDate(e.date);
   });
   $("#registration-period-end-datepicker").on("dp.change",function (e) {

--- a/app/assets/javascripts/osem-datepickers.js
+++ b/app/assets/javascripts/osem-datepickers.js
@@ -1,10 +1,19 @@
 $(function () {
-  $("#registration-arrival-datepicker, #registration-departure-datepicker").datetimepicker({
+  $("#registration-arrival-datepicker").datetimepicker({
       pickTime: true,
       useCurrent: false,
       minuteStepping: 15,
       sideBySide: true,
-      format: "YYYY-MM-DD HH:mm"
+      format: "YYYY-MM-DD HH:mm",
+      defaultDate :   $("#registration-arrival-datepicker").attr('start_date')
+  });
+  $("#registration-departure-datepicker").datetimepicker({
+      pickTime: true,
+      useCurrent: false,
+      minuteStepping: 15,
+      sideBySide: true,
+      format: "YYYY-MM-DD HH:mm",
+      defaultDate :   $("#registration-arrival-datepicker").attr('end_date')
   });
 
   $("#registration-arrival-datepicker").on("dp.change",function (e) {

--- a/app/assets/javascripts/osem-datepickers.js
+++ b/app/assets/javascripts/osem-datepickers.js
@@ -68,7 +68,7 @@ $(function () {
       format: "YYYY-MM-DD",
       minDate : today,
       maxDate : $("#registration-period-start-datepicker").attr('end_date'),
-      defaultDate : today,
+    //   defaultDate : today,
   });
   
   $("#registration-period-end-datepicker").datetimepicker({
@@ -77,7 +77,7 @@ $(function () {
       format: "YYYY-MM-DD",
       minDate: today,
       maxDate : $("#registration-period-start-datepicker").attr('end_date'),
-      defaultDate : $("#registration-period-start-datepicker").attr('end_date'),
+    //   defaultDate : $("#registration-period-start-datepicker").attr('end_date'),
   });
 
   //   end_date_conference >= registration-period-Start_date >= Current_date

--- a/app/assets/javascripts/osem-datepickers.js
+++ b/app/assets/javascripts/osem-datepickers.js
@@ -39,17 +39,45 @@ $(function () {
 
   });
   
-  $("#conference-end-datepicker").on("dp.change",function (e) {
-      $('#registration-arrival-datepicker').data("DateTimePicker").setMaxDate(e.date);
-  });
+  // departure_date >= arrival_date
+   $("#registration-departure-datepicker").on("dp.change",function (e) {
 
+       $('#registration-arrival-datepicker').data("DateTimePicker").setMaxDate(e.date);
 
-  const $datetimepickers = $("#conference-start-datepicker, #conference-end-datepicker");
-
-  $datetimepickers.datetimepicker({
+   });
+  
+  $("#conference-start-datepicker").datetimepicker({
       pickTime: false,
       useCurrent: false,
-      format: "YYYY-MM-DD"
+      format: "YYYY-MM-DD",
+      // conference-start-day >= Current_date
+      minDate : today ,
+  });
+  
+  $("#conference-end-datepicker").datetimepicker({
+      pickTime: false,
+      useCurrent: false,
+      format: "YYYY-MM-DD",
+  });
+
+  //   end_date_conference >= registration-period-Start_date >= Current_date
+  //   registration-period-Start_date <= registration-period-End_date <= End_date (of conference)
+  $("#registration-period-start-datepicker").datetimepicker({
+      pickTime: false,
+      useCurrent: false,
+      format: "YYYY-MM-DD",
+      minDate : today,
+      maxDate : $("#registration-period-start-datepicker").attr('end_date'),
+      defaultDate : today,
+  });
+  
+  $("#registration-period-end-datepicker").datetimepicker({
+      pickTime: false,
+      useCurrent: false,
+      format: "YYYY-MM-DD",
+      minDate: today,
+      maxDate : $("#registration-period-start-datepicker").attr('end_date'),
+      defaultDate : $("#registration-period-start-datepicker").attr('end_date'),
   });
 
   //   end_date_conference >= registration-period-Start_date >= Current_date
@@ -73,7 +101,7 @@ $(function () {
 
   $("#conference-start-datepicker").on("dp.change",function (e) {
       console.log (e.date)
-      $('#conference-end-datepicker').data("DateTimePicker").setDate(e.date);
+    //   $('#conference-end-datepicker').data("DateTimePicker").setDate(e.date);
       $('#conference-end-datepicker').data("DateTimePicker").setMinDate(e.date);
   });
   $("#conference-end-datepicker").on("dp.change",function (e) {

--- a/app/assets/javascripts/osem-datepickers.js
+++ b/app/assets/javascripts/osem-datepickers.js
@@ -44,13 +44,32 @@ $(function () {
   });
 
 
-  const $datetimepickers = $("#conference-start-datepicker, #conference-end-datepicker, #registration-period-start-datepicker, #registration-period-end-datepicker");
+  const $datetimepickers = $("#conference-start-datepicker, #conference-end-datepicker");
 
   $datetimepickers.datetimepicker({
       pickTime: false,
       useCurrent: false,
       format: "YYYY-MM-DD"
   });
+
+  //   end_date_conference >= registration-period-Start_date >= Current_date
+  //   registration-period-Start_date <= registration-period-End_date <= End_date (of conference)
+  $("#registration-period-start-datepicker").datetimepicker({
+      pickTime: false,
+      useCurrent: false,
+      format: "YYYY-MM-DD",
+      minDate : today,
+      maxDate : $("#registration-period-start-datepicker").attr('end_date'),
+  });
+  
+  $("#registration-period-end-datepicker").datetimepicker({
+      pickTime: false,
+      useCurrent: false,
+      format: "YYYY-MM-DD",
+      minDate: today,
+      maxDate : $("#registration-period-start-datepicker").attr('end_date'),
+  });
+
 
   $("#conference-start-datepicker").on("dp.change",function (e) {
       console.log (e.date)
@@ -63,7 +82,7 @@ $(function () {
 
   $("#registration-period-start-datepicker").on("dp.change",function (e) {
       console.log (e.date)
-      $('#registration-period-end-datepicker').data("DateTimePicker").setDate(e.date);
+    //   $('#registration-period-end-datepicker').data("DateTimePicker").setDate(e.date);
       $('#registration-period-end-datepicker').data("DateTimePicker").setMinDate(e.date);
   });
   $("#registration-period-end-datepicker").on("dp.change",function (e) {

--- a/app/views/admin/registration_periods/_form.html.haml
+++ b/app/views/admin/registration_periods/_form.html.haml
@@ -5,7 +5,7 @@
 .row
   .col-md-8
     = semantic_form_for(@registration_period, url: admin_conference_registration_period_path(@conference.short_title)) do |f|
-      = f.input :start_date, as: :string, input_html: { id: 'registration-period-start-datepicker', readonly: 'readonly'  }
+      = f.input :start_date, as: :string, input_html: { id: 'registration-period-start-datepicker',start_date: @conference.start_date,end_date: @conference.end_date, readonly: 'readonly'  }
       = f.input :end_date, as: :string, input_html: { id: 'registration-period-end-datepicker', readonly: 'readonly'  }
       %p.text-right
         = f.submit 'Save Registration Period', class: 'btn btn-primary'

--- a/app/views/conference_registrations/_registration_info.html.haml
+++ b/app/views/conference_registrations/_registration_info.html.haml
@@ -4,5 +4,5 @@
   =f.inputs 'Pre-registration required for the following:' do
     = f.input :events, as: :check_boxes, label: false, collection: @conference.program.events.workshops
 = f.inputs 'Your Travel Info' do
-  = f.input :arrival, as: :string, label: 'Your arrival time', input_html: { value: (f.object.arrival.to_formatted_s(:db_without_seconds) unless f.object.arrival.nil?), id: 'registration-arrival-datepicker', readonly: 'readonly'  }
+  = f.input :arrival, as: :string, label: 'Your arrival time', input_html: { value: (f.object.arrival.to_formatted_s(:db_without_seconds) unless f.object.arrival.nil?), id: 'registration-arrival-datepicker',start_date: @conference.start_date,end_date: @conference.end_date, readonly: 'readonly'  }
   = f.input :departure, as: :string, label: 'Your departure time', input_html: { value: (f.object.departure.to_formatted_s(:db_without_seconds) unless f.object.departure.nil?), id: 'registration-departure-datepicker', readonly: 'readonly'  }


### PR DESCRIPTION
*Defined [Arrival/Departure constraints for attendees #911](https://github.com/openSUSE/osem/issues/911)
 `End_date_conference> registration-arrival-date > current_date`
 `Registration-departure-date > max(start-date-conference,registration-arrival-date)`
along with prefilled dates referenced to date of conference. 

*#910 
   Constraints for Registration Period parameters  -

    end-date-conference >= registration-period-start-date >= Current_date

    registration-period-Start-date <= registration-period-End-date <= End-date-conference

Which means , admin is only allowed to set registration period in between current date and end_date of conference

*#909
Only allow creating a new Conference ,while - 
         `conference-start-day >= Current_date`
         `conference-end-day >= conference-start-day `
