### PR TITLE
Remove ununsed code from events_controller#index

### DIFF
--- a/app/controllers/admin/events_controller.rb
+++ b/app/controllers/admin/events_controller.rb
@@ -19,58 +19,10 @@ module Admin
       @events = @program.events
       @tracks = @program.tracks
       @difficulty_levels = @program.difficulty_levels
-      @machine_states = @events.state_machine.states.map
       @event_types = @program.event_types
       @tracks_distribution_confirmed = @conference.tracks_distribution(:confirmed)
       @event_distribution = @conference.event_distribution
       @scheduled_event_distribution = @conference.scheduled_event_distribution
-
-      @mystates = []
-      @mytypes = []
-      @eventstats = {}
-      @totallength = 0
-
-      @machine_states.each do |mystate|
-        length = 0
-        events_mystate = @events.where('state' => mystate.name)
-        if events_mystate.count > 0
-          @mystates << mystate
-          events_mystate.each do |myevent|
-            length += myevent.event_type.length
-          end
-          @eventstats["#{mystate.name}"] = { 'count' => events_mystate.count, 'length' => length }
-        end
-      end
-
-      @event_types.each do |mytype|
-        events_mytype = @events.where('event_type_id' => mytype.id)
-        if events_mytype.count > 0
-          @mytypes << mytype
-        end
-      end
-      @mytypes.each do |mytype|
-        @mystates.each do |mystate|
-          events_mytype = @events.where('event_type_id' => mytype.id)
-          events_mytype_mystate = events_mytype.where('state' => mystate.name)
-          typelength = 0
-          if events_mytype_mystate.count > 0
-            events_mytype_mystate.each do |myevent|
-              typelength += myevent.event_type.length
-              @totallength += myevent.event_type.length
-            end
-
-            if @eventstats[mytype.title].nil?
-              @eventstats[mytype.title] = { 'count' => events_mytype.count,
-                                            'length' => events_mytype.count * mytype.length }
-            end
-
-            tmp = { "#{mystate.name}" => { 'type_state_count' => events_mytype_mystate.count,
-                                           'type_state_length' => typelength } }
-            @eventstats[mytype.title].merge!(tmp)
-          end
-        end
-      end
-      @eventstats['totallength'] = @totallength
 
       respond_to do |format|
         format.html


### PR DESCRIPTION
The use of the instance variables  @mystatesm, @mytypes, @eventstats, @totallength was removed in https://github.com/openSUSE/osem/commit/28063129c72307e3b66bd2df16ca8497bd82fdfa