### PR TITLE
Running rubocop first would give faster CI response for style offense

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -20,5 +20,5 @@ before_script:
   - cp config/secrets.yml.example config/secrets.yml
   - RAILS_ENV=test bundle exec rake db:migrate --trace
 script:
-  - 'bundle exec rspec --color --format documentation'
   - 'bundle exec rubocop -Dc .rubocop.yml'
+  - 'bundle exec rspec --color --format documentation'


### PR DESCRIPTION
Chekout:
https://travis-ci.org/openSUSE/osem/builds/118816901
https://travis-ci.org/openSUSE/osem/builds/117943633
https://travis-ci.org/openSUSE/osem/builds/116962415
https://travis-ci.org/openSUSE/osem/builds/116489044

Time is scarce :clock12: We shouldn't have to wait 8 minutes for style offense fail.