### PR TITLE
Add new page with organizer reports

### DIFF
--- a/app/controllers/admin/events_controller.rb
+++ b/app/controllers/admin/events_controller.rb
@@ -144,6 +144,10 @@ module Admin
       @events_commercials = Commercial.where(commercialable_type: 'Event', commercialable_id: @events.pluck(:id))
       @events_missing_commercial = @events.where.not(id: @events_commercials.pluck(:commercialable_id))
       @events_with_requirements = @events.where.not(description: ['', nil])
+
+      attended_registrants_ids = @conference.registrations.where(attended: true).pluck(:user_id)
+      @missing_event_speakers = EventUser.joins(:event).where('event_role = ? and program_id = ?', 'submitter', @program.id).
+                                                                                        where.not(user_id: attended_registrants_ids).includes(:user, :event)
     end
 
     private

--- a/app/controllers/admin/events_controller.rb
+++ b/app/controllers/admin/events_controller.rb
@@ -5,7 +5,7 @@ module Admin
     load_and_authorize_resource :event, through: :program
     load_and_authorize_resource :events_registration, only: :toggle_attendance
 
-    before_action :get_event, except: [:index, :create]
+    before_action :get_event, except: [:index, :create, :reports]
 
     # FIXME: The timezome should only be applied on output, otherwise
     # you get lost in timezone conversions...
@@ -137,6 +137,13 @@ module Admin
       else
         head :unprocessable_entity
       end
+    end
+
+    def reports
+      @events = @program.events
+      @events_commercials = Commercial.where(commercialable_type: 'Event', commercialable_id: @events.pluck(:id))
+      @events_missing_commercial = @events.where.not(id: @events_commercials.pluck(:commercialable_id))
+      @events_with_requirements = @events.where.not(description: ['', nil])
     end
 
     private

--- a/app/views/admin/events/reports.html.haml
+++ b/app/views/admin/events/reports.html.haml
@@ -13,6 +13,12 @@
         %span.label.label-success{style: 'border-radius: 1em;'}
           = @events_with_requirements.length
 
+    %li
+      %a{href: '#missing-speakers', 'data-toggle' => 'tab'}
+        Missing Speakers
+        %span.label.label-danger{style: 'border-radius: 1em;'}
+          = @missing_event_speakers.length
+
   .tab-content
     #all.tab-pane.active
       .row
@@ -94,3 +100,28 @@
                 %td= link_to event.title, edit_conference_program_proposal_path(@conference.short_title, event)
                 %td  #{event.speaker_names}
                 %td= event.description
+
+    #missing-speakers.tab-pane
+      .row
+        .col-md-12
+          .page-header
+            %h1
+              Missing Speakers
+              = "(#{@missing_event_speakers.length})"
+            %p.text-muted
+              All event speakers who haven't checked in
+      .col-md-12
+        %table.table.table-striped.table-bordered.table-hover.datatable
+          %thead
+            %th Speaker Name
+            %th Registered?
+            %th Event
+            %th Start Time
+          %tbody
+            - @missing_event_speakers.each do |speaker|
+              %tr
+                %td= speaker.user.name
+                %td= @conference.user_registered?(speaker.user) ? 'Yes' : 'No'
+                %td= link_to speaker.event.title, edit_conference_program_proposal_path(@conference.short_title, speaker.event)
+                - event_start_time = speaker.event.time
+                %td= event_start_time.present? ? event_start_time : '-'

--- a/app/views/admin/events/reports.html.haml
+++ b/app/views/admin/events/reports.html.haml
@@ -1,0 +1,96 @@
+.tabbable
+  %ul.nav.nav-tabs
+    %li.active
+      = link_to 'All Events', '#all', 'data-toggle' => 'tab'
+    %li
+      %a{href: '#missing-commercial', 'data-toggle' => 'tab'}
+        Events without Commercials
+        %span.label.label-danger{style: 'border-radius: 1em;'}
+          = @events_missing_commercial.length
+    %li
+      %a{href: '#requirements', 'data-toggle' => 'tab'}
+        Speaker Requirements
+        %span.label.label-success{style: 'border-radius: 1em;'}
+          = @events_with_requirements.length
+
+  .tab-content
+    #all.tab-pane.active
+      .row
+        .col-md-12
+          .page-header
+            %h1
+              All Events
+              = "(#{@events.length})"
+            %p.text-muted
+              All submissions and the information that they are mssing
+
+      .col-md-12
+        %table.table.table-striped.table-bordered.table-hover.datatable
+          %thead
+            %th Title
+            %th Submitter Registered
+            %th Submitter Biography
+            %th Commercial
+            %th Subtitle
+            %th Difficulty Level
+            - if @program.tracks.any?
+              %th Track
+          %tbody
+            - @events.each do |event|
+              %tr
+                - progress_status = event.progress_status
+                %td
+                  = link_to event.title, edit_conference_program_proposal_path(@conference.short_title, event)
+                  %br
+                  .small (Presented by #{event.speaker_names})
+
+                - %w(registered biography commercials subtitle difficulty_level).each do |info|
+                  %td{'data-order' => "#{progress_status[info]}"}
+                    %span{class: class_for_todo(progress_status[info])}
+                      %span{class: [icon_for_todo(progress_status[info]), 'fa-lg']}
+                - if @program.tracks.any?
+                  %td{'data-order' => "#{progress_status['track']}"}
+                    %span{class: class_for_todo(progress_status['track'])}
+                      %span{class: [icon_for_todo(progress_status['track']), 'fa-lg']}
+
+    #missing-commercial.tab-pane
+      .row
+        .col-md-12
+          .page-header
+            %h1
+              Events without commercials
+              = "(#{@events_missing_commercial.length})"
+            %p.text-muted
+              All submissions that have no commercial
+      .col-md-12
+        %table.table.table-striped.table-bordered.table-hover.datatable
+          %thead
+            %th Title
+            %th Speaker(s)
+          %tbody
+            - @events_missing_commercial.each do |event|
+              %tr
+                %td= link_to event.title, edit_conference_program_proposal_path(@conference.short_title, event)
+                %td  #{event.speaker_names}
+
+    #requirements.tab-pane
+      .row
+        .col-md-12
+          .page-header
+            %h1
+              Requirements
+              = "(#{@events_with_requirements.length})"
+            %p.text-muted
+              All submissions where the speakers have special requirements
+      .col-md-12
+        %table.table.table-striped.table-bordered.table-hover.datatable
+          %thead
+            %th Title
+            %th Speaker(s)
+            %th Requirements
+          %tbody
+            - @events_with_requirements.each do |event|
+              %tr
+                %td= link_to event.title, edit_conference_program_proposal_path(@conference.short_title, event)
+                %td  #{event.speaker_names}
+                %td= event.description

--- a/app/views/layouts/_admin_sidebar.html.haml
+++ b/app/views/layouts/_admin_sidebar.html.haml
@@ -84,6 +84,9 @@
           - if can? :update, @conference.program.schedules.build
             %li{class: active_nav_li(admin_conference_schedules_path(@conference.short_title))}
               = link_to 'Schedules', admin_conference_schedules_path(@conference.short_title)
+          - if can? :update, @conference.program.events.build
+            %li{:class=> active_nav_li(reports_admin_conference_program_path(@conference.short_title))}
+              = link_to 'Reports', reports_admin_conference_program_path(@conference.short_title)
 
   - if can? :update, Registration.new(conference_id: @conference.id)
     %li{:class=> active_nav_li(admin_conference_registrations_path(@conference.short_title))}

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -69,6 +69,7 @@ Osem::Application.routes.draw do
             get :vote
           end
         end
+        get 'reports' => 'events#reports'
       end
 
       resources :tickets


### PR DESCRIPTION
As suggested by @differentreality here https://github.com/openSUSE/osem/pull/1114#issuecomment-241228744 this PR adds a new admin side bar item 'Reports'
that displays
- All events and what they are missing (commercial, difficulty level, track, subtitle etc)
- List of events that have no commercials
- List of events where speakers had requirements (event.description)  
  Solves issue #1155 

![all_events](https://cloud.githubusercontent.com/assets/7537349/17889990/b08d5444-6950-11e6-8882-d0decbb558ea.png)
![commercials](https://cloud.githubusercontent.com/assets/7537349/17889988/b06cbca2-6950-11e6-9ebb-76cff5db1bc7.png)
![speaker_requirements](https://cloud.githubusercontent.com/assets/7537349/17889989/b0716a22-6950-11e6-83ec-408321b60bdb.png)
