### PR TITLE
Fix event type description display on proposals#new and proposals#edit

### DIFF
--- a/app/views/proposals/_proposal_form.html.haml
+++ b/app/views/proposals/_proposal_form.html.haml
@@ -23,9 +23,6 @@
       %span{ class: 'help-block select-help-text event_event_type_id collapse', id: "#{event_type.id}-help" }
         = event_type.description
 
-    :javascript
-      $("##{@conference.program.event_types.first.id}-help").collapse('show');
-
     = f.input :difficulty_level, as: :select, collection: @conference.program.difficulty_levels, input_html: { class: 'select-help-toggle' },
       include_blank: '(Please select)' if @conference.program.difficulty_levels.any?
 

--- a/app/views/proposals/new.html.haml
+++ b/app/views/proposals/new.html.haml
@@ -40,9 +40,6 @@
                 %span{ class: 'help-block event_event_type_id collapse', id: "#{event_type.id}-help" }
                   = event_type.description
 
-              :javascript
-                $("##{@program.event_types.first.id}-help").collapse('show');
-
               = f.input :abstract, required: true, input_html: { rows: 5, data: { provide: 'markdown-editable' } },
                 hint: markdown_hint(link_to('Tips to improve your presentations.', 'http://blog.hubspot.com/blog/tabid/6307/bid/5975/10-Rules-to-Instantly-Improve-Your-Presentations.aspx'))
 


### PR DESCRIPTION
Fix #1208  

On load the correct event type description is displayed by osem.js:166 when the dropdown value is set. Re-showing the text would be harmless, but it triggers a change event listener [here](https://github.com/openSUSE/osem/blob/7cc2609662dd6e1c581c74a36c87edd57e6b82ab/app/assets/javascripts/osem.js#L34-L39)

Just removing these lines seems to display the description correctly for different event types and renders from errors, on both `proposals#new` and `proposals#edit`.
