### PR TITLE
Add ability for attendees to view tickets grouped by payment mode

### DIFF
--- a/app/models/ticket_purchase.rb
+++ b/app/models/ticket_purchase.rb
@@ -16,6 +16,7 @@ class TicketPurchase < ActiveRecord::Base
   delegate :price, to: :ticket
   delegate :price_cents, to: :ticket
   delegate :price_currency, to: :ticket
+  delegate :payment_mode, to: :ticket
 
   def self.purchase(conference, user, purchases)
     errors = []

--- a/app/views/conference_registrations/show.html.haml
+++ b/app/views/conference_registrations/show.html.haml
@@ -89,29 +89,48 @@
           %span.fa-stack
             %i.fa.fa-square-o.fa-stack-2x
             %i.fa.fa-ticket.fa-stack-1x
-          Tickets
+          Booked Tickets
           -if @tickets.any?
             = "(#{@total_price} #{@tickets.first.price.symbol})"
+        Offline Payments
         %ul
           - @tickets.each do |ticket|
-            %li
-              = ticket.quantity
-              = ticket.title
-              = word_pluralize(ticket.quantity, 'Ticket')
-              for
-              = humanized_money ticket.price
-              = ticket.price.symbol
-              = link_to conference_ticket_purchase_path(@conference.short_title, ticket.id), method: :delete,
+            -if ticket.payment_mode == "Offline"
+              %li
+                = ticket.quantity
+                = ticket.title
+                = word_pluralize(ticket.quantity, 'Ticket')
+                for
+                = humanized_money ticket.price
+                = ticket.price.symbol
+                = link_to conference_ticket_purchase_path(@conference.short_title, ticket.id), method: :delete,
                                                                                             id: "ticket-#{ticket.id}-delete",
                                                                                             class: 'btn btn-danger btn-xs',
                                                                                             data: { confirm: "Do you really want to delete the #{ticket.title} ticket for #{@conference.title}?" } do
-                %i.fa.fa-trash-o
-          %li
-            - if @tickets.any?
-              = link_to 'Buy more tickets', conference_tickets_path(@conference.short_title)
-            - else
-              You haven't bought any tickets.
-              = link_to 'Please buy some tickets to support us!', conference_tickets_path(@conference.short_title)
+                  %i.fa.fa-trash-o
+
+        Online Payments
+        %ul
+          - @tickets.each do |ticket|
+            -if ticket.payment_mode == "Online"
+              %li
+                = ticket.quantity
+                = ticket.title
+                = word_pluralize(ticket.quantity, 'Ticket')
+                for
+                = humanized_money ticket.price
+                = ticket.price.symbol
+                = link_to conference_ticket_purchase_path(@conference.short_title, ticket.id), method: :delete,
+                                                                                            id: "ticket-#{ticket.id}-delete",
+                                                                                            class: 'btn btn-danger btn-xs',
+                                                                                            data: { confirm: "Do you really want to delete the #{ticket.title} ticket for #{@conference.title}?" } do
+                  %i.fa.fa-trash-o
+
+        - if @tickets.any?
+          = link_to 'Buy more tickets', conference_tickets_path(@conference.short_title)
+        - else
+          You haven't bought any tickets.
+          = link_to 'Please buy some tickets to support us!', conference_tickets_path(@conference.short_title)
 
   .row
     .col-md-12

--- a/app/views/tickets/_ticket.html.haml
+++ b/app/views/tickets/_ticket.html.haml
@@ -7,6 +7,8 @@
         %h5.media-heading
         -if !ticket.description.blank?
           = markdown(ticket.description)
+  %td.col-sm-q.col-md-1
+    = ticket.payment_mode
   %td.col-sm-1.col-md-1
     - if ticket.bought?(current_user)
       = text_field_tag("tickets[][#{ticket.id}]", ticket.quantity_bought_by(current_user),

--- a/app/views/tickets/index.html.haml
+++ b/app/views/tickets/index.html.haml
@@ -14,6 +14,7 @@
           %thead
             %tr
               %th Ticket
+              %th Payment
               %th Quantity
               %th Price
               %th Total
@@ -21,6 +22,7 @@
           - @conference.tickets.each do |ticket|
             = render partial: 'ticket', f: f, locals: {ticket: ticket}
           %tr
+            %td
             %td
             %td
             %td.col-sm-1.col-md-1.text-center


### PR DESCRIPTION
this PR is in succession to https://github.com/openSUSE/osem/pull/1018.

this provides ability to attendees to view payment modes related to tickets and then groups their tickets according to payment modes.