### PR TITLE
[WIP] Adds domain support to OSEM

### DIFF
--- a/app/controllers/admin/conferences_controller.rb
+++ b/app/controllers/admin/conferences_controller.rb
@@ -176,7 +176,7 @@ module Admin
     private
 
     def conference_params
-      params.require(:conference).permit(:title, :short_title, :description, :timezone,
+      params.require(:conference).permit(:title, :short_title, :description, :timezone, :domain,
                                          :start_date, :end_date, :rooms_attributes, :tracks_attributes,
                                          :tickets_attributes, :event_types_attributes,
                                          :picture, :picture_cache, :questions_attributes,

--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -37,7 +37,8 @@ class ApplicationController < ActionController::Base
   end
 
   def get_conferences
-    @conferences =Conference.all
+    domain = request.host
+    @conferences = Conference.get_conferences_to_list(domain, 0)
   end
 
   def current_ability

--- a/app/controllers/conferences_controller.rb
+++ b/app/controllers/conferences_controller.rb
@@ -5,7 +5,8 @@ class ConferencesController < ApplicationController
   load_resource :program, through: :conference, singleton: true, except: :index
 
   def index
-    @current = Conference.where('end_date >= ?', Date.current).reorder(start_date: :asc)
+    domain = request.host
+    @current = Conference.get_conferences_to_list domain
     @antiquated = @conferences - @current
   end
 

--- a/app/models/conference.rb
+++ b/app/models/conference.rb
@@ -499,6 +499,10 @@ class Conference < ActiveRecord::Base
     result - active_conferences
   end
 
+  def self.get_conferences_to_list(domain, end_date = Date.current)
+    return Conference.where('end_date >= ? AND (domain = ? OR domain IS NULL)', end_date, domain).reorder(start_date: :asc)
+  end
+
   ##
   # A list with the three event states submitted, confirmed, unconfirmed with corresponding colors
   #

--- a/app/views/admin/conferences/edit.html.haml
+++ b/app/views/admin/conferences/edit.html.haml
@@ -9,6 +9,7 @@
     = semantic_form_for(@conference, :url => admin_conference_path(@conference.short_title),:html => {:multipart => true}) do |f|
       = f.input :title, :hint => "The full title of the conference, e.g. 'openSUSE Conference 2014'"
       = f.input :short_title, :hint => "A short title, e.g. 'oSC14', to be used in URLs"
+      = f.input :domain, hint: "Optional domain on which the conference will be visible. This only affects the conference listings."
       = f.input :description, hint: markdown_hint('A description of the conference.'), input_html: { rows: 5, data: { provide: 'markdown-editable' } }
       = f.input :color, :hint => "The color will be used eg for the dashboard.", :input_html => {:size => 6, :type => "color"}
       = f.label 'Conference Logo'

--- a/app/views/admin/conferences/new.html.haml
+++ b/app/views/admin/conferences/new.html.haml
@@ -6,6 +6,7 @@
                           input_html: { required: 'required' }
         = f.input :short_title, hint: "A short and unique handle for your conference, using only lower-case letters, numbers and underscores. This will be used to identify your conference in URLs etc. Example: 'froscon2011'",
                                 input_html: { required: 'required' }
+        = f.input :domain, hint: "Optional domain on which the conference will be visible. This only affects the conference listings."
       = f.inputs 'Scheduling' do
         = f.input :timezone, as: :time_zone, default: Time.zone.name, hint: 'Please select in what time zone your conference will take place.'
         = f.input :start_date, as: :string, input_html: { id: 'conference-start-datepicker', required: 'required' }

--- a/db/migrate/20170201193336_add_domain_to_conferences.rb
+++ b/db/migrate/20170201193336_add_domain_to_conferences.rb
@@ -1,0 +1,6 @@
+class AddDomainToConferences < ActiveRecord::Migration
+  def change
+  	add_column :conferences, :domain, :string
+  	add_index :conferences, [:domain]
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -11,7 +11,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 20160815140302) do
+ActiveRecord::Schema.define(version: 20170201193336) do
 
   create_table "ahoy_events", force: :cascade do |t|
     t.uuid     "visit_id",   limit: 16
@@ -98,7 +98,10 @@ ActiveRecord::Schema.define(version: 20160815140302) do
     t.text     "description"
     t.integer  "registration_limit", default: 0
     t.string   "picture"
+    t.string   "domain"
   end
+
+  add_index "conferences", ["domain"], name: "index_conferences_on_domain"
 
   create_table "conferences_questions", id: false, force: :cascade do |t|
     t.integer "conference_id"


### PR DESCRIPTION
- This is a very basic support. All it affects is the listings
  on the homepage. Every conference can set a domain, and as
  long as the request host matches this domain, the conference
  will be shown on the list
- If a conference does not have a domain set (which will be the
  case for older conferences), such conferences are shown
  always
- Conference creation and edits now have an optional domain field
- Also adds corresponding migrations (+index)

The use case is for the osem instance powering hackbeach. We want to re-use the same instance for hillhacks, and maintain the user accounts. This will let both of the services use the same rails instance+db, while showing a different set of conferences at `osem.{hillhacks|hackbeach}.in`.