### PR TITLE
intersecting events without overlapping in admin/schedule#show

### DIFF
--- a/app/controllers/admin/events_controller.rb
+++ b/app/controllers/admin/events_controller.rb
@@ -124,6 +124,15 @@ module Admin
 
     def cancel
       update_state(:cancel, 'Event canceled!')
+      selected_schedule = @event.program.selected_schedule
+      event_schedule = EventSchedule.unscoped.where(event: @event).find_by(schedule: selected_schedule) if selected_schedule
+      Rails.logger.debug "schedule: #{selected_schedule.inspect} and event_schedule #{event_schedule.inspect}"
+      if selected_schedule && event_schedule
+        event_schedule.enabled = false
+        event_schedule.save
+      else
+        @event.event_schedules.destroy_all
+      end
     end
 
     def reject

--- a/app/controllers/proposals_controller.rb
+++ b/app/controllers/proposals_controller.rb
@@ -91,6 +91,15 @@ class ProposalsController < ApplicationController
 
     begin
       @event.withdraw
+      selected_schedule = @event.program.selected_schedule
+      event_schedule = @event.event_schedules.find_by(schedule: selected_schedule) if selected_schedule
+      Rails.logger.debug "schedule: #{selected_schedule.inspect} and event_schedule #{event_schedule.inspect}"
+      if selected_schedule && event_schedule
+        event_schedule.enabled = false
+        event_schedule.save
+      else
+        @event.event_schedules.destroy_all
+      end
     rescue Transitions::InvalidTransition
       redirect_to :back, error: "Event can't be withdrawn"
       return

--- a/app/models/event_schedule.rb
+++ b/app/models/event_schedule.rb
@@ -1,4 +1,5 @@
 class EventSchedule < ApplicationRecord
+  default_scope { where(enabled: true) }
   belongs_to :schedule
   belongs_to :event
   belongs_to :room
@@ -33,7 +34,7 @@ class EventSchedule < ApplicationRecord
   # Returns event schedules that are scheduled in the same room and start_time as event
   #
   def intersecting_event_schedules
-    room.event_schedules.where(start_time: start_time, schedule: schedule).where.not(id: id)
+    EventSchedule.unscoped.where(room: room, start_time: start_time, schedule: schedule).where.not(id: id)
   end
 
   def replacement?

--- a/db/migrate/20170212145523_add_enabled_to_event_schedules.rb
+++ b/db/migrate/20170212145523_add_enabled_to_event_schedules.rb
@@ -1,0 +1,5 @@
+class AddEnabledToEventSchedules < ActiveRecord::Migration
+  def change
+    add_column :event_schedules, :enabled, :boolean, default: true
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -217,6 +217,7 @@ ActiveRecord::Schema.define(version: 20171130172334) do
     t.datetime "start_time"
     t.datetime "created_at",  null: false
     t.datetime "updated_at",  null: false
+    t.boolean  "enabled",     default: true
     t.index ["event_id", "schedule_id"], name: "index_event_schedules_on_event_id_and_schedule_id", unique: true
     t.index ["event_id"], name: "index_event_schedules_on_event_id"
     t.index ["room_id"], name: "index_event_schedules_on_room_id"
@@ -494,7 +495,7 @@ ActiveRecord::Schema.define(version: 20171130172334) do
     t.integer  "user_id"
     t.integer  "payment_id"
     t.integer  "week"
-    t.float    "amount_paid",   default: 0.0
+    t.float    "amount_paid"
   end
 
   create_table "ticket_scannings", force: :cascade do |t|


### PR DESCRIPTION
Following up from #1168 does something like this make sense @Ana06 ? Does it solve all you needed about the overlapping issue and allow you to continue with #1106 ?

This introduces a new attribute for event_schedule, namely `enabled`.

When there is a selected schedule and an event is scheduled, if the event is withdrawn, then the event_schedule is **not** destroyed, but `event_schedule.enabled = false`

The EventSchedule model has a default scope to ignore records that are not enabled (ie.` enabled == false`).

We take the disabled event_schedules into account, only when we want to show intersecting events.