### PR TITLE
Updated layout of ichain sign in page

### DIFF
--- a/app/views/devise/ichain_sessions/new.html.haml
+++ b/app/views/devise/ichain_sessions/new.html.haml
@@ -6,7 +6,7 @@
           %h3.panel-title
             Sign in
         .panel-body
-          = semantic_form_for "", method: :post, enctype: 'application/x-www-form-urlencoded', url: @login_url do |f|
+          = semantic_form_for '', method: :post, enctype: 'application/x-www-form-urlencoded', url: @login_url do |f|
             = f.input :url, as: :hidden, input_html: { value: @back_url }
             = f.input :context, as: :hidden, input_html: { value: @context }
             = f.input :proxypath, as: :hidden, input_html: { value: @proxypath }

--- a/app/views/devise/ichain_sessions/new.html.haml
+++ b/app/views/devise/ichain_sessions/new.html.haml
@@ -1,0 +1,20 @@
+.container
+  .row
+    .col-md-6.col-md-offset-3
+      .panel.panel-default
+        .panel-heading
+          %h3.panel-title
+            Sign in
+        .panel-body
+          = semantic_form_for "", method: :post, enctype: 'application/x-www-form-urlencoded', url: @login_url do |f|
+            = f.input :url, as: :hidden, input_html: { value: @back_url }
+            = f.input :context, as: :hidden, input_html: { value: @context }
+            = f.input :proxypath, as: :hidden, input_html: { value: @proxypath }
+
+            = f.input :username, input_html: { autofocus: true }
+            = f.input :password, as: :password
+
+            %p.text-right
+              = f.action :submit, as: :button, label: 'Sign In', button_html: { class: 'btn btn-success' }
+
+            = render partial: 'devise/shared/help'

--- a/app/views/devise/ichain_sessions/new_test.html.haml
+++ b/app/views/devise/ichain_sessions/new_test.html.haml
@@ -1,0 +1,19 @@
+.container
+  .row
+    .col-md-6.col-md-offset-3
+      .panel.panel-default
+        .panel-heading
+          %h3.panel-title
+            Sign in (TEST MODE)
+        .panel-body
+          = semantic_form_for "", method: :post, enctype: 'application/x-www-form-urlencoded', url: @login_url do |f|
+            = f.input :username, input_html: { autofocus: true }
+
+            - if ::Devise.ichain_force_test_attributes.blank?
+              - @fields.each do |field|
+                = f.input "attributes[#{field}]", label: field.to_s.humanize
+
+            %p.text-right
+              = f.action :submit, as: :button, label: 'Sign In', button_html: { class: 'btn btn-success' }
+
+            = render partial: 'devise/shared/help'

--- a/app/views/devise/shared/_links.html.haml
+++ b/app/views/devise/shared/_links.html.haml
@@ -9,3 +9,7 @@
 - if devise_mapping.lockable? && resource_class.unlock_strategy_enabled?(:email) && controller_name != 'unlocks'
   = link_to "Didn't receive unlock instructions?", new_unlock_path(resource_name)
   %br
+
+- if devise_mapping.ichain_registerable?
+  = link_to "Sign up", new_ichain_registration_path(resource_name)
+  %br


### PR DESCRIPTION
Fix for #1098 

I basically merged the content of the [devise ichain views](https://github.com/openSUSE/devise_ichain_authenticatable/tree/master/app/views/devise/ichain_sessions) with the current database_authenticatable sign in page.

I could sign in successfully using ichain test mode. When not in test mode, how can I test this locally? Do I just need to create an openSUSE account and try to sign in, or is there more setup? (I am not familiar with ichain at all)