### PR TITLE
Update for security warning on hakiri

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -467,9 +467,8 @@ GEM
       coffee-rails
     tzinfo (1.2.2)
       thread_safe (~> 0.1)
-    uglifier (2.5.0)
-      execjs (>= 0.3.0)
-      json (>= 1.8.0)
+    uglifier (3.0.0)
+      execjs (>= 0.3.0, < 3)
     unicode-display_width (0.3.1)
     unicode_utils (1.4.0)
     unobtrusive_flash (3.1.0)


### PR DESCRIPTION
The upstream library for the Ruby uglifier gem, UglifyJS, is
affected by a vulnerability that allows a specially crafted
Javascript file to have altered functionality after minification.
See on Hakiri: https://hakiri.io/github/openSUSE/osem/master/e0ec57b0dcf080bdb9e9b254f2362c52c7657b07/warnings?name=Code+Injection

NOTE: Uglifier 3 dropped support of ruby 1.8 [Changelog](https://github.com/lautis/uglifier/blob/master/CHANGELOG.md)