### PR TITLE
Event Page Comments

### DIFF
--- a/app/views/admin/events/index.html.haml
+++ b/app/views/admin/events/index.html.haml
@@ -158,3 +158,5 @@
                     %span.caret
                   %ul.dropdown-menu{:role=>"menu"}
                     = render 'change_state_dropdown', event: event
+            %td.text-center
+              = link_to "#{event.comment_threads.count}", admin_conference_program_event_path(@conference.short_title, event), anchor: 'comments-div'


### PR DESCRIPTION
#1135 View Comments in Events List - added comments column to Events Index on Admin Dashboard. Number of comments for each event are displayed with a link to event page (proposal partial).

<img width="1436" alt="screen shot 2016-08-29 at 2 30 48 pm" src="https://cloud.githubusercontent.com/assets/6282795/18132889/7ef695fa-6f66-11e6-9cda-b7f5f302eba8.png">
