### PR TITLE
Remove routes of Speakers,People and Photos controllers

### DIFF
--- a/config/routes.rb
+++ b/config/routes.rb
@@ -19,11 +19,9 @@ Osem::Application.routes.draw do
 
   namespace :admin do
     resources :users
-    resources :people
     resources :comments, only: [:index]
     resources :conference do
       resource :contact, except: [:index, :new, :create, :show, :destroy]
-      resources :photos, except: [:show]
       resource :schedule, only: [:show, :update]
       get 'commercials/render_commercial' => 'commercials#render_commercial'
       resources :commercials, only: [:index, :create, :update, :destroy]
@@ -64,7 +62,6 @@ Osem::Application.routes.draw do
             patch :restart
             get :vote
           end
-          resource :speaker, only: [:edit, :update]
         end
       end
 


### PR DESCRIPTION
speakers and photos controllers were removed in #548 
peoples_controller was removed in [23bf55b66c0f8fac504618acea4cc97178d9454a](https://github.com/openSUSE/osem/commit/23bf55b66c0f8fac504618acea4cc97178d9454a)