### PR TITLE
Use protocol relative URL when loading OSM tiles

### DIFF
--- a/app/views/conference/_venue_map.html.haml
+++ b/app/views/conference/_venue_map.html.haml
@@ -5,7 +5,7 @@
     // create a map in the "map" div, set the view to a given place and zoom
     var map = L.map('map', { scrollWheelZoom: false }).setView([#{@conference.venue.latitude}, #{@conference.venue.longitude}], 11);
     // add an OpenStreetMap tile layer
-    L.tileLayer('http://{s}.tile.osm.org/{z}/{x}/{y}.png', {
+    L.tileLayer('//{s}.tile.openstreetmap.org/{z}/{x}/{y}.png', {
       attribution: 'Map data &copy; <a href="http://openstreetmap.org">OpenStreetMap</a> contributors, <a href="http://creativecommons.org/licenses/by-sa/2.0/">CC-BY-SA</a>, Imagery © <a href="http://mapbox.com">Mapbox</a>',
       maxZoom: 18
     }).addTo(map);


### PR DESCRIPTION
This avoids mixed content warnings and gives us our padlock back on Chromium
and Firefox.

This also switches the domain for the tile servers from osm.org to 
openstreetmap.org because the certificates do not mention osm.org and hence
using this domain the tiles fail to load.