### PR TITLE
Schedule tags improved

### DIFF
--- a/app/assets/stylesheets/osem-schedule.css.scss
+++ b/app/assets/stylesheets/osem-schedule.css.scss
@@ -199,6 +199,9 @@ td.no-padding{
   overflow: hidden;
   display: inline-block;
   white-space: normal;
+  padding-left: 1px;
+  padding-right: 1px;
+  font-size: 7px;
 }
 
 /* Small devices (tablets, 768px and up) */
@@ -217,7 +220,12 @@ td.no-padding{
   }
 
   td.event{
-    padding: 3px 4px !important;
+    padding: 3px 3px !important;
+  }
+
+  .schedule-label{
+    padding-left: 2px;
+    padding-right: 3px;
   }
 }
 
@@ -232,13 +240,10 @@ td.no-padding{
     max-width: 10%;
   }
 
-  td.event{
-    padding: 3px 5px !important;
-  }
-
   .schedule-label{
     height: 15px;
     line-height: 12px;
+    font-size: 7px;
   }
 }
 
@@ -246,6 +251,12 @@ td.no-padding{
 @media (min-width: 1200px) {
   .room, .event-title{
     font-size: 14px;
+  }
+
+  .schedule-label{
+    padding-left: 2px;
+    padding-right: 2px;
+    font-size: 8px;
   }
 
   td.room{


### PR DESCRIPTION
As @differentreality suggested I have created this new PR to improve the tags introduced in https://github.com/openSUSE/osem/pull/1082 by @nishanthvijayan 

The whole `CANCELED` tag is displayed even in small devices. The `REPLACEMENT` one is too big for small devices, so it is shorted, but it is better than before I think. Some screenshots:

**Before:**

![image](https://cloud.githubusercontent.com/assets/16052290/17464980/ff189320-5cea-11e6-8c6d-ead45eaa58fe.png)

![image](https://cloud.githubusercontent.com/assets/16052290/17464972/d97c3f18-5cea-11e6-9c7a-780624c00fbd.png)

**Now:**

![image](https://cloud.githubusercontent.com/assets/16052290/17464935/09d028ec-5cea-11e6-9944-4f963326ba89.png)

![image](https://cloud.githubusercontent.com/assets/16052290/17464955/6b850242-5cea-11e6-9c85-a230f1985bfb.png)

![image](https://cloud.githubusercontent.com/assets/16052290/17464961/9cd8fe5c-5cea-11e6-964d-3afe515654f4.png)

![image](https://cloud.githubusercontent.com/assets/16052290/17464958/852a8bc2-5cea-11e6-9e3c-99b68f0d5d55.png)

