### PR TITLE
Allow updating currency of ticket if its the only ticket of that conference

### DIFF
--- a/app/models/ticket.rb
+++ b/app/models/ticket.rb
@@ -59,6 +59,7 @@ class Ticket < ActiveRecord::Base
   private
 
   def tickets_of_conference_have_same_currency
+    return if self.persisted? && Ticket.where(conference_id: conference_id).count == 1
     unless Ticket.where(conference_id: conference_id).all?{|t| t.price_currency == self.price_currency }
       errors.add(:price_currency, 'is different from the existing tickets of this conference.')
     end

--- a/spec/models/ticket_spec.rb
+++ b/spec/models/ticket_spec.rb
@@ -45,6 +45,11 @@ describe Ticket do
     end
   end
 
+  it 'allows updating currency of ticket if its the only ticket of the conference' do
+    ticket.price_currency = 'INR'
+    expect(ticket).to be_valid
+  end
+
   describe 'association' do
     it { should belong_to(:conference) }
     it { should have_many(:ticket_purchases).dependent(:destroy) }


### PR DESCRIPTION
Currently if a new ticket is added to a conference its currency should be the same as that of the existing type of tickets.But the validation that checks this also prevents updating a ticket's currency even if its the only type  of ticket.