### PR TITLE
using sprockets-rails instead of quiet-assets

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -187,6 +187,9 @@ gem 'factory_girl_rails'
 # for integrating Stripe payment gateway
 gem 'stripe'
 
+# Provides Sprockets implementation for Rails Asset Pipeline
+gem 'sprockets-rails'
+
 # Use guard and spring for testing in development
 group :development do
   # to launch specs when files are modified
@@ -194,8 +197,6 @@ group :development do
   gem 'spring-commands-rspec'
   # for static code analisys
   gem 'rubocop', require: false
-  # to silence rack assests messages
-  gem 'quiet_assets'
   # as database
   gem 'sqlite3'
   # to open mails

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -338,8 +338,6 @@ GEM
       coderay (~> 1.0)
       method_source (~> 0.8)
       slop (~> 3.4)
-    quiet_assets (1.0.2)
-      railties (>= 3.1, < 5.0)
     rack (1.6.4)
     rack-openid (1.3.1)
       rack (>= 1.1.0)
@@ -597,7 +595,6 @@ DEPENDENCIES
   piwik_analytics (~> 1.0.1)
   poltergeist
   prawn_rails
-  quiet_assets
   rails (~> 4.2)
   rails-assets-bootstrap-markdown!
   rails-assets-date.format!
@@ -624,6 +621,7 @@ DEPENDENCIES
   sass-rails (>= 4.0.2)
   shoulda-matchers
   spring-commands-rspec
+  sprockets-rails
   sqlite3
   stripe
   stripe-ruby-mock

--- a/config/environments/development.rb
+++ b/config/environments/development.rb
@@ -34,6 +34,9 @@ Osem::Application.configure do
   # Do not eager load code on boot.
   config.eager_load = false
 
+  # Do not log asset requests
+  config.assets.quiet = true
+
   # Set the detault url for action mailer
   config.action_mailer.default_url_options = { host: (ENV['OSEM_HOSTNAME'] || 'localhost:3000') }
 


### PR DESCRIPTION
Gem `quiet_assets` is deprecated. This PR uses `sprocket-rails` instead of quiet assets to mute the log messages.
