### PR TITLE
Restore css removed

### DIFF
--- a/app/assets/stylesheets/osem-schedule.css.scss
+++ b/app/assets/stylesheets/osem-schedule.css.scss
@@ -63,6 +63,12 @@ background-image: -webkit-gradient(
     color: rgb(185, 74, 72);
 }
 
+a.unstyled-link {
+  text-decoration: none;
+  color: #333333;
+  outline: 0;
+ }
+
 .program-dropdown, .schedule-dropdown{
   margin-left: 20%;
   margin-right: 20%;


### PR DESCRIPTION
I shouldn't have removed `a.unstyled-link` css in https://github.com/openSUSE/osem/pull/1132 as it is used in the public schedule. :anguished:

Look how ugly it looks now: :sob: 

![image](https://cloud.githubusercontent.com/assets/16052290/17608340/2029fde4-602c-11e6-92c8-a903e98bd0df.png)
