### PR TITLE
Remove unnecessary code from conference_controller

### DIFF
--- a/app/controllers/admin/conference_controller.rb
+++ b/app/controllers/admin/conference_controller.rb
@@ -79,7 +79,6 @@ module Admin
     end
 
     def update
-      @conference = Conference.find_by(short_title: params[:id])
       short_title = @conference.short_title
       @conference.assign_attributes(conference_params)
       send_mail_on_conf_update = @conference.notify_on_dates_changed?


### PR DESCRIPTION
Remove unnecessary code from conference_controller#update.

`@conference = Conference.find_by(short_title: params[:id])` is not needed as it is loaded in https://github.com/Ana06/osem/blob/2fc19f1b6c67e56409de6333d0f0661ec0427add/app/controllers/admin/conference_controller.rb#L3