### PR TITLE
ability to create and purchase free tickets

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -96,8 +96,6 @@ Metrics/BlockNesting:
 
 Metrics/ClassLength:
   Max: 575
-  Exclude:
-  - 'app/models/conference.rb'
 
 # avoid redundunt curly braces when it is obvious that hash is used
 Style/BracesAroundHashParameters:

--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -96,6 +96,8 @@ Metrics/BlockNesting:
 
 Metrics/ClassLength:
   Max: 575
+  Exclude:
+  - 'app/models/conference.rb'
 
 # avoid redundunt curly braces when it is obvious that hash is used
 Style/BracesAroundHashParameters:

--- a/app/controllers/ticket_purchases_controller.rb
+++ b/app/controllers/ticket_purchases_controller.rb
@@ -11,8 +11,13 @@ class TicketPurchasesController < ApplicationController
         redirect_to new_conference_payment_path,
                     notice: 'Please pay here to get tickets.'
       else
-        redirect_to conference_tickets_path(@conference.short_title),
-                    error: 'Please get at least one ticket to continue.'
+        if current_user.ticket_purchases.by_conference(@conference).paid.any?
+          redirect_to conference_conference_registration_path(@conference.short_title),
+                      notice: 'You have free tickets for the conference.'
+        else
+          redirect_to conference_tickets_path(@conference.short_title),
+                      error: 'Please get at least one ticket to continue.'
+        end
       end
     else
       redirect_to conference_conference_registration_path(@conference.short_title),

--- a/app/controllers/ticket_purchases_controller.rb
+++ b/app/controllers/ticket_purchases_controller.rb
@@ -10,14 +10,12 @@ class TicketPurchasesController < ApplicationController
       if current_user.ticket_purchases.by_conference(@conference).unpaid.any?
         redirect_to new_conference_payment_path,
                     notice: 'Please pay here to get tickets.'
+      elsif current_user.ticket_purchases.by_conference(@conference).paid.any?
+        redirect_to conference_conference_registration_path(@conference.short_title),
+                    notice: 'You have free tickets for the conference.'
       else
-        if current_user.ticket_purchases.by_conference(@conference).paid.any?
-          redirect_to conference_conference_registration_path(@conference.short_title),
-                      notice: 'You have free tickets for the conference.'
-        else
-          redirect_to conference_tickets_path(@conference.short_title),
-                      error: 'Please get at least one ticket to continue.'
-        end
+        redirect_to conference_tickets_path(@conference.short_title),
+                    error: 'Please get at least one ticket to continue.'
       end
     else
       redirect_to conference_conference_registration_path(@conference.short_title),

--- a/app/models/conference.rb
+++ b/app/models/conference.rb
@@ -64,6 +64,8 @@ class Conference < ActiveRecord::Base
   before_create :add_color
   before_create :create_email_settings
 
+  after_create :create_free_ticket
+
   def date_range_string
     startstr = 'Unknown - '
     endstr = 'Unknown'
@@ -645,6 +647,14 @@ class Conference < ActiveRecord::Base
     self.create_contact
     self.create_program
     create_roles
+  end
+
+  ##
+  # Creates free ticket for the conference
+  # after the conference has been successfully created
+  # Will create 1 new record for 'free' ticket
+  def create_free_ticket
+    ticket = Ticket.where(conference: self, title: 'Free Access', price_cents: 0).first_or_create!(description: 'Get free access tickets for the conference.')
   end
 
   ##

--- a/app/models/conference.rb
+++ b/app/models/conference.rb
@@ -654,7 +654,7 @@ class Conference < ActiveRecord::Base
   # after the conference has been successfully created
   # Will create 1 new record for 'free' ticket
   def create_free_ticket
-    ticket = Ticket.where(conference: self, title: 'Free Access', price_cents: 0).first_or_create!(description: 'Get free access tickets for the conference.')
+    tickets.where(title: 'Free Access', price_cents: 0).first_or_create!(description: 'Get free access tickets for the conference.')
   end
 
   ##

--- a/app/models/conference.rb
+++ b/app/models/conference.rb
@@ -1,3 +1,4 @@
+# rubocop:disable Metrics/ClassLength
 ##
 # This class represents a conference
 class Conference < ActiveRecord::Base
@@ -1063,3 +1064,4 @@ class Conference < ActiveRecord::Base
     result
   end
 end
+# rubocop:enable Metrics/ClassLength

--- a/app/models/ticket.rb
+++ b/app/models/ticket.rb
@@ -13,7 +13,7 @@ class Ticket < ActiveRecord::Base
 
   validates :price_cents, :price_currency, :title, presence: true
 
-  validates_numericality_of :price_cents, greater_than: 0
+  validates_numericality_of :price_cents, greater_than_or_equal_to: 0
 
   def bought?(user)
     buyers.include?(user)

--- a/app/models/ticket_purchase.rb
+++ b/app/models/ticket_purchase.rb
@@ -23,7 +23,7 @@ class TicketPurchase < ActiveRecord::Base
     ActiveRecord::Base.transaction do
       conference.tickets.each do |ticket|
         quantity = purchases[ticket.id.to_s].to_i
-        # if the user bought the ticket, just update the quantity
+        # if the user bought the ticket and is still unpaid, just update the quantity
         if ticket.bought?(user) && ticket.unpaid?(user)
           purchase = update_quantity(conference, quantity, ticket, user)
         else
@@ -39,10 +39,20 @@ class TicketPurchase < ActiveRecord::Base
   end
 
   def self.purchase_ticket(conference, quantity, ticket, user)
-    purchase = new(ticket_id: ticket.id,
-                   conference_id: conference.id,
-                   user_id: user.id,
-                   quantity: quantity) if quantity > 0
+    if quantity > 0
+      if ticket.price_cents.zero?
+        purchase = new(ticket_id: ticket.id,
+                       conference_id: conference.id,
+                       user_id: user.id,
+                       quantity: quantity,
+                       paid: true)
+      else
+        purchase = new(ticket_id: ticket.id,
+                       conference_id: conference.id,
+                       user_id: user.id,
+                       quantity: quantity)
+      end
+    end
     purchase
   end
 

--- a/app/models/ticket_purchase.rb
+++ b/app/models/ticket_purchase.rb
@@ -40,18 +40,11 @@ class TicketPurchase < ActiveRecord::Base
 
   def self.purchase_ticket(conference, quantity, ticket, user)
     if quantity > 0
-      if ticket.price_cents.zero?
-        purchase = new(ticket_id: ticket.id,
-                       conference_id: conference.id,
-                       user_id: user.id,
-                       quantity: quantity,
-                       paid: true)
-      else
-        purchase = new(ticket_id: ticket.id,
-                       conference_id: conference.id,
-                       user_id: user.id,
-                       quantity: quantity)
-      end
+      purchase = new(ticket_id: ticket.id,
+                     conference_id: conference.id,
+                     user_id: user.id,
+                     quantity: quantity,
+                     paid: ticket.price_cents.zero?)
     end
     purchase
   end

--- a/spec/features/ticket_purchases_spec.rb
+++ b/spec/features/ticket_purchases_spec.rb
@@ -101,10 +101,10 @@ feature Registration do
 
         click_button 'Continue'
 
-        expect(current_path).to eq(new_conference_conference_registration_path(conference.short_title))
+        expect(current_path).to eq(conference_conference_registration_path(conference.short_title))
         purchase = TicketPurchase.where(user_id: participant.id, ticket_id: free_ticket.id).first
         expect(purchase.quantity).to eq(5)
-        expect(purchase.paid).to eq(true)
+        expect(purchase.paid).to be true
 
         expect(page.has_content?("5 #{free_ticket.title} Tickets for $ 0")).to be true
       end

--- a/spec/features/tickets_spec.rb
+++ b/spec/features/tickets_spec.rb
@@ -35,7 +35,7 @@ feature Ticket do
       fill_in 'ticket_price', with: '-1'
 
       click_button 'Create Ticket'
-      expect(flash).to eq("Creating Ticket failed: Title can't be blank. Price cents must be greater than 0.")
+      expect(flash).to eq("Creating Ticket failed: Title can't be blank. Price cents must be greater than or equal to 0.")
       expect(Ticket.count).to eq(0)
     end
 
@@ -72,7 +72,7 @@ feature Ticket do
         # It's necessary to multiply by 100 because the price is in cents
         expect(ticket.price).to eq(Money.new(100 * 100, 'USD'))
         expect(ticket.title).to eq('Business Ticket')
-        expect(flash).to eq("Ticket update failed: Title can't be blank. Price cents must be greater than 0.")
+        expect(flash).to eq("Ticket update failed: Title can't be blank. Price cents must be greater than or equal to 0.")
         expect(Ticket.count).to eq(1)
       end
 

--- a/spec/features/tickets_spec.rb
+++ b/spec/features/tickets_spec.rb
@@ -24,7 +24,7 @@ feature Ticket do
 
       click_button 'Create Ticket'
       expect(flash).to eq('Ticket successfully created.')
-      expect(Ticket.count).to eq(1)
+      expect(Ticket.count).to eq(2)
     end
 
     scenario 'add a invalid ticket', feature: true, js: true do
@@ -36,7 +36,7 @@ feature Ticket do
 
       click_button 'Create Ticket'
       expect(flash).to eq("Creating Ticket failed: Title can't be blank. Price cents must be greater than or equal to 0.")
-      expect(Ticket.count).to eq(0)
+      expect(Ticket.count).to eq(1)
     end
 
     context 'Ticket already created' do
@@ -44,9 +44,9 @@ feature Ticket do
 
       scenario 'edit valid ticket', feature: true, js: true do
         visit admin_conference_tickets_path(conference.short_title)
-        click_link 'Edit'
+        click_link('Edit', href: edit_admin_conference_ticket_path(conference.short_title, ticket.id))
 
-        fill_in 'ticket_title', with: 'Free Ticket'
+        fill_in 'ticket_title', with: 'Event Ticket'
         fill_in 'ticket_price', with: '50'
 
         click_button 'Update Ticket'
@@ -54,14 +54,14 @@ feature Ticket do
         ticket.reload
         # It's necessary to multiply by 100 because the price is in cents
         expect(ticket.price).to eq(Money.new(50 * 100, 'USD'))
-        expect(ticket.title).to eq('Free Ticket')
+        expect(ticket.title).to eq('Event Ticket')
         expect(flash).to eq('Ticket successfully updated.')
-        expect(Ticket.count).to eq(1)
+        expect(Ticket.count).to eq(2)
       end
 
       scenario 'edit invalid ticket', feature: true, js: true do
         visit admin_conference_tickets_path(conference.short_title)
-        click_link 'Edit'
+        click_link('Edit', href: edit_admin_conference_ticket_path(conference.short_title, ticket.id))
 
         fill_in 'ticket_title', with: ''
         fill_in 'ticket_price', with: '-5'
@@ -73,15 +73,15 @@ feature Ticket do
         expect(ticket.price).to eq(Money.new(100 * 100, 'USD'))
         expect(ticket.title).to eq('Business Ticket')
         expect(flash).to eq("Ticket update failed: Title can't be blank. Price cents must be greater than or equal to 0.")
-        expect(Ticket.count).to eq(1)
+        expect(Ticket.count).to eq(2)
       end
 
       scenario 'delete ticket', feature: true, js: true do
         visit admin_conference_tickets_path(conference.short_title)
-        click_link 'Delete'
+        click_link('Delete', href: admin_conference_ticket_path(conference.short_title, ticket.id))
 
         expect(flash).to eq('Ticket successfully destroyed.')
-        expect(Ticket.count).to eq(0)
+        expect(Ticket.count).to eq(1)
       end
     end
   end

--- a/spec/models/conference_spec.rb
+++ b/spec/models/conference_spec.rb
@@ -1588,7 +1588,7 @@ describe Conference do
     let!(:conference) { create(:conference) }
 
     it 'creates free tickets' do
-      free_ticket = Ticket.find_by(conference: conference)
+      free_ticket = conference.tickets.first
       expect(free_ticket).not_to be_nil
       expect(free_ticket.price_cents).to eq(0)
     end

--- a/spec/models/conference_spec.rb
+++ b/spec/models/conference_spec.rb
@@ -1585,11 +1585,12 @@ describe Conference do
   end
 
   describe 'after_create' do
-    let!(:conference) { create(:conference) }
+    let(:conference) { Conference.new(title: 'ABC', short_title: 'XYZ', start_date: Date.today, end_date: Date.today + 10, timezone: 'GMT') }
 
-    it 'creates free tickets' do
+    it 'calls back to create free ticket' do
+      conference.save
+      conference.run_callbacks :create
       free_ticket = conference.tickets.first
-      expect(free_ticket).not_to be_nil
       expect(free_ticket.price_cents).to eq(0)
     end
   end

--- a/spec/models/conference_spec.rb
+++ b/spec/models/conference_spec.rb
@@ -1583,4 +1583,14 @@ describe Conference do
       end
     end
   end
+
+  describe 'after_create' do
+    let!(:conference) { create(:conference) }
+
+    it 'creates free tickets' do
+      free_ticket = Ticket.find_by(conference: conference)
+      expect(free_ticket).not_to be_nil
+      expect(free_ticket.price_cents).to eq(0)
+    end
+  end
 end

--- a/spec/models/ticket_purchase_spec.rb
+++ b/spec/models/ticket_purchase_spec.rb
@@ -41,7 +41,7 @@ describe TicketPurchase do
     let!(:participant) { create(:user) }
     let!(:ticket_1) { create(:ticket) }
     let!(:ticket_2) { create(:ticket) }
-    let!(:free_ticket) { create(:ticket) }
+    let!(:free_ticket) { create(:ticket, price_cents: 0) }
     let!(:conference) { create(:conference, tickets: [ticket_1, ticket_2, free_ticket]) }
 
     it 'creates purchase to free ticket' do

--- a/spec/models/ticket_purchase_spec.rb
+++ b/spec/models/ticket_purchase_spec.rb
@@ -41,7 +41,21 @@ describe TicketPurchase do
     let!(:participant) { create(:user) }
     let!(:ticket_1) { create(:ticket) }
     let!(:ticket_2) { create(:ticket) }
-    let!(:conference) { create(:conference, tickets: [ticket_1, ticket_2]) }
+    let!(:free_ticket) { create(:ticket) }
+    let!(:conference) { create(:conference, tickets: [ticket_1, ticket_2, free_ticket]) }
+
+    it 'creates purchase to free ticket' do
+      tickets = { free_ticket.id.to_s => '10' }
+      message = TicketPurchase.purchase(conference, participant, tickets)
+      purchase = TicketPurchase.where(conference_id: conference.id,
+                                      user_id: participant.id,
+                                      ticket_id: free_ticket.id).first
+
+      expect(TicketPurchase.count).to eq(1)
+      expect(purchase.quantity).to eq(10)
+      expect(message.blank?).to be true
+
+    end
 
     it 'creates a purchase for one ticket' do
       tickets = { ticket_1.id.to_s => '1' }

--- a/spec/models/ticket_spec.rb
+++ b/spec/models/ticket_spec.rb
@@ -22,12 +22,12 @@ describe Ticket do
       should validate_presence_of(:price_currency)
     end
 
-    it 'is not valid with a price_cents equals zero' do
-      should_not allow_value(0).for(:price_cents)
-    end
-
     it 'is not valid with a price_cents smaller than zero' do
       should_not allow_value(-1).for(:price_cents)
+    end
+
+    it 'is valid with a price_cents equals zero' do
+      should allow_value(0).for(:price_cents)
     end
 
     it 'is valid with a price_cents greater than zero' do


### PR DESCRIPTION
This provides the ability for organiser to create free tickets and attendees to purchase them.
This will be rebased over #1108 after merge.
