### PR TITLE
Fix bug in the schedule

### DIFF
--- a/app/views/schedules/_carousel.html.haml
+++ b/app/views/schedules/_carousel.html.haml
@@ -27,7 +27,7 @@
               %td.room{ style: "height: #{ td_height(@rooms) }px;" }
                 .room.elipsis.break-words{ style: "-webkit-line-clamp: #{ room_lines(@rooms) }; height: #{ room_height(@rooms) }px;" }
                   = room.name
-                - event_schedules = room.event_schedules.select{ |e| (e.schedule_id == @conference.program.selected_schedule.id) && (e.start_time >= start_time) && (e.start_time <= (start_time + number_columns.hour)) }
+                - event_schedules = room.event_schedules.select{ |e| (e.schedule_id == @conference.program.selected_schedule.id) && (e.end_time > start_time) && (e.start_time <= (start_time + number_columns.hour)) }
                 - (1..intervals).each do |i|
                   - if span > 1
                     - span -= 1


### PR DESCRIPTION
As @eug3nix pointed out there is a bug in the schedule: events that should be rendered in more than one carousel section are only rendered in the first one.