### PR TITLE
allow correct input dates according to its constraints while creating Call for Papers

### DIFF
--- a/app/views/admin/cfps/_form.html.haml
+++ b/app/views/admin/cfps/_form.html.haml
@@ -4,8 +4,8 @@
       %h1 Call for Papers
 .row
   .col-md-8
-    = semantic_form_for(@cfp, :url => admin_conference_program_cfp_path(@conference.short_title),:html => {:multipart => true}) do |f|
-      = f.input :start_date, :as => :string, :input_html => { :id => "conference-start-datepicker", :readonly => "readonly"  }
-      = f.input :end_date, :as => :string, :input_html => { :id => "conference-end-datepicker", :readonly => "readonly"  }
+    = semantic_form_for(@cfp, url: admin_conference_program_cfp_path(@conference.short_title),html: {multipart: true}) do |f|
+      = f.input :start_date, as: :string, input_html: { id: "registration-period-start-datepicker", start_date: @conference.start_date, end_date: @conference.end_date, readonly: "readonly"  }
+      = f.input :end_date, as: :string, input_html: { id: "registration-period-end-datepicker", readonly: "readonly"  }
       %p.text-right
-        = f.action :submit, :as => :button, :button_html => {:class => "btn btn-primary"}
+        = f.action :submit, as: :button, button_html: { class: "btn btn-primary" }

--- a/spec/features/cfp_spec.rb
+++ b/spec/features/cfp_spec.rb
@@ -22,9 +22,9 @@ feature Conference do
 
       today = Date.today - 1
       page.execute_script(
-      "$('#conference-start-datepicker').val('#{today.strftime('%d/%m/%Y')}')")
+      "$('#registration-period-start-datepicker').val('#{today.strftime('%d/%m/%Y')}')")
       page.execute_script(
-      "$('#conference-end-datepicker').val('#{(today + 6).strftime('%d/%m/%Y')}')")
+      "$('#registration-period-end-datepicker').val('#{(today + 6).strftime('%d/%m/%Y')}')")
 
       click_button 'Create Cfp'
 
@@ -47,7 +47,7 @@ feature Conference do
 
       # Validate update with empty start date will not saved
       page.execute_script(
-          "$('#conference-start-datepicker').val('')")
+          "$('#registration-period-start-datepicker').val('')")
       click_button 'Update Cfp'
       expect(flash).
           to eq('Updating call for papers failed. ' +
@@ -56,9 +56,9 @@ feature Conference do
       # Fill in date
       today = Date.today - 9
       page.execute_script(
-        "$('#conference-start-datepicker').val('#{today.strftime('%d/%m/%Y')}')")
+        "$('#registration-period-start-datepicker').val('#{today.strftime('%d/%m/%Y')}')")
       page.execute_script(
-        "$('#conference-end-datepicker').val('#{(today + 14).strftime('%d/%m/%Y')}')")
+        "$('#registration-period-end-datepicker').val('#{(today + 14).strftime('%d/%m/%Y')}')")
 
       click_button 'Update Cfp'
 


### PR DESCRIPTION
using existing date-picker config for `registration-period` to place correct constraints on Call for Paper's date-picker.

Issue #1028.