### PR TITLE
Remove the unreachable code and modify the error message in ConferenceRegistrationsController#new

### DIFF
--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -46,7 +46,7 @@ class ApplicationController < ActionController::Base
   rescue_from CanCan::AccessDenied do |exception|
     Rails.logger.debug "Access denied on #{exception.action} #{exception.subject.inspect}"
     message = exception.message
-    message << ' Maybe you need to sign in?' unless current_user
+    message << ' Maybe you need to sign in?' unless @ignore_not_signed_in_user || current_user
     redirect_to root_path, alert: message
   end
 


### PR DESCRIPTION
When iChain is enabled if the user is not signed in the message "You are not authorized to access this page. Maybe you need to sign in?" will be displayed, while if the user is signed in and something else goes wrong, the message "Sorry, you can not register for #{@conference.title}. Registration limit exceeded or the registration is not open." will be shown.

Fixes #1140