### PR TITLE
Add payment mode selection with conference for organisers

### DIFF
--- a/app/controllers/admin/conference_controller.rb
+++ b/app/controllers/admin/conference_controller.rb
@@ -186,7 +186,7 @@ module Admin
                                          :vpositions_attributes, :use_volunteers, :color,
                                          :sponsorship_levels_attributes, :sponsors_attributes,
                                          :targets, :targets_attributes,
-                                         :campaigns, :campaigns_attributes, :registration_limit)
+                                         :campaigns, :campaigns_attributes, :registration_limit, :payment_method)
     end
   end
 end

--- a/app/models/conference.rb
+++ b/app/models/conference.rb
@@ -57,6 +57,9 @@ class Conference < ActiveRecord::Base
   validates_format_of :short_title, with: /\A[a-zA-Z0-9_-]*\z/
   validates :registration_limit, numericality: { only_integer: true, greater_than_or_equal_to: 0 }
 
+  validates :payment_method, presence: true, null: false, inclusion: {in: %w(online offline),
+                                                                      message: "'%{value}' is not a valid payment method"}
+
   # This validation is needed since a conference with a start date greater than the end date is not possible
   validate :valid_date_range?
   before_create :generate_guid

--- a/app/views/admin/conference/edit.html.haml
+++ b/app/views/admin/conference/edit.html.haml
@@ -23,4 +23,13 @@
         = f.input :end_date, :as => :string, :input_html => { :id => "conference-end-datepicker", :readonly => "readonly"  }
       = f.inputs name: "Registrations" do
         = f.input :registration_limit, as: :number, in: 0..9999, hint: "Limit the number of registrations to the conference (0 no limit)"
+      = f.inputs name: "Tickets" do
+        = f.label :payment_method
+        .btn-group{"data-toggle" => :payment_method, class: "pull-right"}
+          %label.btn.btn-default
+            = f.radio_button :payment_method, 'online'
+            Pay Online
+          %label.btn.btn-default
+            = f.radio_button :payment_method, 'offline'
+            Pay at the venue
       = f.action :submit, :as => :button, :button_html => {:class => "btn btn-primary"}

--- a/app/views/admin/conference/new.html.haml
+++ b/app/views/admin/conference/new.html.haml
@@ -10,5 +10,14 @@
         = f.input :timezone, as: :time_zone, hint: 'Please select in what time zone your conference will take place.'
         = f.input :start_date, as: :string, input_html: { id: 'conference-start-datepicker', required: 'required' }
         = f.input :end_date, as: :string, input_html: { id: 'conference-end-datepicker', required: 'required' }
+      = f.inputs name: "Tickets" do
+        = f.label :payment_method
+        .btn-group{"data-toggle" => :payment_method, class: "pull-right"}
+          %label.btn.btn-default
+            = f.radio_button :payment_method, 'online'
+            Pay Online
+          %label.btn.btn-default
+            = f.radio_button :payment_method, 'offline'
+            Pay at the venue
       = f.actions do
         = f.action :submit, button_html: {class: 'btn btn-success pull-right'}

--- a/db/migrate/20160603043546_add_payment_method_to_conferences.rb
+++ b/db/migrate/20160603043546_add_payment_method_to_conferences.rb
@@ -1,0 +1,5 @@
+class AddPaymentMethodToConferences < ActiveRecord::Migration
+  def change
+    add_column :conferences, :payment_method, :string, default: 'offline', null: false
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -11,7 +11,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 20160427104236) do
+ActiveRecord::Schema.define(version: 20160603043546) do
 
   create_table "ahoy_events", force: :cascade do |t|
     t.uuid     "visit_id",   limit: 16
@@ -102,6 +102,7 @@ ActiveRecord::Schema.define(version: 20160427104236) do
     t.text     "description"
     t.integer  "registration_limit",    default: 0
     t.string   "picture"
+    t.string   "payment_method",        default: "offline", null: false
   end
 
   create_table "conferences_questions", id: false, force: :cascade do |t|

--- a/spec/factories/conferences.rb
+++ b/spec/factories/conferences.rb
@@ -9,6 +9,7 @@ FactoryGirl.define do
     end_date { 6.days.from_now }
     registration_limit 0
     description { Faker::Hipster.paragraph }
+    payment_method 'offline'
 
     after(:create) do |conference|
       Role.where(name: 'organizer', resource: conference).first_or_create(description: 'For the organizers of the conference (who shall have full access)')

--- a/spec/models/conference_spec.rb
+++ b/spec/models/conference_spec.rb
@@ -1545,6 +1545,20 @@ describe Conference do
       should validate_presence_of(:end_date)
     end
 
+    it 'is not valid without payment mode' do
+      should validate_presence_of(:payment_method)
+    end
+
+    it 'is valid with payment mode as Online' do
+      should allow_value('online').for(:payment_method).
+        with_message("'%{value}' is not a valid payment method")
+    end
+
+    it 'is valid with payment mode as Offline' do
+      should allow_value('offline').for(:payment_method).
+        with_message("'%{value}' is not a valid payment method")
+    end
+
     it 'is not valid with a duplicate short title' do
       should validate_uniqueness_of(:short_title)
     end


### PR DESCRIPTION
add capability for organisers to select payment modes for their conferences as Online/Offline.