### PR TITLE
Documentation of use of ichain and smtp settings

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -10,21 +10,20 @@ In particular, this community seeks the following types of contributions:
 # How to contribute
 * Prerequisites: familiarity with [GitHub Pull Requests](https://help.github.com/articles/using-pull-requests) and issues.
 * Fork the repository and make a pull-request with your changes
-  * Make sure that the test suite passes (we have [travis](https://travis-ci.org/openSUSE/osem) enabled) before you request a pull and that you comply to our ruby styleguide (we make use of [hound-ci](https://houndci.com/)).
-  * Please make sure to mind what travis tell you! :-)
+  * Make sure that the test suite passes (we have [travis](https://travis-ci.org/openSUSE/osem) enabled) before you request a pull and that you comply to our ruby styleguide.
+  * Please make sure to mind what travis tells you! :-)
   * Please increase code coverage by your pull request (coveralls or simplecov locally will give you insight)
 
 * One of the OSEM maintainers will review your pull-request
-  * If you are already a contributor (means you're in the [group osem-committers](https://github.com/orgs/openSUSE/teams/osem-committers)) and you get a positive review, you can merge your pull-request yourself
+  * If you are already a contributor and you get a positive review, you can merge your pull-request yourself
   * If you are not a contributor already please request a merge via the pull-request comments
-* Run rubocop locally for fixes according to HoundCI comments
-  * https://github.com/openSUSE/osem/wiki/Houndci-and-rubocop
+* Run rubocop locally to check for any ruby style offenses
+  * `bundle exec rubocop`
 
 # Conduct
 OSEM is part of the openSUSE project. We follow all the [openSUSE Guiding
 Principles!](http://en.opensuse.org/openSUSE:Guiding_principles) If you think
-someone doesn't do that, please let any of the [OSEM
-admins](https://github.com/orgs/openSUSE/teams/osem-admins) know!
+someone doesn't do that, please let us know at opensuse-web@opensuse.org.
 
 # Communication
 GitHub issues are the primary way for communicating about specific proposed

--- a/INSTALL.md
+++ b/INSTALL.md
@@ -86,6 +86,15 @@ the image-link to login using the provider will be shown.
 
 
 #### Email Notifications
+Check your service provider smtp settings and set the following variables in `config.yml` file:
+```
+mail_address: 'smtp.host.com'
+mail_port: 587
+mail_username: 'username@host.com'
+mail_password: 'password'
+mail_authentication: 'plain'
+```
+
 Open a separate terminal and go into the directory where the rails app is present, and type the following to start the delayed_jobs worker for sending email notifications.
 ```
 rake jobs:work

--- a/INSTALL.md
+++ b/INSTALL.md
@@ -90,3 +90,17 @@ Open a separate terminal and go into the directory where the rails app is presen
 ```
 rake jobs:work
 ```
+### Using iChain in test mode
+[devise_ichain_authenticatable](https://github.com/openSUSE/devise_ichain_authenticatable) comes with
+test mode, which can be useful in development phase in which an iChain proxy is not usually configured or even available. You can enable ichain authentication by setting `CONFIG['authentication']['ichain']['enabled']` equal to `true` in `config.yml` file. You would also need to set following options in `devise.rb`:
+
+```Ruby
+# Activate the test mode
+config.ichain_test_mode = true
+
+# 'testuser' user will be permanently signed in.
+config.ichain_force_test_username = "testuser"
+
+# set email of 'testuser'
+config.ichain_force_test_attributes = {:email => "testuser@example.com"}
+```

--- a/README.md
+++ b/README.md
@@ -8,7 +8,7 @@ The Open Source Event Manager. An event management tool tailored to Free and Ope
 
 ## Installation and production usage
 
-please refer to [INSTALL](INSTALL.md) documentation file
+Please refer to [INSTALL](INSTALL.md) documentation file
 
 ## Development discipline
 
@@ -23,16 +23,16 @@ as fast as we can. There are some things which we embrace
 * we do planning of next sprint tasks. It is a commitment. We will do our best to deliver what we agreed on
 * we use [waffle.io](https://waffle.io/opensuse/osem) to track current GH issues/pull requests
 * what is planned for current sprint is observable in `ready` column (each issue marked with label with same name)
-* what is delivered is in done columnt
+* what is delivered is in done column
 * what is in progress lives in respecitive column
-* each person assigned in ready column to an issue is acting on his task
+* each person assigned in ready column to an issue is acting on their task
 
 # Issues
 
-please refer to our [CONTRIBUTING guide](CONTRIBUTING.md)
+Please refer to our [CONTRIBUTING guide](CONTRIBUTING.md)
 
 ## Documentation
-OSEM is extensively (some would say maniacally ;-) documented. You can generate a nice HTML documentation with ''rdoc''
+OSEM is extensively (some would say maniacally ;-) ) documented. You can generate a nice HTML documentation with ''rdoc''
 ```
 bundle exec rdoc --op doc/app --all -f fivefish app
 xdg-open doc/app/index.html
@@ -46,9 +46,7 @@ bundle exec guard
 This uses [spring](https://github.com/rails/spring) to provide a
 [fast feedback loop for the red/green cycle](http://bitzesty.com/blog/2013/05/enable-tdd-with-faster-ruby-on-rails-stack-reloading/).
 
-Generally, no PR with decreased test coverage should be accepted. Please look closely on comments which been provided
-by Coveralls in your PR.
-
+Generally, no PR with decreased test coverage should be accepted. Please look closely on status report provided by Coveralls in your PR.
 
 ## Style
 We are using [rubocop](https://github.com/bbatsov/rubocop) as a style checker. It is running each time

--- a/config/config.yml.example
+++ b/config/config.yml.example
@@ -31,3 +31,11 @@ production:
   # If you add more providers that do not require a key, you still have to create the 2 variables with sample data
 
   transifex_live_api_key: ''
+
+  # Set the smtp configuration of your service provider
+  # For further details of each configuration checkout: http://guides.rubyonrails.org/action_mailer_basics.html#action-mailer-configuration
+  mail_address: 'smtp.host.com'
+  mail_port: 587
+  mail_username: 'username@host.com'
+  mail_password: 'password'
+  mail_authentication: 'plain'

--- a/config/environments/production.rb
+++ b/config/environments/production.rb
@@ -68,4 +68,14 @@ Osem::Application.configure do
 
   # Set the detault url for action mailer
   config.action_mailer.default_url_options = { host: CONFIG['url_for_emails'] }
+
+  # Set the smtp configuration of your service provider
+  # For further details of each configuration checkout: http://guides.rubyonrails.org/action_mailer_basics.html#action-mailer-configuration
+  config.action_mailer.smtp_settings = {
+    address:              CONFIG['MAIL_ADDRESS'],
+    port:                 CONFIG['MAIL_PORT'],
+    user_name:            CONFIG['MAIL_USERNAME'],
+    password:             CONFIG['MAIL_PASSWORD'],
+    authentication:       CONFIG['MAIL_AUTHENTICATION']
+  }
 end


### PR DESCRIPTION
* Remove houndp-ci because we are not using it anymore.
* Remove private links. Ex: [OSEM-admins](https://github.com/orgs/openSUSE/teams/osem-admins)
is accessible only to members ot osem-admins team.
* Add documentation of use of ichain in test mode
* Add configuration and documentation of smtp settings