### PR TITLE
Find correct event id in versions

### DIFF
--- a/app/views/admin/versions/_object_desc_and_link.html.haml
+++ b/app/views/admin/versions/_object_desc_and_link.html.haml
@@ -45,7 +45,7 @@
 - when 'EventsRegistration', 'Comment', 'Vote', 'Event'
   = 'event'
   - object = current_or_last_object_state(version.item_type, version.item_id)
-  - event_id = object.try(:id) || object.try(:event_id) || object.commentable_id
+  - event_id = object.try(:event_id) || object.try(:commentable_id) || object.id
   = link_to (current_or_last_object_state('Event', event_id).try(:title) || 'deleted event'),
           admin_conference_program_event_path(conference_id: Conference.find(version.conference_id).short_title, id: event_id)
 


### PR DESCRIPTION
Fixes #1226

Screenshots:
Before ![Before](https://cloud.githubusercontent.com/assets/3638310/21826653/036ebc26-d791-11e6-9dc7-4ee39bf9f461.png)
After ![After](https://cloud.githubusercontent.com/assets/3638310/21826652/03658d4a-d791-11e6-93fb-f78347016726.png)

