### PR TITLE
Overlapping

### DIFF
--- a/app/assets/javascripts/osem-switch.js
+++ b/app/assets/javascripts/osem-switch.js
@@ -23,7 +23,7 @@ $(function () {
     }
 
     var callback = function(data) {
-      showError($.parseJSON(data.responseText).errors);
+      showMessage($.parseJSON(data.responseText).errors, 'error');
     }
     $.ajax({
       url: url,

--- a/app/controllers/admin/event_schedules_controller.rb
+++ b/app/controllers/admin/event_schedules_controller.rb
@@ -6,7 +6,7 @@ module Admin
       if @event_schedule.save
         render json: { event_schedule_id: @event_schedule.id }
       else
-        render json: { errors: "The event couldn't be scheduled. #{@event_schedule.errors.full_messages.join('. ')}" }, status: 422
+        render json: { errors: parse_errors(@event_schedule) }, status: 422
       end
     end
 
@@ -14,7 +14,7 @@ module Admin
       if @event_schedule.update(event_schedule_params)
         render json: { event_schedule_id: @event_schedule.id }
       else
-        render json: { errors: "The event couldn't be scheduled. #{@event_schedule.errors.full_messages.join('. ')}" }, status: 422
+        render json: { errors: parse_errors(@event_schedule) }, status: 422
       end
     end
 
@@ -22,7 +22,7 @@ module Admin
       if @event_schedule.destroy
         render json: {}
       else
-        render json: { errors: "The event couldn't be unscheduled. #{@event_schedule.errors.full_messages.join('. ')}" }, status: 422
+        render json: { errors: parse_errors(@event_schedule) }, status: 422
       end
     end
 
@@ -30,6 +30,12 @@ module Admin
 
     def event_schedule_params
       params.require(:event_schedule).permit(:schedule_id, :event_id, :room_id, :start_time)
+    end
+
+    def parse_errors(event_schedule)
+      title = event_schedule.event.try(:title).present? ? event_schedule.event.title : 'The event'
+      errors = event_schedule.errors.full_messages.present? ? " (#{event_schedule.errors.full_messages.join('. ')})" : ''
+      "#{title} couldn't be scheduled#{errors}. "
     end
   end
 end

--- a/app/controllers/admin/event_schedules_controller.rb
+++ b/app/controllers/admin/event_schedules_controller.rb
@@ -2,40 +2,40 @@ module Admin
   class EventSchedulesController < Admin::BaseController
     load_and_authorize_resource :event_schedule
 
-    def create
-      if @event_schedule.save
-        render json: { event_schedule_id: @event_schedule.id }
-      else
-        render json: { errors: parse_errors(@event_schedule) }, status: 422
-      end
-    end
-
-    def update
-      if @event_schedule.update(event_schedule_params)
-        render json: { event_schedule_id: @event_schedule.id }
-      else
-        render json: { errors: parse_errors(@event_schedule) }, status: 422
-      end
-    end
-
-    def destroy
-      if @event_schedule.destroy
+    def bulk_create
+      result = EventSchedule.create(params[:event_schedules].values).reject { |p| p.errors.empty? }
+      if result.empty?
         render json: {}
       else
-        render json: { errors: parse_errors(@event_schedule) }, status: 422
+        event_names = result.collect { |event_schedule| event_schedule.event.try(:title) }
+        render json: { errors: event_names.to_s }, status: 422
       end
     end
 
-    private
-
-    def event_schedule_params
-      params.require(:event_schedule).permit(:schedule_id, :event_id, :room_id, :start_time)
+    def bulk_update
+      keys = []
+      values = []
+      params[:event_schedules].values.each do |e|
+        keys << e.keys[0]
+        values << e.values[0]
+      end
+      result = EventSchedule.update(keys, values).reject { |p| p.errors.empty? }
+      if result.empty?
+        render json: {}
+      else
+        event_names = result.collect { |event_schedule| event_schedule.event.try(:title) }
+        render json: { errors: event_names.to_s }, status: 422
+      end
     end
 
-    def parse_errors(event_schedule)
-      title = event_schedule.event.try(:title).present? ? event_schedule.event.title : 'The event'
-      errors = event_schedule.errors.full_messages.present? ? " (#{event_schedule.errors.full_messages.join('. ')})" : ''
-      "#{title} couldn't be scheduled#{errors}. "
+    def bulk_destroy
+      result = EventSchedule.destroy(params[:event_schedules].values).reject { |p| p.errors.empty? }
+      if result.empty?
+        render json: {}
+      else
+        event_names = result.collect { |event_schedule| event_schedule.event.try(:title) }
+        render json: { errors: event_names.to_s }, status: 422
+      end
     end
   end
 end

--- a/app/views/admin/schedules/_day_tab.html.haml
+++ b/app/views/admin/schedules/_day_tab.html.haml
@@ -5,17 +5,22 @@
       .room-name
         - room_date_event_schedules = date_event_schedules.select{ |e| e.room == room }
         = room.name
+        - cells_with_event = 0
       - (9*4..18*4).each do |slot|
         - hour = slot / 4
         - minutes = (15 * (slot % 4) == 0) ? '00' : 15 * (slot % 4)
         - time = "#{hour}:#{minutes}"
-        .schedule-room-slot{ id: "schedule-room-#{room.guid}-#{hour}-#{minutes}", |
-                             room_id: room.id, |
-                             hour: time, |
-                             date: date}
+        - event_schedules = room_date_event_schedules.select{ |e| (e.start_time.hour.to_s + e.start_time.strftime(':%M')).eql? time }
+        - if event_schedules.any?
+          - event_schedule = event_schedules.first
+          - cells_with_event = event_schedule.event.event_type.length / EventType::LENGTH_STEP
+        %div{ class: "schedule-room-slot #{'with-event' if cells_with_event > 0}", |
+              id: "schedule-room-#{room.guid}-#{hour}-#{minutes}", |
+              room_id: room.id, |
+              hour: time, |
+              date: date}
           .div
             = time
-          - event_schedules = room_date_event_schedules.select{ |e| (e.start_time.hour.to_s + e.start_time.strftime(':%M')).eql? time }
-          - if event_schedules.any?
-            - event_schedule = event_schedules.first
+          - if event_schedule
             = render partial: 'event', locals: { event: event_schedule.event, event_schedule_id: event_schedule.id}
+        - (cells_with_event = cells_with_event - 1) if cells_with_event > 0

--- a/app/views/admin/schedules/show.html.haml
+++ b/app/views/admin/schedules/show.html.haml
@@ -17,6 +17,8 @@
                                           off_color: 'warning',
                                           on_text: 'Yes',
                                           off_text: 'No' }
+      %button.btn.btn-success.schedule-save
+        Save
       .h4
         Unscheduled events
       .unscheduled-events

--- a/app/views/admin/schedules/show.html.haml
+++ b/app/views/admin/schedules/show.html.haml
@@ -4,8 +4,14 @@
   .col-md-12
     .page-header
       %h1 Schedule
-      %p.text-muted
-        Create the schedules for the conference
+      .row
+        .col-md-10.col-xs-8
+          %p.text-muted
+            Create the schedules for the conference
+        .col-md-2.col-xs-4
+          .text-right
+            %button.btn.btn-success.schedule-save
+              Save
 
 - if @rooms.present?
   .row
@@ -17,8 +23,6 @@
                                           off_color: 'warning',
                                           on_text: 'Yes',
                                           off_text: 'No' }
-      %button.btn.btn-success.schedule-save
-        Save
       .h4
         Unscheduled events
       .unscheduled-events
@@ -34,6 +38,10 @@
         - @dates.each do |date|
           .tab-pane{ class: "#{ (@dates.first == date) ? 'active' : '' }", id: "#{date}" }
             = render partial: 'day_tab', locals: { date: date }
+  .row
+    .col-md-12.text-right
+      %button.btn.btn-success.schedule-save
+        Save
 - else
   .h3
     No Rooms!

--- a/app/views/admin/schedules/show.html.haml
+++ b/app/views/admin/schedules/show.html.haml
@@ -51,5 +51,13 @@
 
 :javascript
   $(document).ready( function() {
-    Schedule.initialize("#{admin_conference_event_schedules_path(@conference)}", "#{@schedule.id}");
+    // When reload the page after saving, show flash messages in the url.
+    var url = window.location.href;
+    if (url.indexOf("?") > 0){
+      var params = (url.split("?"))[1].split(/[&=]/);
+      if(params[0] == 'flash' && params[2] == 'type')
+        showMessage(decodeURI(params[1]), params[3]);
+    }
+
+    Schedule.initialize("#{@conference.short_title}", "#{@schedule.id}");
   });

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -28,7 +28,9 @@ Osem::Application.routes.draw do
     resources :conferences do
       resource :contact, except: [:index, :new, :create, :show, :destroy]
       resources :schedules, only: [:index, :create, :show, :update, :destroy]
-      resources :event_schedules, only: [:create, :update, :destroy]
+      post '/bulk_create' => 'event_schedules#bulk_create'
+      post '/bulk_update' => 'event_schedules#bulk_update'
+      post '/bulk_destroy' => 'event_schedules#bulk_destroy'
       get 'commercials/render_commercial' => 'commercials#render_commercial'
       resources :commercials, only: [:index, :create, :update, :destroy]
       get '/volunteers_list' => 'volunteers#show'

--- a/spec/controllers/admin/event_schedules_controller_spec.rb
+++ b/spec/controllers/admin/event_schedules_controller_spec.rb
@@ -4,30 +4,39 @@ describe Admin::EventSchedulesController do
   let(:venue) { create(:venue) }
   let(:conference) { create(:conference, venue: venue) }
   let(:room) { create(:room, venue: venue) }
-  let(:schedule) { create(:schedule, program: conference.program)}
-  let(:event_schedule) { create(:event_schedule, schedule: schedule)}
+  let(:schedule) { create(:schedule, program: conference.program) }
   let!(:organizer_role) { Role.find_by(name: 'organizer', resource: conference) }
   let(:organizer) { create(:user, role_ids: organizer_role.id) }
 
   context 'logged in as an organizer' do
     before :each do
       sign_in(organizer)
-      event_schedule
     end
 
     describe 'POST #create' do
       context 'with valid attributes' do
+        let(:event1) { create(:event, program: conference.program) }
+        let(:event2) { create(:event, program: conference.program) }
         let(:create_action) do
-          post :create, conference_id: conference.short_title, event_schedule:
-               attributes_for(:event_schedule,
-                              schedule_id: schedule.id,
-                              event_id: create(:event, program: conference.program).id,
-                              room_id: create(:room, venue: venue).id,
-                              start_time: conference.start_date)
+          post :bulk_create, conference_id: conference.short_title,
+                             event_schedules: {
+                               event1.id => {
+                                 schedule_id: schedule.id,
+                                 event_id: event1.id,
+                                 room_id: create(:room, venue: venue).id,
+                                 start_time: conference.start_date
+                               },
+                               event2.id => {
+                                 schedule_id: schedule.id,
+                                 event_id: event2.id,
+                                 room_id: create(:room, venue: venue).id,
+                                 start_time: conference.start_date
+                               }
+                             }
         end
 
         it 'saves the event schedule to the database' do
-          expect{ create_action }.to change { EventSchedule.count }.by 1
+          expect{ create_action }.to change { EventSchedule.count }.by 2
         end
 
         it 'has 200 status code' do
@@ -37,14 +46,17 @@ describe Admin::EventSchedulesController do
       end
 
       context 'with invalid attributes' do
-
+        let(:event1) { create(:event, program: conference.program) }
         let(:create_action) do
-          post :create, conference_id: conference.short_title, event_schedule:
-               attributes_for(:event_schedule,
-                              schedule_id: schedule.id,
-                              event_id: nil,
-                              room_id: nil,
-                              start_time: nil)
+          post :bulk_create, conference_id: conference.short_title,
+                             event_schedules: {
+                               event1.id => {
+                                 schedule_id: schedule.id,
+                                 event_id: event1.id,
+                                 room_id: nil,
+                                 start_time: nil
+                               }
+                             }
         end
 
         it 'does not save the event schedule to the database' do
@@ -60,22 +72,38 @@ describe Admin::EventSchedulesController do
 
     describe 'POST #update' do
       context 'with valid attributes' do
+        let(:event1) { create(:event, program: conference.program) }
+        let(:event2) { create(:event, program: conference.program) }
+        let(:event_schedule1) { create(:event_schedule, schedule: schedule, event: event1) }
+        let(:event_schedule2) { create(:event_schedule, schedule: schedule, event: event2) }
         before :each do
-          patch :update, id: event_schedule.id, conference_id: conference.short_title, event_schedule:
-                 attributes_for(:event_schedule,
-                                schedule_id: schedule.id,
-                                event_id: create(:event, program: conference.program).id,
-                                room_id: room.id,
-                                start_time: conference.start_date)
-          event_schedule.reload
+          post :bulk_update, conference_id: conference.short_title,
+                             event_schedules: {
+                               event1.id => {
+                                 event_schedule1.id => {
+                                   room_id: room.id,
+                                   start_time: conference.start_date
+                                 }
+                               },
+                               event2.id => {
+                                 event_schedule2.id => {
+                                   room_id: room.id,
+                                   start_time: conference.start_date + 1.day
+                                 }
+                               }
+                             }
+          event_schedule1.reload
+          event_schedule2.reload
         end
 
         it 'updates the room' do
-          expect(event_schedule.room_id).to eq(room.id)
+          expect(event_schedule1.room_id).to eq(room.id)
+          expect(event_schedule2.room_id).to eq(room.id)
         end
 
         it 'updates the start_time' do
-          expect(event_schedule.start_time).to eq(conference.start_date)
+          expect(event_schedule1.start_time).to eq(conference.start_date)
+          expect(event_schedule2.start_time).to eq(conference.start_date + 1.day)
         end
 
         it 'has 200 status code' do
@@ -84,13 +112,18 @@ describe Admin::EventSchedulesController do
       end
 
       context 'with invalid attributes' do
+        let(:event) { create(:event, program: conference.program) }
+        let(:event_schedule) { create(:event_schedule, schedule: schedule, event: event) }
         let(:update_action) do
-          patch :update, id: event_schedule.id, conference_id: conference.short_title, event_schedule:
-               attributes_for(:event_schedule,
-                              schedule_id: schedule.id,
-                              event_id: nil,
-                              room_id: nil,
-                              start_time: nil)
+          post :bulk_update, conference_id: conference.short_title,
+                             event_schedules: {
+                               event.id => {
+                                 event_schedule.id => {
+                                   room_id: nil,
+                                   start_time: nil
+                                 }
+                               }
+                             }
         end
         it 'does not save the event schedule to the database' do
           expect{ update_action }.to_not change { event_schedule }
@@ -104,12 +137,22 @@ describe Admin::EventSchedulesController do
     end
 
     describe 'DELETE #destroy' do
+      let(:event1) { create(:event, program: conference.program) }
+      let(:event2) { create(:event, program: conference.program) }
+      let(:event_schedule1) { create(:event_schedule, schedule: schedule, event: event1) }
+      let(:event_schedule2) { create(:event_schedule, schedule: schedule, event: event2) }
       let(:destroy_action) do
-        delete :destroy, id: event_schedule.id, conference_id: conference.short_title
+        post :bulk_destroy, conference_id: conference.short_title,
+                            event_schedules: {
+                              event1.id => event_schedule1,
+                              event2.id => event_schedule2
+                            }
       end
 
       it 'deletes the event schedule' do
-        expect{ destroy_action }.to change { EventSchedule.count }.by(-1)
+        event_schedule1.reload
+        event_schedule2.reload
+        expect{ destroy_action }.to change { EventSchedule.count }.by(-2)
       end
 
       it 'has 200 status code' do

--- a/spec/models/event_schedule_spec.rb
+++ b/spec/models/event_schedule_spec.rb
@@ -17,5 +17,32 @@ describe EventSchedule do
     it { is_expected.to validate_presence_of(:event) }
     it { is_expected.to validate_presence_of(:room) }
     it { is_expected.to validate_presence_of(:start_time) }
+
+    describe '#not_overlapping' do
+      let!(:event) { create(:event, event_type: create(:event_type, length: 60)) }
+      let!(:event2) { create(:event, event_type: create(:event_type, length: 30), program: event.program) }
+      let!(:schedule) { create(:schedule, program: event.program) }
+      let!(:room) { create(:room, venue: create(:venue, conference: event.program.conference)) }
+      let!(:event_schedule) { create(:event_schedule, schedule: schedule, event: event, room: room, start_time: event.program.conference.start_date.tomorrow.to_time + 60.minutes) }
+
+      describe "can't be scheduled at the same time than other event in the same room" do
+        it 'case 1' do
+          expect(build(:event_schedule, schedule: schedule, event: event2, room: room, start_time: event_schedule.start_time - 15.minutes)).to_not be_valid
+        end
+
+        it 'case 2' do
+          expect(build(:event_schedule, schedule: schedule, event: event2, room: room, start_time: event_schedule.start_time + 45.minutes)).to_not be_valid
+        end
+
+        it 'case 3' do
+          expect(build(:event_schedule, schedule: schedule, event: event2, room: room, start_time: event_schedule.start_time + 15.minutes)).to_not be_valid
+        end
+
+        it 'case 4' do
+          event2.event_type = create(:event_type, length: 120)
+          expect(build(:event_schedule, schedule: schedule, event: event2, room: room, start_time: event_schedule.start_time - 30.minutes)).to_not be_valid
+        end
+      end
+    end
   end
 end


### PR DESCRIPTION
**Branch copied from #1106, so maybe I have to change this if #1106 changes.**

Not allow that an event is scheduled at the same time than other event in the admin schedule, as previously:

![image](https://cloud.githubusercontent.com/assets/16052290/17876232/dadd3048-68d8-11e6-8d70-210c018996f2.png)

I've also added a validation to avoid that this happens when scheduling in different tabs. I've added tests for this validation with four cases that are representative.
