### PR TITLE
Move reports to its own controler

### DIFF
--- a/app/controllers/admin/events_controller.rb
+++ b/app/controllers/admin/events_controller.rb
@@ -5,7 +5,7 @@ module Admin
     load_and_authorize_resource :event, through: :program
     load_and_authorize_resource :events_registration, only: :toggle_attendance
 
-    before_action :get_event, except: [:index, :create, :reports]
+    before_action :get_event, except: [:index, :create]
 
     # FIXME: The timezome should only be applied on output, otherwise
     # you get lost in timezone conversions...
@@ -150,17 +150,6 @@ module Admin
       else
         head :unprocessable_entity
       end
-    end
-
-    def reports
-      @events = @program.events
-      @events_commercials = Commercial.where(commercialable_type: 'Event', commercialable_id: @events.pluck(:id))
-      @events_missing_commercial = @events.where.not(id: @events_commercials.pluck(:commercialable_id))
-      @events_with_requirements = @events.where.not(description: ['', nil])
-
-      attended_registrants_ids = @conference.registrations.where(attended: true).pluck(:user_id)
-      @missing_event_speakers = EventUser.joins(:event).where('event_role = ? and program_id = ?', 'submitter', @program.id).
-                                                                                        where.not(user_id: attended_registrants_ids).includes(:user, :event)
     end
 
     private

--- a/app/controllers/admin/reports_controller.rb
+++ b/app/controllers/admin/reports_controller.rb
@@ -1,0 +1,19 @@
+module Admin
+  class ReportsController < Admin::BaseController
+    load_and_authorize_resource :conference, find_by: :short_title
+    load_and_authorize_resource :program, through: :conference, singleton: true
+
+    def index
+      @events = @program.events
+      @events_commercials = Commercial.where(commercialable_type: 'Event', commercialable_id: @events.pluck(:id))
+      @events_missing_commercial = @events.where.not(id: @events_commercials.pluck(:commercialable_id))
+      @events_with_requirements = @events.where.not(description: ['', nil])
+
+      attended_registrants_ids = @conference.registrations.where(attended: true).pluck(:user_id)
+      @missing_event_speakers = EventUser.joins(:event).
+                                where('event_role = ? and program_id = ?', 'submitter', @program.id).
+                                where.not(user_id: attended_registrants_ids).
+                                includes(:user, :event)
+    end
+  end
+end

--- a/app/views/admin/reports/_all_events.html.haml
+++ b/app/views/admin/reports/_all_events.html.haml
@@ -1,0 +1,39 @@
+.row
+  .col-md-12
+    .page-header
+      %h1
+        All Events
+        = "(#{@events.length})"
+      %p.text-muted
+        All submissions and the information that they are mssing
+
+.col-md-12
+  %table.table.table-striped.table-bordered.table-hover.datatable
+    %thead
+      %th ID
+      %th Title
+      %th Submitter Registered
+      %th Submitter Biography
+      %th Commercial
+      %th Subtitle
+      %th Difficulty Level
+      - if @program.tracks.any?
+        %th Track
+    %tbody
+      - @events.each do |event|
+        %tr
+          - progress_status = event.progress_status
+          %td= event.id
+          %td
+            = link_to event.title, edit_admin_conference_program_event_path(@conference.short_title, event)
+            %br
+            .small (Presented by #{event.speaker_names})
+
+          - %w(registered biography commercials subtitle difficulty_level).each do |info|
+            %td{'data-order' => "#{progress_status[info]}"}
+              %span{class: class_for_todo(progress_status[info])}
+                %span{class: [icon_for_todo(progress_status[info]), 'fa-lg']}
+          - if @program.tracks.any?
+            %td{'data-order' => "#{progress_status['track']}"}
+              %span{class: class_for_todo(progress_status['track'])}
+                %span{class: [icon_for_todo(progress_status['track']), 'fa-lg']}

--- a/app/views/admin/reports/_events_with_requirements.html.haml
+++ b/app/views/admin/reports/_events_with_requirements.html.haml
@@ -1,0 +1,28 @@
+.row
+  .col-md-12
+    .page-header
+      %h1
+        Requirements
+        = "(#{@events_with_requirements.length})"
+      %p.text-muted
+        All submissions where the speakers have special requirements
+.col-md-12
+  %table.table.table-striped.table-bordered.table-hover.datatable
+    %thead
+      %th ID
+      %th Title
+      %th Speaker(s)
+      %th Requirements
+      %th Room
+      %th Date
+      %th Time
+    %tbody
+      - @events_with_requirements.each do |event|
+        %tr
+          %td= event.id
+          %td= link_to event.title, edit_admin_conference_program_event_path(@conference.short_title, event)
+          %td  #{event.speaker_names}
+          %td= event.description
+          %td= event.room.name if event.room
+          %td= event.time.to_date if event.time
+          %td= event.time.strftime('%H:%M') if event.time

--- a/app/views/admin/reports/_events_without_commercials.html.haml
+++ b/app/views/admin/reports/_events_without_commercials.html.haml
@@ -1,0 +1,20 @@
+.row
+  .col-md-12
+    .page-header
+      %h1
+        Events without commercials
+        = "(#{@events_missing_commercial.length})"
+      %p.text-muted
+        All submissions that have no commercial
+.col-md-12
+  %table.table.table-striped.table-bordered.table-hover.datatable
+    %thead
+      %th ID
+      %th Title
+      %th Speaker(s)
+    %tbody
+      - @events_missing_commercial.each do |event|
+        %tr
+          %td= event.id
+          %td= link_to event.title, edit_admin_conference_program_event_path(@conference.short_title, event)
+          %td  #{event.speaker_names}

--- a/app/views/admin/reports/_missing_speakers.html.haml
+++ b/app/views/admin/reports/_missing_speakers.html.haml
@@ -1,0 +1,32 @@
+.row
+  .col-md-12
+    .page-header
+      %h1
+        Missing Speakers
+        = "(#{@missing_event_speakers.group(:user_id).length})"
+      %p.text-muted
+        All event speakers who haven't checked in
+.col-md-12
+  %table.table.table-striped.table-bordered.table-hover.datatable
+    %thead
+      %th Speaker Name
+      %th Registered?
+      %th Event
+      %th Room
+      %th Date
+      %th Time
+    %tbody
+      - @missing_event_speakers.each do |event_user|
+        - speaker = event_user.user
+        - event = event_user.event
+        %tr
+          %td= link_to speaker.name, admin_user_path(speaker)
+          %td
+            - if @conference.user_registered?(speaker)
+              = link_to 'Yes', admin_conference_registrations_path(@conference.short_title)
+            - else
+              No
+          %td= link_to event.title, edit_admin_conference_program_event_path(@conference.short_title, event)
+          %td= event.room.name if event.room
+          %td= event.time.to_date if event.time
+          %td= event.time.strftime('%H:%M') if event.time

--- a/app/views/admin/reports/index.html.haml
+++ b/app/views/admin/reports/index.html.haml
@@ -1,0 +1,33 @@
+.tabbable
+  %ul.nav.nav-tabs
+    %li.active
+      = link_to 'All Events', '#all', 'data-toggle' => 'tab'
+    %li
+      %a{href: '#missing-commercial', 'data-toggle' => 'tab'}
+        Events without Commercials
+        %span.label.label-danger{style: 'border-radius: 1em;'}
+          = @events_missing_commercial.length
+    %li
+      %a{href: '#requirements', 'data-toggle' => 'tab'}
+        Speaker Requirements
+        %span.label.label-success{style: 'border-radius: 1em;'}
+          = @events_with_requirements.length
+
+    %li
+      %a{href: '#missing-speakers', 'data-toggle' => 'tab'}
+        Missing Speakers
+        %span.label.label-danger{style: 'border-radius: 1em;'}
+          = @missing_event_speakers.group(:user_id).length
+
+  .tab-content
+    #all.tab-pane.active
+      = render partial: 'all_events'
+
+    #missing-commercial.tab-pane
+      = render partial: 'events_without_commercials'
+
+    #requirements.tab-pane
+      = render partial: 'events_with_requirements'
+
+    #missing-speakers.tab-pane
+      = render partial: 'missing_speakers'

--- a/app/views/layouts/_admin_sidebar.html.haml
+++ b/app/views/layouts/_admin_sidebar.html.haml
@@ -85,8 +85,8 @@
             %li{class: active_nav_li(admin_conference_schedules_path(@conference.short_title))}
               = link_to 'Schedules', admin_conference_schedules_path(@conference.short_title)
           - if can? :update, @conference.program.events.build
-            %li{class: active_nav_li(reports_admin_conference_program_path(@conference.short_title))}
-              = link_to 'Reports', reports_admin_conference_program_path(@conference.short_title)
+            %li{ class: active_nav_li(admin_conference_program_reports_path(@conference.short_title)) }
+              = link_to 'Reports', admin_conference_program_reports_path(@conference.short_title)
 
   - if can? :update, Registration.new(conference_id: @conference.id)
     %li{class: active_nav_li(admin_conference_registrations_path(@conference.short_title))}

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -69,7 +69,7 @@ Osem::Application.routes.draw do
             get :vote
           end
         end
-        get 'reports' => 'events#reports'
+        resources :reports, only: :index
       end
 
       resources :resources


### PR DESCRIPTION
This is a follow-up for https://github.com/openSUSE/osem/pull/1169
And it includes https://github.com/openSUSE/osem/issues/1146

* Moves reports to its own controller
* Makes all links of reports in the admin namespace
* Adds ID column for events in report pages 
* Creates partial for every tab in reports#index
* Shows commercial tab in admin/events#show