### PR TITLE
Handle cancellation of scheduled events

### DIFF
--- a/app/assets/stylesheets/osem-schedule.css.scss
+++ b/app/assets/stylesheets/osem-schedule.css.scss
@@ -193,6 +193,14 @@ td.no-padding{
   color:  #D8D8D8 !important;
 }
 
+.schedule-label{
+  height: 14px;
+  line-height: 11px;
+  overflow: hidden;
+  display: inline-block;
+  white-space: normal;
+}
+
 /* Small devices (tablets, 768px and up) */
 @media (min-width: 768px) {
   .room, .event-title{
@@ -226,6 +234,11 @@ td.no-padding{
 
   td.event{
     padding: 3px 5px !important;
+  }
+
+  .schedule-label{
+    height: 15px;
+    line-height: 12px;
   }
 }
 

--- a/app/models/event.rb
+++ b/app/models/event.rb
@@ -38,6 +38,8 @@ class Event < ActiveRecord::Base
   validate :max_attendees_no_more_than_room_size
 
   scope :confirmed, -> { where(state: 'confirmed') }
+  scope :canceled, -> { where(state: 'canceled') }
+  scope :withdrawn, -> { where(state: 'withdrawn') }
   scope :highlighted, -> { where(is_highlight: true) }
 
   state_machine initial: :new do
@@ -228,6 +230,13 @@ class Event < ActiveRecord::Base
   #
   def end_time
     self.start_time + self.event_type.length.minutes
+  end
+
+  ##
+  # Returns events that are scheduled in the same room and start_time as event
+  #
+  def intersecting_events
+    room.events.where(start_time: start_time).where.not(id: id)
   end
 
   private

--- a/app/views/conference/_carousel.html.haml
+++ b/app/views/conference/_carousel.html.haml
@@ -33,6 +33,11 @@
                     - span -= 1
                   - else
                     - event = events.find{|e| e.start_time <= start_room_time and e.end_time > start_room_time}
+
+                    - if event && (event.state == 'canceled' || event.state == 'withdrawn') && !event.intersecting_events.confirmed.empty?
+                      - replacement_event = event.intersecting_events.confirmed.first
+                      - event = (replacement_event.start_time <= start_room_time && replacement_event.end_time > start_room_time) ? replacement_event : nil
+
                     - if event
                       / There is an event, calculate the span and show it
                       - event_span =  (event.end_time.to_i - start_room_time.to_i) / 60 / EventType::LENGTH_STEP

--- a/app/views/conference/_schedule_item.html.haml
+++ b/app/views/conference/_schedule_item.html.haml
@@ -4,7 +4,14 @@
   %a.unstyled-link{href: url_for(conference_program_proposal_path(@conference.short_title, event.id))}
     %div{ class: "elipsis break-words event-title", |
           style: "-webkit-line-clamp: #{ event_lines(@rooms) }; height: #{ event_height(@rooms) }px;"} |
+
+      - if event.state == 'canceled' || event.state == 'withdrawn'
+        %span.label.label-danger.schedule-label CANCELED
+      - elsif event.state == 'confirmed' && (!event.intersecting_events.canceled.empty? || !event.intersecting_events.withdrawn.empty?)
+        %span.label.label-info.schedule-label REPLACEMENT
+
       = event.title
+
     - if speaker = event.speakers.first
       = image_tag speaker.gravatar_url, :class => "img-circle pull-right speaker-pic", |
                                         :alt => speaker.name, |

--- a/app/views/proposal/show.html.haml
+++ b/app/views/proposal/show.html.haml
@@ -14,6 +14,12 @@
             = link_to "Edit", edit_conference_program_proposal_path(@conference.short_title, @event), :class => "btn btn-mini btn-primary"
           - if can? :schedule, @conference
             = link_to "Schedule", schedule_conference_path(@conference.short_title), :class =>"btn btn-success"
+
+      - if @event.state == 'canceled' || @event.state == 'withdrawn'
+        %span.label.label-danger CANCELED
+      - elsif @event.state == 'confirmed' && (!@event.intersecting_events.canceled.empty? || !@event.intersecting_events.withdrawn.empty?)
+        %span.label.label-info REPLACEMENT
+
   .row
     .col-md-3
       .speakerinfo
@@ -34,6 +40,16 @@
     .col-md-9
       .row
         .col-md-12
+          .lead
+            - if @event.state == 'confirmed' && !@event.intersecting_events.withdrawn.empty?
+              = "Please note that this talk replaces"
+              = link_to @event.intersecting_events.withdrawn.first.title,
+                    conference_program_proposal_path(@conference.short_title, @event.intersecting_events.withdrawn.first.id)
+            - elsif @event.state == 'confirmed' && !@event.intersecting_events.canceled.empty?
+              = "Please note that this talk replaces"
+              = link_to @event.intersecting_events.canceled.first.title,
+                    conference_program_proposal_path(@conference.short_title, @event.intersecting_events.canceled.first.id)
+
           - if @event.commercials.empty?
             %h5.text-warning
               No video of the event yet, sorry!


### PR DESCRIPTION
Currently if a scheduled event is cancelled/withdrawn,
  - It remains scheduled.The public schedule page will still display the event without any change
  - The event disappears from the admin scheduling interface.
  - If a new event is scheduled in the same room and time of the cancelled event, it won't be shown in the public schedule until the cancelled event is unscheduled (which is difficult as it won't be accessible from the scheduling interface)  
  - There is no way to let attendees know that the event has been cancelled other than manually by  changing the title/abstract.

With these changes, if a scheduled event is cancelled/withdrawn,
  - A red label with text 'CANCELED' will be displayed before its title in the schedule
  - If a new event is scheduled in the same room and time as that of the canceled event
    - The cancelled event will no longer be displayed in the schedule
    - A label with text 'REPLACEMENT' will be displayed before its title in the schedule
    -  'Please note that this talk replaces #{cancelled event's title}' will be shown in the replacement event's proposal page

![cancelled_event](https://cloud.githubusercontent.com/assets/7537349/16874990/5732ee68-4aba-11e6-95e9-a53cccd88c35.png)
![replacement](https://cloud.githubusercontent.com/assets/7537349/16874991/57376fd8-4aba-11e6-8e14-d7735b15f4cd.png)





 
