### PR TITLE
Avoid a Javascript error when @tag is null

### DIFF
--- a/app/views/schedules/events.html.haml
+++ b/app/views/schedules/events.html.haml
@@ -61,5 +61,8 @@
 
   // Go to current date and time
   $(document).ready(function(){
-    document.getElementById("#{ @tag }").scrollIntoView();
+    tag = "#{ @tag }";
+    if(tag !== ""){
+      document.getElementById(tag).scrollIntoView();
+    }
   });


### PR DESCRIPTION
As it was pointed out in https://github.com/openSUSE/osem/pull/1142 if `@tag` is `null` there is an error in the Console when trying to take the user to the current day and time.