### PR TITLE
Add devise confirmation controller test

### DIFF
--- a/spec/controllers/confirmations_controller_spec.rb
+++ b/spec/controllers/confirmations_controller_spec.rb
@@ -1,0 +1,28 @@
+require 'spec_helper'
+
+describe ConfirmationsController do
+  let(:user) { create(:user, confirmed_at: nil) }
+
+  before do
+    @request.env['devise.mapping'] = Devise.mappings[:user]
+  end
+
+  context 'user is not signed in' do
+    it 'confirms and signs in user' do
+      get :show, confirmation_token: user.confirmation_token
+      user.reload
+      expect(user.confirmed?).to eq true
+      expect(controller.current_user).to eq user
+    end
+  end
+
+  context 'user is signed in' do
+    before { sign_in user }
+
+    it 'confirms user' do
+      get :show, confirmation_token: user.confirmation_token
+      user.reload
+      expect(user.confirmed?).to eq true
+    end
+  end
+end


### PR DESCRIPTION
It would be awesome if we could test path here but response after confirmation is not redirect[1] but 200. If anyone knows how to test response `path` here, please let me know. 


[1] `expect(response).to redirect_to path` won't work