### PR TITLE
implement user creation by admin

### DIFF
--- a/app/controllers/admin/users_controller.rb
+++ b/app/controllers/admin/users_controller.rb
@@ -6,6 +6,17 @@ module Admin
       @user = User.new
     end
 
+    def create
+      @user = User.new(user_params)
+      @user.skip_confirmation!
+      if @user.save
+        redirect_to admin_users_path, notice: 'User successfully created.'
+      else
+        flash.now[:error] = "Creating User failed: #{@user.errors.full_messages.join('. ')}."
+        render :new
+      end
+    end
+
     def index
       @users = User.all
     end
@@ -50,8 +61,9 @@ module Admin
     private
 
     def user_params
-      params.require(:user).permit(:email, :name, :email_public, :biography, :nickname, :affiliation, :is_admin, :username, :login, :is_disabled,
-                                   :tshirt, :mobile, :volunteer_experience, :languages, :to_confirm, role_ids: [])
+      params.require(:user).permit(:email, :name, :email_public, :biography, :nickname, :affiliation, :is_admin,
+                                   :username, :login, :is_disabled, :tshirt, :mobile, :volunteer_experience,
+                                   :languages, :to_confirm, :password, role_ids: [])
     end
   end
 end

--- a/app/models/ability.rb
+++ b/app/models/ability.rb
@@ -119,6 +119,9 @@ class Ability
     # for admins
     can :manage, :all if user.is_admin
 
+    # even admin cannot create new users with ICHAIN enabled
+    cannot [:new, :create], User if ENV['OSEM_ICHAIN_ENABLED'] == 'true'
+
     cannot :revert_object, PaperTrail::Version do |version|
       (version.event == 'create' && %w(Conference User Event).include?(version.item_type))
     end

--- a/app/views/admin/users/_form.html.haml
+++ b/app/views/admin/users/_form.html.haml
@@ -1,25 +1,28 @@
 = semantic_form_for [:admin, @user] do |f|
   = f.inputs 'Basic Information' do
-    .pull-right
-      %b
-        Confirmed?
-      - if can? :toggle_confirmation, @user
-        = check_box_tag @user.id, @user.id, @user.confirmed?, 
-          method: :patch, 
-          url: "/admin/users/#{@user.id}/toggle_confirmation?user[to_confirm]=", 
-          class: 'switch-checkbox', 
-          readonly: false,
-          data: { size: 'small', on_color: 'success', off_color: 'warning', on_text: 'Yes', off_text: 'No' } 
-      - else
-        = check_box_tag @user.id, @user.id, @user.confirmed?, 
-          method: :patch, 
-          url: "/admin/users/#{@user.id}/toggle_confirmation?user[to_confirm]=", 
-          class: 'switch-checkbox', 
-          readonly: true,
-          data: { size: 'small', on_color: 'success', off_color: 'warning', on_text: 'Yes', off_text: 'No' } 
+    - unless @user.new_record?
+      .pull-right
+        %b
+          Confirmed?
+        - if can? :toggle_confirmation, @user
+          = check_box_tag @user.id, @user.id, @user.confirmed?,
+            method: :patch,
+            url: "/admin/users/#{@user.id}/toggle_confirmation?user[to_confirm]=",
+            class: 'switch-checkbox',
+            readonly: false,
+            data: { size: 'small', on_color: 'success', off_color: 'warning', on_text: 'Yes', off_text: 'No' }
+        - else
+          = check_box_tag @user.id, @user.id, @user.confirmed?,
+            method: :patch,
+            url: "/admin/users/#{@user.id}/toggle_confirmation?user[to_confirm]=",
+            class: 'switch-checkbox',
+            readonly: true,
+            data: { size: 'small', on_color: 'success', off_color: 'warning', on_text: 'Yes', off_text: 'No' }
     = f.input :is_admin, hint: 'An admin can create a new conference, manage users and make other users admins.'
     = f.input :name, as: :string
+    = f.input :username, :as => :string if @user.new_record?
     = f.input :email
+    = f.input :password if @user.new_record?
     = f.input :affiliation, as: :string
     = f.input :biography, input_html: { rows: 10, data: { provide: 'markdown-editable' } },
       hint: markdown_hint

--- a/app/views/admin/users/index.html.haml
+++ b/app/views/admin/users/index.html.haml
@@ -1,10 +1,13 @@
 .row
   .col-md-12
     .page-header
-      %h2
+      %h1
         Users
         - if @users
           = "(#{@users.length})"
+        - if can? :create, User
+          .pull-right
+            =link_to 'Add User', new_admin_user_path, :class => 'button btn btn-default btn-info'
 .row
   .col-md-12.table-responsive
     %table.table.table-striped.table-bordered.table-hover.datatable

--- a/spec/controllers/admin/users_controller_spec.rb
+++ b/spec/controllers/admin/users_controller_spec.rb
@@ -6,7 +6,7 @@ describe Admin::UsersController do
     sign_in(admin)
   end
   describe 'GET #index' do
-    it 'populates an array of users' do
+    it 'sets up users array with existing users records' do
       user1 = create(:user, email: 'user1@email.osem')
       user2 = create(:user, email: 'user2@email.osem')
       user_deleted = User.find_by(name: 'User deleted')
@@ -47,6 +47,57 @@ describe Admin::UsersController do
       end
       it 'redirects to the updated user' do
         expect(response).to redirect_to admin_users_path
+      end
+    end
+  end
+  describe 'GET #new' do
+    it 'sets up a user instance for the form' do
+      get :new
+      expect(assigns(:user)).to be_instance_of(User)
+    end
+    it 'renders new user template' do
+      get :new
+      expect(response).to render_template :new
+    end
+  end
+
+  describe 'POST #create' do
+    context 'saves successfuly' do
+      before do
+        post :create, user: attributes_for(:user)
+      end
+
+      it 'redirects to admin users index path' do
+        expect(response).to redirect_to admin_users_path
+      end
+
+      it 'shows success message in flash notice' do
+        expect(flash[:notice]).to match('User successfully created.')
+      end
+
+      it 'creates new user' do
+        expect(User.find(user.id)).to be_instance_of(User)
+      end
+    end
+
+    context 'save fails' do
+      before do
+        allow_any_instance_of(User).to receive(:save).and_return(false)
+        post :create, user: attributes_for(:user)
+      end
+
+      it 'renders new template' do
+        expect(response).to render_template('new')
+      end
+
+      it 'shows error in flash message' do
+        expect(flash[:error]).to match("Creating User failed: #{user.errors.full_messages.join('. ')}.")
+      end
+
+      it 'does not create new user' do
+        expect do
+          post :create, user: attributes_for(:user)
+        end.not_to change{ Event.count }
       end
     end
   end


### PR DESCRIPTION
the new Add User functionality can be accessed using the *Add User* button on admin/users URI
the manually created users are in confirmed state and thus does not need any extra confirmation from the user.

best regards,
Eugene/CommandPrompt Inc.