### PR TITLE
Fixes #1260, Change behavior of proposal update page requirement field

### DIFF
--- a/app/views/proposals/_proposal_form.html.haml
+++ b/app/views/proposals/_proposal_form.html.haml
@@ -55,7 +55,7 @@
     %p.text-right
       = link_to '#description', 'data-toggle' => 'collapse' do
         Do you require something special?
-    .collapse#description
+    #description{ class: "collapse #{ 'in' if @event.description.present? }" }
       = f.input :description, input_html: { rows: 5 }, label: 'Requirements', placeholder: 'Eg. Whiteboard, printer, or something like that.'
 
 


### PR DESCRIPTION
Fixes #1260 
Pull request add following behavior to Proposal page:
1) Requirement field collapse when description is empty
2) Requirement field does not collapse when description is present

@differentreality, Required changes included.