### PR TITLE
Fix reference to non-existant route path in commercials_controller

### DIFF
--- a/app/controllers/commercials_controller.rb
+++ b/app/controllers/commercials_controller.rb
@@ -11,7 +11,7 @@ class CommercialsController < ApplicationController
       redirect_to edit_conference_program_proposal_path(conference_id: @conference.short_title, id: @event.id, anchor: 'commercials-content'),
                   notice: 'Commercial was successfully created.'
     else
-      redirect_to edit_conference_proposal_path(conference_id: @conference.short_title, id: @event.id, anchor: 'commercials-content'),
+      redirect_to edit_conference_program_proposal_path(conference_id: @conference.short_title, id: @event.id, anchor: 'commercials-content'),
                   error: "An error prohibited this Commercial from being saved: #{@commercial.errors.full_messages.join('. ')}."
     end
   end
@@ -21,7 +21,7 @@ class CommercialsController < ApplicationController
       redirect_to edit_conference_program_proposal_path(conference_id: @conference.short_title, id: @event.id, anchor: 'commercials-content'),
                   notice: 'Commercial was successfully updated.'
     else
-      redirect_to edit_conference_proposal_path(conference_id: @conference.short_title, id: @event.id, anchor: 'commercials-content'),
+      redirect_to edit_conference_program_proposal_path(conference_id: @conference.short_title, id: @event.id, anchor: 'commercials-content'),
                   error: "An error prohibited this Commercial from being saved: #{@commercial.errors.full_messages.join('. ')}."
     end
   end

--- a/spec/features/commercials_spec.rb
+++ b/spec/features/commercials_spec.rb
@@ -71,6 +71,20 @@ feature Commercial do
       expect(event.commercials.count).to eq(@expected_count)
     end
 
+    scenario 'does not add an invalid commercial of an event', feature: true, js: true do
+      visit edit_conference_program_proposal_path(conference.short_title, event.id)
+      click_link 'Commercials'
+      fill_in 'commercial_url', with: 'invalid_commercial_url'
+
+      # Workaround to enable the 'Create Commercial' button
+      page.execute_script("$('#commercial_submit_action').prop('disabled', false)")
+
+      click_button 'Create Commercial'
+      expect(flash).to include('An error prohibited this Commercial from being saved:')
+      expect(current_path).to eq edit_conference_program_proposal_path(conference.short_title, event.id)
+      expect(event.commercials.count).to eq 0
+    end
+
     scenario 'updates a commercial of an event', feature: true, js: true do
       commercial = create(:commercial,
                           commercialable_id: event.id,
@@ -83,6 +97,20 @@ feature Commercial do
       expect(event.commercials.count).to eq(@expected_count)
       commercial.reload
       expect(commercial.url).to eq('https://www.youtube.com/watch?v=M9bq_alk-sw')
+    end
+
+    scenario 'does not update a commercial of an event with invalid data', feature: true, js: true do
+      commercial = create(:commercial,
+                          commercialable_id: event.id,
+                          commercialable_type: 'Event')
+      visit edit_conference_program_proposal_path(conference.short_title, event.id)
+      click_link 'Commercials'
+      fill_in "commercial_url_#{commercial.id}", with: 'invalid_commercial_url'
+      click_button 'Update'
+      expect(flash).to include('An error prohibited this Commercial from being saved:')
+      expect(current_path).to eq edit_conference_program_proposal_path(conference.short_title, event.id)
+      commercial.reload
+      expect(commercial.url).to eq('https://www.youtube.com/watch?v=BTTygyxuGj8')
     end
 
     scenario 'deletes a commercial of an event', feature: true, js: true do


### PR DESCRIPTION
The route edit_conference_proposal_path was removed in [this commit](https://github.com/openSUSE/osem/commit/444356fb)