### PR TITLE
Default value for length in as_json fixed

### DIFF
--- a/app/models/event.rb
+++ b/app/models/event.rb
@@ -116,7 +116,7 @@ class Event < ActiveRecord::Base
 
     json[:room_guid] = room.try(:guid)
     json[:track_color] = track.try(:color) || '#FFFFFF'
-    json[:length] = event_type.try(:length) || 25
+    json[:length] = event_type.try(:length) || EventType::LENGTH_STEP
 
     json
   end

--- a/app/serializers/event_serializer.rb
+++ b/app/serializers/event_serializer.rb
@@ -36,6 +36,6 @@ class EventSerializer < ActiveModel::Serializer
 
   # FIXME: duplicated logic from Event#as_json
   def length
-    object.event_type.try(:length) || 25
+    object.event_type.try(:length) || EventType::LENGTH_STEP
   end
 end

--- a/spec/models/event_spec.rb
+++ b/spec/models/event_spec.rb
@@ -246,7 +246,7 @@ describe Event do
 
       expect(json_hash[:room_guid]).to be_nil
       expect(json_hash[:track_color]).to eq('#FFFFFF')
-      expect(json_hash[:length]).to eq(25)
+      expect(json_hash[:length]).to eq(15)
     end
   end
 


### PR DESCRIPTION
The default value for length in as_json should be a multiple of EventType::LENGTH_STEP.