### PR TITLE
Improvements in the DatabaseCleaner

### DIFF
--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -55,13 +55,6 @@ RSpec.configure do |config|
   #     --seed 1234
   config.order = 'random'
 
-  config.around(:each) do |example|
-    DatabaseCleaner.cleaning do
-      Rails.application.load_seed
-      example.run
-    end
-  end
-
   # poltergeist as a underlying mech for Capybara
   Capybara.javascript_driver = :poltergeist
 

--- a/spec/support/database_cleaner.rb
+++ b/spec/support/database_cleaner.rb
@@ -1,16 +1,6 @@
 RSpec.configure do |config|
-  config.before(:suite) do
+  config.before(:each) do
     DatabaseCleaner.clean_with(:truncation)
     Rails.application.load_seed
-  end
-
-  config.before(:each) do |example|
-    DatabaseCleaner.strategy = (example.metadata[:js] == true) ? :truncation : :transaction
-    DatabaseCleaner.start
-  end
-
-  config.after(:each) do |example|
-    DatabaseCleaner.clean
-    Rails.application.load_seed if example.metadata[:js] == true
   end
 end

--- a/spec/support/database_cleaner.rb
+++ b/spec/support/database_cleaner.rb
@@ -1,13 +1,16 @@
 RSpec.configure do |config|
   config.before(:suite) do
     DatabaseCleaner.clean_with(:truncation)
+    Rails.application.load_seed
   end
 
-  config.before(:each) do
-    DatabaseCleaner.strategy = :transaction
+  config.before(:each) do |example|
+    DatabaseCleaner.strategy = (example.metadata[:js] == true) ? :truncation : :transaction
+    DatabaseCleaner.start
   end
 
-  config.before(:each, js: true) do
-    DatabaseCleaner.strategy = :truncation
+  config.after(:each) do |example|
+    DatabaseCleaner.clean
+    Rails.application.load_seed if example.metadata[:js] == true
   end
 end


### PR DESCRIPTION
Move all what is related to the `DatabaseCleaner` to the `database_cleaner.rb` file. Load the seeds only when they have been deleted and not before every test.