### PR TITLE
Support JSONP callbacks for the API/v1 endpoints

### DIFF
--- a/app/controllers/api/v1/conferences_controller.rb
+++ b/app/controllers/api/v1/conferences_controller.rb
@@ -5,11 +5,11 @@ module Api
       respond_to :json
 
       def index
-        render json: @conferences, serializer: ConferencesArraySerializer
+        render json: @conferences, serializer: ConferencesArraySerializer, callback: params['callback']
       end
 
       def show
-        render json: [@conference], serializer: ConferencesArraySerializer
+        render json: [@conference], serializer: ConferencesArraySerializer, callback: params['callback']
       end
     end
   end

--- a/app/controllers/api/v1/conferences_controller.rb
+++ b/app/controllers/api/v1/conferences_controller.rb
@@ -4,6 +4,9 @@ module Api
       load_resource find_by: :short_title
       respond_to :json
 
+      # Disable forgery protection for any json requests. This is required for jsonp support
+      skip_before_action :verify_authenticity_token
+
       def index
         render json: @conferences, serializer: ConferencesArraySerializer, callback: params['callback']
       end

--- a/app/controllers/api/v1/events_controller.rb
+++ b/app/controllers/api/v1/events_controller.rb
@@ -4,6 +4,9 @@ module Api
       load_resource :conference, find_by: :short_title
       respond_to :json
 
+      # Disable forgery protection for any json requests. This is required for jsonp support
+      skip_before_action :verify_authenticity_token
+
       def index
         events = Event.includes(:track, :event_type, event_users: :user)
 

--- a/app/controllers/api/v1/events_controller.rb
+++ b/app/controllers/api/v1/events_controller.rb
@@ -11,7 +11,7 @@ module Api
           events = events.where(program: @conference.program)
         end
 
-        respond_with events.confirmed
+        respond_with events.confirmed, callback: params[:callback]
       end
     end
   end

--- a/app/controllers/api/v1/rooms_controller.rb
+++ b/app/controllers/api/v1/rooms_controller.rb
@@ -6,9 +6,9 @@ module Api
 
       def index
         if @conference
-          respond_with @conference.venue ? @conference.venue.rooms : Room.none
+          respond_with @conference.venue ? @conference.venue.rooms : Room.none, callback: params[:callback]
         else
-          respond_with Room.all
+          respond_with Room.all, callback: params[:callback]
         end
       end
     end

--- a/app/controllers/api/v1/rooms_controller.rb
+++ b/app/controllers/api/v1/rooms_controller.rb
@@ -4,6 +4,9 @@ module Api
       load_resource :conference, find_by: :short_title
       respond_to :json
 
+      # Disable forgery protection for any json requests. This is required for jsonp support
+      skip_before_action :verify_authenticity_token
+
       def index
         if @conference
           respond_with @conference.venue ? @conference.venue.rooms : Room.none, callback: params[:callback]

--- a/app/controllers/api/v1/speakers_controller.rb
+++ b/app/controllers/api/v1/speakers_controller.rb
@@ -4,6 +4,9 @@ module Api
       load_resource :conference, find_by: :short_title
       respond_to :json
 
+      # Disable forgery protection for any json requests. This is required for jsonp support
+      skip_before_action :verify_authenticity_token
+
       def index
         if @conference
           users = User.joins(event_users: { event: { program: :conference} })

--- a/app/controllers/api/v1/speakers_controller.rb
+++ b/app/controllers/api/v1/speakers_controller.rb
@@ -13,7 +13,7 @@ module Api
         end
 
         users = users.where(event_users: {event_role: :speaker}).uniq
-        render json: users, each_serializer: SpeakerSerializer
+        render json: users, each_serializer: SpeakerSerializer, callback: params['callback']
       end
     end
   end

--- a/app/controllers/api/v1/tracks_controller.rb
+++ b/app/controllers/api/v1/tracks_controller.rb
@@ -7,7 +7,7 @@ module Api
       def index
         tracks = @conference ? @conference.program.tracks : Track.all
 
-        respond_with tracks
+        respond_with tracks, callback: params[:callback]
       end
     end
   end

--- a/app/controllers/api/v1/tracks_controller.rb
+++ b/app/controllers/api/v1/tracks_controller.rb
@@ -4,6 +4,9 @@ module Api
       load_resource :conference, find_by: :short_title
       respond_to :json
 
+      # Disable forgery protection for any json requests. This is required for jsonp support
+      skip_before_action :verify_authenticity_token
+
       def index
         tracks = @conference ? @conference.program.tracks : Track.all
 


### PR DESCRIPTION
SeaGL currently uses OSEM as a backend, but still has a static website
serving as our public interface. The API endpoints have a great amount
of data, but without the jsonp callback paramater, embedding the data
is a bit difficult. This change just adds the jsonp callback param
to all the API endpoints. This should be a NOOP for anyone using direct
json calls, but will allow cross domain requests that require jsonp.