### PR TITLE
Text color of event types and difficulty levels

### DIFF
--- a/app/views/admin/difficulty_levels/index.html.haml
+++ b/app/views/admin/difficulty_levels/index.html.haml
@@ -20,7 +20,7 @@
             %td
               = difficulty_level.description
             %td
-              %span.label{style: "background-color: #{difficulty_level.color};"}
+              %span.label{style: "background-color: #{difficulty_level.color}; color: #{ contrast_color(difficulty_level.color) };"}
                 = difficulty_level.color
             %td
               .btn-group{role: "group"}

--- a/app/views/admin/event_types/index.html.haml
+++ b/app/views/admin/event_types/index.html.haml
@@ -28,7 +28,7 @@
               = "#{event_type.minimum_abstract_length} - #{event_type.maximum_abstract_length}"
               Words
             %td
-              %span.label{style: "background-color: #{event_type.color};"}
+              %span.label{style: "background-color: #{event_type.color}; color: #{ contrast_color(event_type.color) };"}
                 = event_type.color
             %td
               .btn-group{role: "group"}
@@ -39,4 +39,3 @@
 .row
   .col-md-12.text-right
     = link_to 'Add Event Type', new_admin_conference_program_event_type_path(@conference.short_title), class: 'btn btn-primary'
-

--- a/app/views/proposal/show.html.haml
+++ b/app/views/proposal/show.html.haml
@@ -76,7 +76,7 @@
             %dt Difficulty:
             %dd
               - if @event.difficulty_level
-                %span.label{:style =>"background-color: #{@event.difficulty_level.color};"}
+                %span.label{:style =>"background-color: #{@event.difficulty_level.color}; color: #{ contrast_color(@event.difficulty_level.color) };"}
                   = @event.difficulty_level.title
 
           - if @event.require_registration


### PR DESCRIPTION
Changing the text color of event types and difficulty levels taking the background color into account. Similar to what it is done with tracks. See issue https://github.com/openSUSE/osem/issues/1033.

Closes https://github.com/openSUSE/osem/issues/1078