### PR TITLE
Make abstract optional

### DIFF
--- a/app/models/event.rb
+++ b/app/models/event.rb
@@ -30,7 +30,6 @@ class Event < ActiveRecord::Base
   validate :abstract_limit
   validate :before_end_of_conference, on: :create
   validates :title, presence: true
-  validates :abstract, presence: true
   validates :event_type, presence: true
   validates :program, presence: true
   validates :max_attendees, numericality: { only_integer: true, greater_than_or_equal_to: 1, allow_nil: true }

--- a/app/views/proposal/_proposal_form.html.haml
+++ b/app/views/proposal/_proposal_form.html.haml
@@ -34,7 +34,7 @@
         = difficulty_level.description
 
     = f.input :abstract, input_html: { rows: 5 },
-      required: true, hint: link_to('Tips to improve your presentations', 'http://blog.hubspot.com/blog/tabid/6307/bid/5975/10-Rules-to-Instantly-Improve-Your-Presentations.aspx')
+       hint: link_to('Tips to improve your presentations', 'http://blog.hubspot.com/blog/tabid/6307/bid/5975/10-Rules-to-Instantly-Improve-Your-Presentations.aspx')
 
     %p
       You have used

--- a/app/views/proposal/new.html.haml
+++ b/app/views/proposal/new.html.haml
@@ -43,8 +43,8 @@
               :javascript
                 $("##{@program.event_types.first.id}-help").collapse('show');
 
-              = f.input :abstract, input_html: { rows: 5, required: true },
-                required: true, hint: link_to('Tips to improve your presentations', 'http://blog.hubspot.com/blog/tabid/6307/bid/5975/10-Rules-to-Instantly-Improve-Your-Presentations.aspx')
+              = f.input :abstract, input_html: { rows: 5},
+                hint: link_to('Tips to improve your presentations', 'http://blog.hubspot.com/blog/tabid/6307/bid/5975/10-Rules-to-Instantly-Improve-Your-Presentations.aspx')
 
               %p
                 You have used

--- a/spec/models/event_spec.rb
+++ b/spec/models/event_spec.rb
@@ -20,7 +20,6 @@ describe Event do
     end
 
     it { is_expected.to validate_presence_of(:title) }
-    it { is_expected.to validate_presence_of(:abstract) }
     it { is_expected.to validate_presence_of(:program) }
     it { is_expected.to validate_presence_of(:event_type) }
 


### PR DESCRIPTION
Fixes #1092
Removed client-side and server-side validation for `abstract`