### PR TITLE
fixed #1096

### DIFF
--- a/app/assets/javascripts/application.js
+++ b/app/assets/javascripts/application.js
@@ -54,4 +54,8 @@ $(document).ready(function() {
     $('body').smoothScroll({
         delegateSelector: 'a.smoothscroll'
     });
+    // Navbar collapse when clicked elsewhere
+    $('.navbar-toggle').blur(function() {
+        $(this).click();
+    });
 });


### PR DESCRIPTION
In mobile screen , when the navbar hamburger(menu) btn is clicked , it expands , but it only collapse when the user clicks on that button only. So I have made this improvement in which it also collapse when the user clicks anywhere on the screen . Thus I think it improves UX . (Maybe you have seen this behaviour for modals in which on clicking outside the modal it disappears .) 
