### PR TITLE
User schedule

### DIFF
--- a/app/assets/javascripts/osem-schedule.js
+++ b/app/assets/javascripts/osem-schedule.js
@@ -1,3 +1,5 @@
+// ADMIN SCHEDULE
+
 var url; // Should be initialize in Schedule.initialize
 var schedule_id; // Should be initialize in Schedule.initialize
 
@@ -116,6 +118,34 @@ $(document).ready( function() {
       }
   });
 });
+
+
+// PUBLIC SCHEDULE
+
+function starClicked(e){
+  // stops the click from propagating
+  if (!e) var e = window.event;
+  e.preventDefault();
+  e.cancelBubble = true;
+  if (e.stopPropagation) e.stopPropagation();
+
+  var callback = function(data) {
+    $(e.target).toggleClass('fa-star fa-star-o');
+  }
+
+  var params = { favourite_user_id: $(e.target).data('user') };
+  if($(e.target).hasClass('fa-star-o')){
+    params['add'] = true;
+  }
+
+  $.ajax({
+    url: $(e.target).data('url'),
+    type: 'PATCH',
+    data: params,
+    success: callback,
+    dataType : 'json'
+  });
+}
 
 function eventClicked(e, element){
   var url = $(element).data('url');

--- a/app/assets/javascripts/osem-schedule.js
+++ b/app/assets/javascripts/osem-schedule.js
@@ -134,9 +134,6 @@ function starClicked(e){
   }
 
   var params = { favourite_user_id: $(e.target).data('user') };
-  if($(e.target).hasClass('fa-star-o')){
-    params['add'] = true;
-  }
 
   $.ajax({
     url: $(e.target).data('url'),

--- a/app/assets/stylesheets/osem-schedule.css.scss
+++ b/app/assets/stylesheets/osem-schedule.css.scss
@@ -127,7 +127,7 @@ a.unstyled-link {
 .program-dropdown, .schedule-dropdown{
   margin-left: 20%;
   margin-right: 20%;
-  margin-top: 40px;
+  margin-top: 10px;
   margin-bottom: 20px;
 }
 
@@ -234,20 +234,6 @@ td.no-padding{
    cursor: pointer;
  }
 
-.program-dropdown{
-  margin-left: 20%;
-  margin-right: 20%;
-  margin-top: 40px;
-}
-
-.program-dropdown > button{
-  width: 100%;
-}
-
-.program-dropdown > .dropdown-menu{
-  width: 100%;
-}
-
 .no-events-day{
   color:  #D8D8D8 !important;
 }
@@ -261,10 +247,6 @@ td.no-padding{
   padding-left: 1px;
   padding-right: 1px;
   font-size: 7px;
-}
-
-#star{
-  margin-top: 8px;
 }
 
 #star-events{

--- a/app/assets/stylesheets/osem-schedule.css.scss
+++ b/app/assets/stylesheets/osem-schedule.css.scss
@@ -263,6 +263,15 @@ td.no-padding{
   font-size: 7px;
 }
 
+#star{
+  margin-top: 8px;
+}
+
+#star-events{
+  margin-right: 5px;
+  vertical-align: text-top;
+}
+
 /* Small devices (tablets, 768px and up) */
 @media (min-width: 768px) {
   .room, .event-title{

--- a/app/controllers/proposals_controller.rb
+++ b/app/controllers/proposals_controller.rb
@@ -63,14 +63,28 @@ class ProposalsController < ApplicationController
   end
 
   def update
-    @url = conference_program_proposal_path(@conference.short_title, params[:id])
+    respond_to do |format|
+      format.html do
+        @url = conference_program_proposal_path(@conference.short_title, params[:id])
 
-    if @event.update(event_params)
-      redirect_to conference_program_proposals_path(conference_id: @conference.short_title),
-                  notice: 'Proposal was successfully updated.'
-    else
-      flash[:error] = "Could not update proposal: #{@event.errors.full_messages.join(', ')}"
-      render action: 'edit'
+        if @event.update(event_params)
+          redirect_to conference_program_proposals_path(conference_id: @conference.short_title),
+                      notice: 'Proposal was successfully updated.'
+        else
+          flash[:error] = "Could not update proposal: #{@event.errors.full_messages.join(', ')}"
+          render action: 'edit'
+        end
+      end
+      format.json do
+        user = User.find(params[:favourite_user_id])
+        users = @event.favourite_users
+        if users.include? user
+          @event.favourite_users.delete(user)
+        else
+          @event.favourite_users << User.find(params[:favourite_user_id])
+        end
+        render json: {}
+      end
     end
   end
 

--- a/app/models/event.rb
+++ b/app/models/event.rb
@@ -22,8 +22,11 @@ class Event < ActiveRecord::Base
   belongs_to :difficulty_level
   belongs_to :program
 
+  has_and_belongs_to_many :favourite_users, class_name: 'User'
+
   accepts_nested_attributes_for :event_users, allow_destroy: true
   accepts_nested_attributes_for :users
+  accepts_nested_attributes_for :favourite_users
 
   before_create :generate_guid
 

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -49,6 +49,9 @@ class User < ActiveRecord::Base
   has_many :votes, dependent: :destroy
   has_many :voted_events, through: :votes, source: :events
   has_many :subscriptions, dependent: :destroy
+
+  has_and_belongs_to_many :favourite_events, class_name: 'Event'
+
   accepts_nested_attributes_for :roles
 
   scope :admin, -> { where(is_admin: true) }

--- a/app/views/schedules/_carousel.html.haml
+++ b/app/views/schedules/_carousel.html.haml
@@ -30,6 +30,7 @@
                 .room.elipsis.break-words{ style: "-webkit-line-clamp: #{ room_lines(@rooms) }; height: #{ room_height(@rooms) }px;" }
                   = room.name
                 - event_schedules = room.event_schedules.select{ |e| (e.schedule_id == @conference.program.selected_schedule.id) && (e.end_time > start_time) && (e.start_time <= (start_time + hrs_per_slide.hour)) }
+                - event_schedules = event_schedules.select{ |e| e.event.favourite_users.exists?(current_user.id) } if current_user && @favourites
                 - (1..intervals).each do |i|
                   - if span > 1
                     - span -= 1

--- a/app/views/schedules/_event.html.haml
+++ b/app/views/schedules/_event.html.haml
@@ -4,11 +4,15 @@
       = image_tag speaker.gravatar_url, :class => "img-circle pull-right all-speaker-pic", |
                                         :alt => speaker.name, |
                                         :title => speaker.name |
-
     %p
       = canceled_replacement_event_label(event, event_schedule)
       = replacement_event_notice(event_schedule)
-
+    - if current_user
+      = link_to('#', onClick: 'starClicked();') do
+        %span#star-events{ class: "fa fa-lg #{ event.favourite_users.exists?(current_user.id) ? 'fa-star' : 'fa-star-o' }", |
+                           "aria-hidden" => "true", |
+                           "data-url" => conference_program_proposal_path(@conference.short_title, event.id), |
+                           "data-user" => current_user.id }
     %span.h3
       = event.title
       %br

--- a/app/views/schedules/_event.html.haml
+++ b/app/views/schedules/_event.html.haml
@@ -11,7 +11,7 @@
       = link_to('#', onClick: 'starClicked();') do
         %span#star-events{ class: "fa fa-lg #{ event.favourite_users.exists?(current_user.id) ? 'fa-star' : 'fa-star-o' }", |
                            "aria-hidden" => "true", |
-                           "data-url" => conference_program_proposal_path(@conference.short_title, event.id), |
+                           "data-url" => toogle_favorite_conference_program_proposal_path(@conference.short_title, event.id), |
                            "data-user" => current_user.id }
     %span.h3
       = event.title

--- a/app/views/schedules/_schedule_item.html.haml
+++ b/app/views/schedules/_schedule_item.html.haml
@@ -11,7 +11,7 @@
         = link_to('#', onClick: 'starClicked();') do
           %span#star{ class: "fa fa-lg #{ event.favourite_users.exists?(current_user.id) ? 'fa-star' : 'fa-star-o' }", |
                       "aria-hidden" =>"true", |
-                      "data-url" => conference_program_proposal_path(@conference.short_title, event.id), |
+                      "data-url" => toogle_favorite_conference_program_proposal_path(@conference.short_title, event.id), |
                       "data-user" => current_user.id }
       = event.title
 

--- a/app/views/schedules/_schedule_item.html.haml
+++ b/app/views/schedules/_schedule_item.html.haml
@@ -7,14 +7,13 @@
 
       = canceled_replacement_event_label(event, event_schedule, 'schedule-label')
 
+      - if current_user
+        = link_to('#', onClick: 'starClicked();') do
+          %span#star{ class: "fa fa-lg #{ event.favourite_users.exists?(current_user.id) ? 'fa-star' : 'fa-star-o' }", |
+                      "aria-hidden" =>"true", |
+                      "data-url" => conference_program_proposal_path(@conference.short_title, event.id), |
+                      "data-user" => current_user.id }
       = event.title
-
-    - if current_user
-      = link_to('#', onClick: 'starClicked();') do
-        %span#star{ class: "fa fa-lg #{ event.favourite_users.exists?(current_user.id) ? 'fa-star' : 'fa-star-o' }", |
-                    "aria-hidden" =>"true", |
-                    "data-url" => conference_program_proposal_path(@conference.short_title, event.id), |
-                    "data-user" => current_user.id }
 
     - if speaker = event.speakers.first
       = image_tag speaker.gravatar_url, :class => "img-circle pull-right speaker-pic", |

--- a/app/views/schedules/_schedule_item.html.haml
+++ b/app/views/schedules/_schedule_item.html.haml
@@ -1,13 +1,20 @@
 %td.event{ width: "#{ width * span }%" , |
            colspan: span, |
            role: "button" }
-  %a.unstyled-link{href: url_for(conference_program_proposal_path(@conference.short_title, event.id))}
+  %div{ onClick: 'eventClicked(event, this);', "data-url" => "#{url_for(conference_program_proposal_path(@conference.short_title, event.id))}" }
     %div{ class: "elipsis break-words event-title", |
           style: "-webkit-line-clamp: #{ event_lines(@rooms) }; height: #{ event_height(@rooms) }px;"} |
 
       = canceled_replacement_event_label(event, event_schedule, 'schedule-label')
 
       = event.title
+
+    - if current_user
+      = link_to('#', onClick: 'starClicked();') do
+        %span#star{ class: "fa fa-lg #{ event.favourite_users.exists?(current_user.id) ? 'fa-star' : 'fa-star-o' }", |
+                    "aria-hidden" =>"true", |
+                    "data-url" => conference_program_proposal_path(@conference.short_title, event.id), |
+                    "data-user" => current_user.id }
 
     - if speaker = event.speakers.first
       = image_tag speaker.gravatar_url, :class => "img-circle pull-right speaker-pic", |

--- a/app/views/schedules/_schedule_tabs.html.haml
+++ b/app/views/schedules/_schedule_tabs.html.haml
@@ -2,6 +2,6 @@
   / Nav tabs
   %ul.nav.nav-tabs{ role: "tablist" }
     %li{ class: "schedule #{ 'active' if active == 'schedule' }", role: "presentation" }
-      = link_to('Schedule', conference_schedule_path(@conference.short_title))
+      = link_to('Schedule', conference_schedule_path(@conference.short_title, favourites: @favourites))
     %li{ class: "program #{ 'active' if active == 'program' }", role: "presentation" }
-      = link_to('All events', events_conference_schedule_path(@conference.short_title))
+      = link_to('All events', events_conference_schedule_path(@conference.short_title, favourites: @favourites))

--- a/app/views/schedules/events.html.haml
+++ b/app/views/schedules/events.html.haml
@@ -5,6 +5,13 @@
   %h1.text-center
     Program for
     = @conference.title
+  - if current_user
+    .row
+      .col-md-12.text-center
+        = button_to (@favourites ? 'All events' : 'Only favourites events'),
+                    events_conference_schedule_path(@conference.short_title),
+                    params: { favourites: !@favourites },
+                    method: :get, class: 'btn btn-success'
   .dropdown.program-dropdown
     %button{ type: "button", class: "btn btn-default dropdown-toggle", 'data-toggle' => "dropdown" }
       Dates

--- a/app/views/schedules/show.html.haml
+++ b/app/views/schedules/show.html.haml
@@ -5,6 +5,13 @@
     %h1.text-center
       Schedule for
       = @conference.title
+    - if current_user
+      .row
+        .col-md-12.text-center
+          = button_to (@favourites ? 'All events' : 'Only favourites events'),
+                      conference_schedule_path(@conference.short_title),
+                      params: { favourites: !@favourites },
+                      method: :get, class: 'btn btn-success'
     .dropdown.schedule-dropdown
       %button{ type: "button", class: "btn btn-default dropdown-toggle", 'data-toggle' => "dropdown" }
         = @day

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -115,6 +115,7 @@ Osem::Application.routes.draw do
           get :registrations
           patch '/confirm' => 'proposals#confirm'
           patch '/restart' => 'proposals#restart'
+          patch :toogle_favorite
         end
       end
     end

--- a/db/migrate/20160811143427_create_events_users.rb
+++ b/db/migrate/20160811143427_create_events_users.rb
@@ -1,0 +1,8 @@
+class CreateEventsUsers < ActiveRecord::Migration
+  def change
+    create_table :events_users, id: false do |t|
+      t.references :event
+      t.references :user
+    end
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -243,6 +243,11 @@ ActiveRecord::Schema.define(version: 20170213145807) do
     t.datetime "created_at"
   end
 
+  create_table "events_users", id: false, force: :cascade do |t|
+    t.integer "event_id"
+    t.integer "user_id"
+  end
+
   create_table "lodgings", force: :cascade do |t|
     t.string   "name"
     t.text     "description"


### PR DESCRIPTION
-   Introduce an association between User and Event
-   Make it possible to select events in both the schedule and events
-   Show the individual User schedule 

![image](https://cloud.githubusercontent.com/assets/16052290/17653127/db785720-628f-11e6-8200-696c7cc8cf88.png)

![image](https://cloud.githubusercontent.com/assets/16052290/17653135/f716fb4e-628f-11e6-8ba9-a3db4895704b.png)

There is one problem. If there are less than 7 rooms, as the speaker picture get bigger to use all the space, in devices with less than 450px weight there is not enough space for the star:

![image](https://cloud.githubusercontent.com/assets/16052290/17653115/b075b004-628f-11e6-9bc4-f80d0645b77e.png)

For less rooms or bigger devices it works fine:
![image](https://cloud.githubusercontent.com/assets/16052290/17653052/e7346984-628d-11e6-81ea-d7ebc01eb06a.png)

**Solutions**
1. Keep the speaker picture size always the same. I don't like that as the speaker picture is really important and it should be as bigger as possible.
2. Put the star at the beginning of the title. The problem with that is that the star would be a little bit smaller and that it takes a little bit of space of the title. On the other hand, it is more consistent with the all events (as there the star is before the title) and I think it looks nice. It would look like this:

![image](https://cloud.githubusercontent.com/assets/16052290/17653093/17eb0bae-628f-11e6-94f7-6fb4f42c74b7.png)

I prefer the second one. Reducing the number of lines for the title I think it is not an alternative, as the title is more important than the speaker picture and the star.
