### PR TITLE
Limit event types length

### DIFF
--- a/app/models/event_type.rb
+++ b/app/models/event_type.rb
@@ -6,6 +6,18 @@ class EventType < ActiveRecord::Base
   validates :length, numericality: {greater_than: 0}
   validates :minimum_abstract_length, presence: true
   validates :maximum_abstract_length, presence: true
+  validate :length_step
 
   alias_attribute :name, :title
+
+  LENGTH_STEP = 15
+
+  private
+
+  ##
+  # Check if length is multiple of LENGTH_STEP. Used as validation.
+  #
+  def length_step
+    errors.add(:length, "must be multiple of #{LENGTH_STEP}") if length % LENGTH_STEP != 0
+  end
 end

--- a/app/views/admin/event_types/_form.html.haml
+++ b/app/views/admin/event_types/_form.html.haml
@@ -10,7 +10,7 @@
   .col-md-12
     = semantic_form_for(@event_type, :url => (@event_type.new_record? ? admin_conference_program_event_types_path : admin_conference_program_event_type_path(@conference.short_title, @event_type))) do |f|
       = f.input :title
-      = f.input :length, :input_html => {:size => 3}
+      = f.input :length, :input_html => {size: 3, type: 'number', step: EventType::LENGTH_STEP, min: EventType::LENGTH_STEP}
       = f.input :description
       = f.input :minimum_abstract_length, :input_html => {:size => 3}
       = f.input :maximum_abstract_length, :input_html => {:size => 3}

--- a/spec/models/conference_spec.rb
+++ b/spec/models/conference_spec.rb
@@ -366,8 +366,8 @@ describe Conference do
 
   describe 'program hours and minutes' do
     before(:each) do
-      @long = create(:event_type, length: 100)
-      @short = create(:event_type, length: 10)
+      @long = create(:event_type, length: 120)
+      @short = create(:event_type, length: 15)
     end
 
     describe '#actual_program_minutes' do
@@ -376,8 +376,8 @@ describe Conference do
         create(:event, program: subject.program, event_type: @long)
         create(:event, program: subject.program, event_type: @short)
         create(:event, program: subject.program, event_type: @short)
-        result_in_hours = 4
-        result_in_minutes = 220
+        result_in_hours = 5
+        result_in_minutes = 270
         expect(subject.current_program_hours).to eq(result_in_hours)
         expect(subject.current_program_minutes).to eq(result_in_minutes)
       end
@@ -397,7 +397,7 @@ describe Conference do
         create(:event, program: subject.program, event_type: @short, created_at: Time.now - 3.days)
         create(:event, program: subject.program, event_type: @short)
         result_in_hours = 2
-        result_in_minutes = 110
+        result_in_minutes = 135
         expect(subject.new_program_hours(Time.now - 5.minutes)).to eq(result_in_hours)
         expect(subject.new_program_minutes(Time.now - 5.minutes)).to eq(result_in_minutes)
       end

--- a/spec/models/event_type_spec.rb
+++ b/spec/models/event_type_spec.rb
@@ -1,0 +1,32 @@
+require 'spec_helper'
+
+describe EventType do
+  let(:conference) { create(:conference) }
+  let(:event_type) { create(:event_type, program: conference.program) }
+
+  describe 'association' do
+    it { is_expected.to belong_to :program }
+    it { is_expected.to have_many :events }
+  end
+
+  describe 'validation' do
+    it 'has a valid factory' do
+      expect(build(:event_type)).to be_valid
+    end
+
+    it { is_expected.to validate_presence_of(:title) }
+    it { is_expected.to validate_presence_of(:minimum_abstract_length) }
+    it { is_expected.to validate_presence_of(:maximum_abstract_length) }
+
+    describe 'has a valid length' do
+      it 'length is greater than 0' do
+        should validate_numericality_of(:length).
+        is_greater_than(0)
+      end
+
+      it 'length is multiple of LENGTH_STEP' do
+        expect(build(:event_type, program: conference.program, length: 37)).not_to be_valid
+      end
+    end
+  end
+end

--- a/spec/models/event_type_spec.rb
+++ b/spec/models/event_type_spec.rb
@@ -18,13 +18,16 @@ describe EventType do
     it { is_expected.to validate_presence_of(:minimum_abstract_length) }
     it { is_expected.to validate_presence_of(:maximum_abstract_length) }
 
-    describe 'has a valid length' do
-      it 'length is greater than 0' do
-        should validate_numericality_of(:length).
-        is_greater_than(0)
+    describe 'length' do
+      it 'validates numericality and greater than 0' do
+        is_expected.to validate_numericality_of(:length).is_greater_than(0)
       end
 
-      it 'length is multiple of LENGTH_STEP' do
+      it 'is valid when length is multiple of LENGTH_STEP' do
+        expect(build(:event_type, program: conference.program, length: 30)).to be_valid
+      end
+
+      it 'is not valid when length is not multiple of LENGTH_STEP' do
         expect(build(:event_type, program: conference.program, length: 37)).not_to be_valid
       end
     end


### PR DESCRIPTION
I've limit the event types length to be a multiple of 15, adding validation and tests.

I've created a variable `LENGTH_STEP` in `EventType` for if we want to change the step (10 minutes instead of 15 for example). I plan to use this variable in the schedule also.