### PR TITLE
Fix proposal#update so that it shows errors when trying to create user

### DIFF
--- a/app/controllers/proposal_controller.rb
+++ b/app/controllers/proposal_controller.rb
@@ -29,6 +29,8 @@ class ProposalController < ApplicationController
 
   def create
     @url = conference_program_proposal_index_path(@conference.short_title)
+    @event = Event.new(event_params)
+    @event.program = @program
 
     # We allow proposal submission and sign up on same page.
     # If user is not signed in then first create new user and then sign them in
@@ -43,11 +45,6 @@ class ProposalController < ApplicationController
         return
       end
     end
-
-    params[:event].delete :user
-
-    @event = Event.new(event_params)
-    @event.program = @program
 
     # User which creates the proposal is both `submitter` and `speaker` of proposal
     # by default.


### PR DESCRIPTION
Creating a propsal without a user, when the user details are not correct, raises an error and does not render 'new' action with @user.errors