### PR TITLE
Hide Submit proposal if iChain is enabled and user is not logged in

### DIFF
--- a/app/views/conference/_conference_details.html.haml
+++ b/app/views/conference/_conference_details.html.haml
@@ -32,7 +32,7 @@
                   Sorry, no places left
             - if !current_user.nil? && current_user.proposal_count(conference) > 0
               = link_to "My Proposals", conference_program_proposal_index_path(conference.short_title), :class =>"btn btn-default"
-            - elsif conference.program.cfp_open?
+            - elsif can? :new, conference.program.events.new
               = link_to "Submit Proposal", new_conference_program_proposal_path(conference.short_title), :class =>"btn btn-default"
             - if current_user.nil? || !current_user.subscribed?(conference)
               = link_to 'Subscribe', conference_subscriptions_path(conference.short_title), method: :post, class: 'btn btn-default'


### PR DESCRIPTION
because it's not possible to create a user while submitting a proposal when iChain is enabled. User would get not authorized error message.