### PR TITLE
Delete EventSchedules when a Room is deleted

### DIFF
--- a/app/models/room.rb
+++ b/app/models/room.rb
@@ -1,6 +1,6 @@
 class Room < ActiveRecord::Base
   belongs_to :venue
-  has_many :event_schedules, dependent: :nullify
+  has_many :event_schedules, dependent: :destroy
 
   has_paper_trail ignore: [:guid], meta: { conference_id: :conference_id }
 

--- a/spec/models/room_spec.rb
+++ b/spec/models/room_spec.rb
@@ -11,7 +11,7 @@ describe Room do
 
   describe 'association' do
     it { should belong_to(:venue) }
-    it { should have_many(:event_schedules).dependent(:nullify) }
+    it { should have_many(:event_schedules).dependent(:destroy) }
   end
 
   describe 'callback' do


### PR DESCRIPTION
We should remove all the EventSchedules that belongs_to a Room when it is deleted. Otherwise both the public and admin schedule would fail.