### PR TITLE
Show Event missing info in admin

### DIFF
--- a/app/helpers/application_helper.rb
+++ b/app/helpers/application_helper.rb
@@ -383,7 +383,7 @@ module ApplicationHelper
       reverse.sub(',', ' dna ').reverse
   end
 
-  def change_creator_link(user_id)
+  def link_to_user(user_id)
     user = User.find_by(id: user_id)
     if user
       link_to user.name, admin_user_path(id: user_id)
@@ -479,16 +479,16 @@ module ApplicationHelper
 
   def user_change_description(version)
     if version.event == 'create'
-     change_creator_link(version.item_id) + ' signed up'
+     link_to_user(version.item_id) + ' signed up'
     elsif version.event == 'update'
       if version.changeset.keys.include?('reset_password_sent_at')
         'Someone requested password reset of'
       elsif version.changeset.keys.include?('confirmed_at') && version.changeset['confirmed_at'][0].nil?
-        (version.whodunnit.nil? ? change_creator_link(version.item_id) : change_creator_link(version.whodunnit)) + ' confirmed account of'
+        (version.whodunnit.nil? ? link_to_user(version.item_id) : link_to_user(version.whodunnit)) + ' confirmed account of'
       elsif version.changeset.keys.include?('confirmed_at') && version.changeset['confirmed_at'][1].nil?
-        change_creator_link(version.whodunnit) + ' unconfirmed account of'
+        link_to_user(version.whodunnit) + ' unconfirmed account of'
       else
-        change_creator_link(version.whodunnit) + " updated #{updated_attributes(version)} of"
+        link_to_user(version.whodunnit) + " updated #{updated_attributes(version)} of"
       end
     end
   end

--- a/app/views/admin/events/show.html.haml
+++ b/app/views/admin/events/show.html.haml
@@ -21,7 +21,7 @@
                   = version.id
                 %td
                   %p
-                    = change_creator_link(version.whodunnit)
+                    = link_to_user(version.whodunnit)
 
                     - if version.item_type == 'Event'
                       = event_change_description(version)

--- a/app/views/admin/events/show.html.haml
+++ b/app/views/admin/events/show.html.haml
@@ -4,6 +4,13 @@
       = link_to "Proposal", "#proposal-content", "data-toggle"=>"tab"
     %li
       = link_to "History", "#history-content", "data-toggle"=>"tab"
+    %li
+      %a{href: '#proposal-tasks', "data-toggle"=>"tab"}
+        Tasks
+        %span.label.label-danger{style: 'border-radius: 1em;'}
+          - progress_status = @event.progress_status
+          = progress_status.reject{ |_key, value| value || value.nil? }.length
+
   .tab-content
     #proposal-content.tab-pane.active
       = render 'proposal'
@@ -42,3 +49,36 @@
                   = render partial: 'shared/object_changes', locals: { version: version }
                 %td
                   = render partial: 'shared/changelog_actions', locals: { version: version }
+
+    #proposal-tasks.tab-pane
+      - progress_percentage = @event.calculate_progress
+      .col-md-12
+        %h3
+          = @event.title
+        %br
+        %table.table.table-hover
+          %tr
+            %td= link_to 'Submitter must be registered to the conference', admin_conference_registrations_path(@event.program.conference.short_title)
+            %td{'class'=>class_for_todo(progress_status['registered'])}
+              %span{'class'=>[icon_for_todo(progress_status['registered']), 'fa-lg']}
+          %tr
+            %td= link_to 'Fill out submitter biography', edit_user_path(@event.submitter)
+            %td{'class'=>class_for_todo(progress_status['biography'])}
+              %span{'class'=>[icon_for_todo(progress_status['biography']), 'fa-lg']}
+          %tr
+            %td= link_to 'Add a subtitle', edit_conference_program_proposal_path(@event.program.conference.short_title, @event)
+            %td{'class'=>class_for_todo(progress_status['subtitle'])}
+              %span{'class'=>[icon_for_todo(progress_status['subtitle']), 'fa-lg']}
+          %tr
+            %td= link_to 'Add a commercial', edit_conference_program_proposal_path(@event.program.conference.short_title, @event, anchor: 'commercials-content')
+            %td{'class'=>class_for_todo(progress_status['commercial'])}
+              %span{'class'=>[icon_for_todo(progress_status['commercial']), 'fa-lg']}
+          - unless progress_status['track'].nil?
+            %tr
+              %td= link_to 'Add a track', edit_conference_program_proposal_path(@event.program.conference.short_title, @event)
+              %td{'class'=>class_for_todo(progress_status['track'])}
+                %span{'class'=>[icon_for_todo(progress_status['track']), 'fa-lg']}
+          %tr
+            %td= link_to 'Add a difficulty level', edit_conference_program_proposal_path(@event.program.conference.short_title, @event)
+            %td{'class'=>class_for_todo(progress_status['difficulty_level'])}
+              %span{'class'=>[icon_for_todo(progress_status['difficulty_level']), 'fa-lg']}

--- a/app/views/admin/versions/index.html.haml
+++ b/app/views/admin/versions/index.html.haml
@@ -17,7 +17,7 @@
           = version.id
         %td.col-md-9
           %p
-            = change_creator_link(version.whodunnit) unless version.item_type == 'User'
+            = link_to_user(version.whodunnit) unless version.item_type == 'User'
 
             - case version.item_type
             - when 'Event'

--- a/app/views/proposal/_form.html.haml
+++ b/app/views/proposal/_form.html.haml
@@ -40,3 +40,6 @@
                         - if can? :destroy, commercial
                           = link_to 'Delete', conference_program_proposal_commercial_path(@conference.short_title, @event.id, commercial.id),
                           :method => :delete, :data => { :confirm => 'Are you sure?' }, class: 'btn btn-danger'
+                    .text-right
+                      = "added by "
+                      = link_to_user(commercial.versions.last.whodunnit)

--- a/spec/features/commercials_spec.rb
+++ b/spec/features/commercials_spec.rb
@@ -58,7 +58,7 @@ feature Commercial do
       sign_out
     end
 
-    scenario 'adds a valid commercial of an event', feature: true, js: true do
+    scenario 'adds a valid commercial of an event', feature: true, versioning: true, js: true do
       visit edit_conference_program_proposal_path(conference.short_title, event.id)
       click_link 'Commercials'
       fill_in 'commercial_url', with: 'https://www.youtube.com/watch?v=M9bq_alk-sw'
@@ -85,7 +85,7 @@ feature Commercial do
       expect(event.commercials.count).to eq 0
     end
 
-    scenario 'updates a commercial of an event', feature: true, js: true do
+    scenario 'updates a commercial of an event', feature: true, versioning: true, js: true do
       commercial = create(:commercial,
                           commercialable_id: event.id,
                           commercialable_type: 'Event')
@@ -99,7 +99,7 @@ feature Commercial do
       expect(commercial.url).to eq('https://www.youtube.com/watch?v=M9bq_alk-sw')
     end
 
-    scenario 'does not update a commercial of an event with invalid data', feature: true, js: true do
+    scenario 'does not update a commercial of an event with invalid data', feature: true, versioning: true, js: true do
       commercial = create(:commercial,
                           commercialable_id: event.id,
                           commercialable_type: 'Event')
@@ -113,7 +113,7 @@ feature Commercial do
       expect(commercial.url).to eq('https://www.youtube.com/watch?v=BTTygyxuGj8')
     end
 
-    scenario 'deletes a commercial of an event', feature: true, js: true do
+    scenario 'deletes a commercial of an event', feature: true, versioning: true, js: true do
       create(:commercial,
              commercialable_id: event.id,
              commercialable_type: 'Event')


### PR DESCRIPTION
(Branch from #1019 - Merge only after it is merged)

Displays missing info tooltip shown in proposal#index in admin events#index as well.

![screenshot 2016-07-31 14 33 26](https://cloud.githubusercontent.com/assets/7537349/17275617/df6c693a-572b-11e6-8f36-fd9ba7dcd74b.png)
  
  
  
  
Displays who added commercials for an event.

![screenshot from 2016-07-31 14 38 40](https://cloud.githubusercontent.com/assets/7537349/17275635/8d6c7296-572c-11e6-89cf-429227b074b4.png)
