### PR TITLE
Make proposal show view more robust

### DIFF
--- a/app/views/proposal/show.html.haml
+++ b/app/views/proposal/show.html.haml
@@ -58,7 +58,7 @@
           .col-md-12
             %dt Room:
             %dd
-              - if @event.room_id
+              - if @event.room
                 = @event.room.name
           .col-md-12
             %dt Conference:
@@ -69,13 +69,13 @@
           .col-md-12
             %dt Track:
             %dd
-              - if @event.track_id
+              - if @event.track
                 %span.label{:style =>"background-color: #{@event.track.color};"}
                   = @event.track.name
           .col-md-12
             %dt Difficulty:
             %dd
-              - if @event.difficulty_level_id
+              - if @event.difficulty_level
                 %span.label{:style =>"background-color: #{@event.difficulty_level.color};"}
                   = @event.difficulty_level.title
 


### PR DESCRIPTION
Partially fixes #718. Some objects have an foreign_key set on track, difficulty level or room but the
referenced object does not exists. This is caused by introducing dependent: nullify after deleting
some of the objects. This commit will make the show page more robust, however, we need to
fix the corrupt objects in an additional commit.