### PR TITLE
Show all events instead of the schedule

### DIFF
--- a/app/controllers/schedules_controller.rb
+++ b/app/controllers/schedules_controller.rb
@@ -7,7 +7,7 @@ class SchedulesController < ApplicationController
   def show
     @rooms = @conference.venue.rooms if @conference.venue
     schedules = @program.selected_event_schedules
-    unless schedules
+    unless schedules && @rooms && @rooms.length > 1
       redirect_to events_conference_schedule_path(@conference.short_title)
     end
 
@@ -28,6 +28,8 @@ class SchedulesController < ApplicationController
 
   def events
     @dates = @conference.start_date..@conference.end_date
+
+    @several_rooms = @conference.venue.try(:rooms) && @conference.venue.rooms.length > 1
 
     @events_schedules = @program.selected_event_schedules
     @events_schedules = [] unless @events_schedules

--- a/app/views/schedules/events.html.haml
+++ b/app/views/schedules/events.html.haml
@@ -1,5 +1,5 @@
 .container#program
-  -if @events_schedules.any?
+  -if @events_schedules.any? && @several_rooms
     = render partial: 'schedule_tabs',  locals: { active: 'program' }
 
   %h1.text-center


### PR DESCRIPTION
Show all events instead od the schedule if there are less than 2 rooms. The schedule looks ugly with only one room:

![image](https://cloud.githubusercontent.com/assets/16052290/17773082/cb78348e-654c-11e6-8103-af9ccada0f82.png)
