### PR TITLE
Add cancel/replacement label in All Events page and fixes bug caused by #1082

### DIFF
--- a/app/helpers/application_helper.rb
+++ b/app/helpers/application_helper.rb
@@ -503,4 +503,22 @@ module ApplicationHelper
       'deleted'
     end
   end
+
+  def canceled_replacement_event_label(event, event_schedule, *label_classes)
+    if event.state == 'canceled' || event.state == 'withdrawn'
+      content_tag :span, 'CANCELED', class: (['label', 'label-danger'] + label_classes)
+    elsif event.state == 'confirmed' && event_schedule.present? && (!event_schedule.intersecting_events.canceled.empty? || !event_schedule.intersecting_events.withdrawn.empty?)
+      content_tag :span, 'REPLACEMENT', class: (['label', 'label-info'] + label_classes)
+    end
+  end
+
+  def replacement_event_notice(event, event_schedule)
+    if event.state == 'confirmed' && event_schedule.present? && (!event_schedule.intersecting_events.withdrawn.empty? || !event_schedule.intersecting_events.canceled.empty?)
+      replaced_event = (event_schedule.intersecting_events.withdrawn.first || event_schedule.intersecting_events.canceled.first).event
+      content_tag :span do
+        concat content_tag :span, 'Please note that this talk replaces '
+        concat link_to replaced_event.title, conference_program_proposal_path(@conference.short_title, replaced_event.id)
+      end
+    end
+  end
 end

--- a/app/helpers/application_helper.rb
+++ b/app/helpers/application_helper.rb
@@ -507,13 +507,13 @@ module ApplicationHelper
   def canceled_replacement_event_label(event, event_schedule, *label_classes)
     if event.state == 'canceled' || event.state == 'withdrawn'
       content_tag :span, 'CANCELED', class: (['label', 'label-danger'] + label_classes)
-    elsif event.state == 'confirmed' && event_schedule.present? && (!event_schedule.intersecting_events.canceled.empty? || !event_schedule.intersecting_events.withdrawn.empty?)
+    elsif event_schedule.present? && event_schedule.replacement?
       content_tag :span, 'REPLACEMENT', class: (['label', 'label-info'] + label_classes)
     end
   end
 
-  def replacement_event_notice(event, event_schedule)
-    if event.state == 'confirmed' && event_schedule.present? && (!event_schedule.intersecting_events.withdrawn.empty? || !event_schedule.intersecting_events.canceled.empty?)
+  def replacement_event_notice(event_schedule)
+    if event_schedule.present? && event_schedule.replacement?
       replaced_event = (event_schedule.intersecting_events.withdrawn.first || event_schedule.intersecting_events.canceled.first).event
       content_tag :span do
         concat content_tag :span, 'Please note that this talk replaces '

--- a/app/models/event_schedule.rb
+++ b/app/models/event_schedule.rb
@@ -28,4 +28,8 @@ class EventSchedule < ActiveRecord::Base
   def intersecting_events
     room.event_schedules.where(start_time: start_time, schedule: schedule).where.not(id: id)
   end
+
+  def replacement?
+    event.state == 'confirmed' && (!intersecting_events.canceled.empty? || !intersecting_events.withdrawn.empty?)
+  end
 end

--- a/app/views/proposal/show.html.haml
+++ b/app/views/proposal/show.html.haml
@@ -15,11 +15,6 @@
           - if can? :schedule, @conference
             = link_to "Schedule", conference_schedule_path(@conference.short_title), :class =>"btn btn-success"
 
-      - if @event.state == 'canceled' || @event.state == 'withdrawn'
-        %span.label.label-danger CANCELED
-      - elsif @event.state == 'confirmed' && @event_schedule.present? && (!@event_schedule.intersecting_events.canceled.empty? || !@event_schedule.intersecting_events.withdrawn.empty?)
-        %span.label.label-info REPLACEMENT
-
   .row
     .col-md-3
       .speakerinfo
@@ -40,16 +35,9 @@
     .col-md-9
       .row
         .col-md-12
-          -if @event_schedule.present?
-            .lead
-              - if @event.state == 'confirmed' && !@event_schedule.intersecting_events.withdrawn.empty?
-                = "Please note that this talk replaces"
-                = link_to @event_schedule.intersecting_events.withdrawn.first.event.title,
-                      conference_program_proposal_path(@conference.short_title, @event_schedule.intersecting_events.withdrawn.first.event.id)
-              - elsif @event.state == 'confirmed' && !@event_schedule.intersecting_events.canceled.empty?
-                = "Please note that this talk replaces"
-                = link_to @event_schedule.intersecting_events.canceled.first.title,
-                      conference_program_proposal_path(@conference.short_title, @event_schedule.intersecting_events.canceled.first.event.id)
+          .lead
+            = canceled_replacement_event_label(@event, @event_schedule)
+            = replacement_event_notice(@event, @event_schedule)
 
           - if @event.commercials.empty?
             %h5.text-warning

--- a/app/views/proposal/show.html.haml
+++ b/app/views/proposal/show.html.haml
@@ -37,7 +37,7 @@
         .col-md-12
           .lead
             = canceled_replacement_event_label(@event, @event_schedule)
-            = replacement_event_notice(@event, @event_schedule)
+            = replacement_event_notice(@event_schedule)
 
           - if @event.commercials.empty?
             %h5.text-warning

--- a/app/views/schedules/_event.html.haml
+++ b/app/views/schedules/_event.html.haml
@@ -4,6 +4,11 @@
       = image_tag speaker.gravatar_url, :class => "img-circle pull-right all-speaker-pic", |
                                         :alt => speaker.name, |
                                         :title => speaker.name |
+
+    %p
+      = canceled_replacement_event_label(event, event_schedule)
+      = replacement_event_notice(event, event_schedule)
+
     %span.h3
       = event.title
       %br

--- a/app/views/schedules/_event.html.haml
+++ b/app/views/schedules/_event.html.haml
@@ -7,7 +7,7 @@
 
     %p
       = canceled_replacement_event_label(event, event_schedule)
-      = replacement_event_notice(event, event_schedule)
+      = replacement_event_notice(event_schedule)
 
     %span.h3
       = event.title

--- a/app/views/schedules/_schedule_item.html.haml
+++ b/app/views/schedules/_schedule_item.html.haml
@@ -5,10 +5,7 @@
     %div{ class: "elipsis break-words event-title", |
           style: "-webkit-line-clamp: #{ event_lines(@rooms) }; height: #{ event_height(@rooms) }px;"} |
 
-      - if event.state == 'canceled' || event.state == 'withdrawn'
-        %span.label.label-danger.schedule-label CANCELED
-      - elsif event.state == 'confirmed' && (!event_schedule.intersecting_events.canceled.empty? || !event_schedule.intersecting_events.withdrawn.empty?)
-        %span.label.label-info.schedule-label REPLACEMENT
+      = canceled_replacement_event_label(event, event_schedule, 'schedule-label')
 
       = event.title
 


### PR DESCRIPTION
-  ~~Access to proposal#show fails if room is not set.(nil)~~
- I've added canceled/replacement labels in All Events like @Ana06  suggested [here](https://github.com/openSUSE/osem/pull/1082#issuecomment-234498947)
  ![labels_all_events_full](https://cloud.githubusercontent.com/assets/7537349/17276088/98642e5a-573b-11e6-8d5c-269820a36f68.png)
