### PR TITLE
Add languages_list in controller admin/events#edit

### DIFF
--- a/app/controllers/admin/events_controller.rb
+++ b/app/controllers/admin/events_controller.rb
@@ -92,6 +92,7 @@ module Admin
       @comment_count = @event.comment_threads.count
       @user = @event.submitter
       @url = admin_conference_program_event_path(@conference.short_title, @event)
+      @languages = @program.languages_list
     end
 
     def comment


### PR DESCRIPTION
The variable exists in proposal#edit and proposal#new but not in admin/events#edit, as a result when editing an event from the admin panel, the drop down does not actually show the available languages.