### PR TITLE
Different colors for new tracks, types and levels

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -95,7 +95,7 @@ Metrics/BlockNesting:
   Max: 4
 
 Metrics/ClassLength:
-  Max: 560
+  Max: 570
 
 # avoid redundunt curly braces when it is obvious that hash is used
 Style/BracesAroundHashParameters:

--- a/app/controllers/admin/difficulty_levels_controller.rb
+++ b/app/controllers/admin/difficulty_levels_controller.rb
@@ -11,7 +11,7 @@ module Admin
     def edit; end
 
     def new
-      @difficulty_level = @conference.program.difficulty_levels.new
+      @difficulty_level = @conference.program.difficulty_levels.new(color: @conference.next_color_for_collection(:levels))
     end
 
     def create

--- a/app/controllers/admin/event_types_controller.rb
+++ b/app/controllers/admin/event_types_controller.rb
@@ -9,7 +9,7 @@ module Admin
     def edit; end
 
     def new
-      @event_type = @conference.program.event_types.new
+      @event_type = @conference.program.event_types.new(color: @conference.next_color_for_collection(:types))
     end
 
     def create

--- a/app/controllers/admin/tracks_controller.rb
+++ b/app/controllers/admin/tracks_controller.rb
@@ -14,7 +14,7 @@ module Admin
     end
 
     def new
-      @track = @program.tracks.new
+      @track = @program.tracks.new(color: @conference.next_color_for_collection(:tracks))
     end
 
     def create

--- a/app/models/conference.rb
+++ b/app/models/conference.rb
@@ -595,6 +595,20 @@ class Conference < ActiveRecord::Base
     registration_limit > 0 && registrations.count >= registration_limit
   end
 
+  # Returns an hexadecimal color given a collection. The returned color changed
+  # when the number of element in the collection changes and for consecutive
+  # number of elements it returns highly different colors.
+  def next_color_for_collection(collection)
+    # we have different start indices for every collection to generate a
+    # different color for every of them.
+    start_index = {
+      tracks: (program.tracks.count + 1),
+      levels: (program.difficulty_levels.count + 51),
+      types: (program.event_types.count + 101)
+    }
+    next_color(start_index[collection])
+  end
+
   private
 
   # Returns a different html colour for every i and consecutive colors are

--- a/app/models/difficulty_level.rb
+++ b/app/models/difficulty_level.rb
@@ -3,4 +3,5 @@ class DifficultyLevel < ActiveRecord::Base
   has_many :events, dependent: :nullify
 
   validates :title, presence: true
+  validates :color, format: /\A#[0-9a-fA-F]{6}\z/
 end

--- a/app/models/difficulty_level.rb
+++ b/app/models/difficulty_level.rb
@@ -3,5 +3,13 @@ class DifficultyLevel < ActiveRecord::Base
   has_many :events, dependent: :nullify
 
   validates :title, presence: true
-  validates :color, format: /\A#[0-9a-fA-F]{6}\z/
+  validates :color, format: /\A#[0-9A-F]{6}\z/
+
+  before_validation :capitalize_color
+
+  private
+
+  def capitalize_color
+    self.color = color.upcase if color.present?
+  end
 end

--- a/app/models/event.rb
+++ b/app/models/event.rb
@@ -115,7 +115,7 @@ class Event < ActiveRecord::Base
     json = super(options)
 
     json[:room_guid] = room.try(:guid)
-    json[:track_color] = track.try(:color) || '#ffffff'
+    json[:track_color] = track.try(:color) || '#FFFFFF'
     json[:length] = event_type.try(:length) || 25
 
     json

--- a/app/models/event_type.rb
+++ b/app/models/event_type.rb
@@ -7,6 +7,7 @@ class EventType < ActiveRecord::Base
   validates :minimum_abstract_length, presence: true
   validates :maximum_abstract_length, presence: true
   validate :length_step
+  validates :color, format: /\A#[0-9a-fA-F]{6}\z/
 
   alias_attribute :name, :title
 

--- a/app/models/event_type.rb
+++ b/app/models/event_type.rb
@@ -7,7 +7,9 @@ class EventType < ActiveRecord::Base
   validates :minimum_abstract_length, presence: true
   validates :maximum_abstract_length, presence: true
   validate :length_step
-  validates :color, format: /\A#[0-9a-fA-F]{6}\z/
+  validates :color, format: /\A#[0-9A-F]{6}\z/
+
+  before_validation :capitalize_color
 
   alias_attribute :name, :title
 
@@ -21,5 +23,9 @@ class EventType < ActiveRecord::Base
   #
   def length_step
     errors.add(:length, "must be multiple of #{LENGTH_STEP}") if length % LENGTH_STEP != 0
+  end
+
+  def capitalize_color
+    self.color = color.upcase if color.present?
   end
 end

--- a/app/models/track.rb
+++ b/app/models/track.rb
@@ -4,6 +4,7 @@ class Track < ActiveRecord::Base
 
   before_create :generate_guid
   validates :name, presence: true
+  validates :color, format: /\A#[0-9a-fA-F]{6}\z/
 
   private
 

--- a/app/models/track.rb
+++ b/app/models/track.rb
@@ -4,7 +4,9 @@ class Track < ActiveRecord::Base
 
   before_create :generate_guid
   validates :name, presence: true
-  validates :color, format: /\A#[0-9a-fA-F]{6}\z/
+  validates :color, format: /\A#[0-9A-F]{6}\z/
+
+  before_validation :capitalize_color
 
   private
 
@@ -14,5 +16,9 @@ class Track < ActiveRecord::Base
 #       guid = SecureRandom.urlsafe_base64
 #     end while Person.where(:guid => guid).exists?
     self.guid = guid
+  end
+
+  def capitalize_color
+    self.color = color.upcase if color.present?
   end
 end

--- a/lib/tasks/capitalize_colors.rake
+++ b/lib/tasks/capitalize_colors.rake
@@ -1,0 +1,21 @@
+namespace :data do
+  desc 'Catitalize tracks, event types and difficult levels colors'
+
+  task capitalize_colors: :environment do
+    capitalize_collection_colors(Track)
+    puts "Tracks' colors capitalized"
+
+    capitalize_collection_colors(DifficultyLevel)
+    puts "Difficulty levels' colors capitalized"
+
+    capitalize_collection_colors(EventType)
+    puts "Event types' colors capitalized"
+  end
+
+  def capitalize_collection_colors(model)
+    model.all.each do |item|
+      item.color = item.color.upcase
+      item.save!
+    end
+  end
+end

--- a/spec/factories/event_types.rb
+++ b/spec/factories/event_types.rb
@@ -6,6 +6,7 @@ FactoryGirl.define do
     length 30
     minimum_abstract_length 0
     maximum_abstract_length 500
+    color '#ffffff'
     program
   end
 

--- a/spec/features/event_types_spec.rb
+++ b/spec/features/event_types_spec.rb
@@ -32,7 +32,7 @@ feature EventType do
       within('table#event_types') do
         expect(page.has_content?('Party')).to be true
         expect(page.has_content?('13042')).to be true
-        expect(page.has_content?('#e4e4e4')).to be true
+        expect(page.has_content?('#E4E4E4')).to be true
         expect(page.assert_selector('tr', count: 3)).to be true
       end
 

--- a/spec/models/conference_spec.rb
+++ b/spec/models/conference_spec.rb
@@ -426,7 +426,7 @@ describe Conference do
         result = {}
         result['Hard'] = {
           'value' => 1,
-          'color' => '#ffffff',
+          'color' => '#FFFFFF',
         }
         result['Easy'] = {
           'value' => 2,
@@ -476,7 +476,7 @@ describe Conference do
         result = {}
         result['Hard'] = {
           'value' => 1,
-          'color' => '#ffffff'
+          'color' => '#FFFFFF'
         }
         result['Easy'] = {
           'value' => 1,
@@ -526,7 +526,7 @@ describe Conference do
         }
         result['Lecture'] = {
           'value' => 1,
-          'color' => '#ffffff',
+          'color' => '#FFFFFF',
         }
         expect(subject.event_type_distribution).to eq(result)
       end
@@ -572,7 +572,7 @@ describe Conference do
         result = {}
         result['Lecture'] = {
           'value' => 1,
-          'color' => '#ffffff'
+          'color' => '#FFFFFF'
         }
         result['Workshop'] = {
           'value' => 1,
@@ -622,7 +622,7 @@ describe Conference do
         }
         result['Track Two'] = {
           'value' => 1,
-          'color' => '#ffffff',
+          'color' => '#FFFFFF',
         }
         expect(subject.tracks_distribution).to eq(result)
       end
@@ -672,7 +672,7 @@ describe Conference do
         }
         result['Track Two'] = {
           'value' => 1,
-          'color' => '#ffffff'
+          'color' => '#FFFFFF'
         }
         expect(subject.tracks_distribution(:confirmed)).to eq(result)
       end

--- a/spec/models/event_spec.rb
+++ b/spec/models/event_spec.rb
@@ -236,7 +236,7 @@ describe Event do
       json_hash = event.as_json(nil)
 
       expect(json_hash[:room_guid]).to eq(event.room.guid)
-      expect(json_hash[:track_color]).to eq('#efefef')
+      expect(json_hash[:track_color]).to eq('#EFEFEF')
       expect(json_hash[:length]).to eq(30)
     end
 
@@ -245,7 +245,7 @@ describe Event do
       json_hash = event.as_json(nil)
 
       expect(json_hash[:room_guid]).to be_nil
-      expect(json_hash[:track_color]).to eq('#ffffff')
+      expect(json_hash[:track_color]).to eq('#FFFFFF')
       expect(json_hash[:length]).to eq(25)
     end
   end

--- a/spec/models/event_type_spec.rb
+++ b/spec/models/event_type_spec.rb
@@ -18,6 +18,22 @@ describe EventType do
     it { is_expected.to validate_presence_of(:minimum_abstract_length) }
     it { is_expected.to validate_presence_of(:maximum_abstract_length) }
 
+    it 'is valid if its color is a correct hexadecimal color with 7 characters' do
+      should allow_value('#FF0000').for(:color)
+    end
+
+    it 'is not valid if its color is not a correct hexadecimal color' do
+      should_not allow_value('#AB1H7G').for(:color)
+    end
+
+    it 'is not valid if its color has less than 7 characters' do
+      should_not allow_value('#fff').for(:color)
+    end
+
+    it 'is not valid if its color has more than 7 characters' do
+      should_not allow_value('#123A4567').for(:color)
+    end
+
     describe 'length' do
       it 'validates numericality and greater than 0' do
         is_expected.to validate_numericality_of(:length).is_greater_than(0)

--- a/spec/views/admin/difficulty_levels/index.html.haml_spec.rb
+++ b/spec/views/admin/difficulty_levels/index.html.haml_spec.rb
@@ -9,6 +9,6 @@ describe 'admin/difficulty_levels/index' do
     render
     expect(rendered).to include('Example Difficulty Level')
     expect(rendered).to include('Lorem Ipsum dolsum')
-    expect(rendered).to include('#ffffff')
+    expect(rendered).to include('#FFFFFF')
   end
 end

--- a/spec/views/admin/tracks/index.html.haml_spec.rb
+++ b/spec/views/admin/tracks/index.html.haml_spec.rb
@@ -10,6 +10,6 @@ describe 'admin/tracks/index' do
     render
     expect(rendered).to include('Example Track')
     expect(rendered).to include('Lorem Ipsum dolsum')
-    expect(rendered).to include('#ffffff')
+    expect(rendered).to include('#FFFFFF')
   end
 end


### PR DESCRIPTION
Every time a new track, event type or difficulty level is created, the color picker has a different color by default. :smile: 

Closes https://github.com/openSUSE/osem/issues/1077