### PR TITLE
Added demo data

### DIFF
--- a/lib/tasks/demo_data_for_development.rake
+++ b/lib/tasks/demo_data_for_development.rake
@@ -1,0 +1,77 @@
+namespace :data do
+  desc 'Create demo data for our local development'
+  task test: :environment do
+    include FactoryGirl::Syntax::Methods
+
+    def generate_program conference
+        program = conference.program
+        user1 = create(:user)
+        user2 = create(:user)
+
+        conference_rooms = conference.venue.rooms
+
+        selected_schedule = create(:schedule, program: program)
+        demo_schedule = create(:schedule, program: program)
+        program.update_attributes!(selected_schedule: selected_schedule)
+
+        create(:event, program: program, title: 'Demo Event', abstract: 'This is a demo event instance whose state not defined.')
+        create(:event, program: program, title: 'Demo Rejected Event', state: 'rejected', abstract: 'This is demo event instance in a rejected state.')
+        create(:event, program: program, title: 'Demo Unconfirmed Event', state: 'unconfirmed', abstract: 'This is a demo event instance in unconfirmed state.')
+        create(:event, program: program, title: 'Demo Confirmed Unscheduled Event', state: 'confirmed', abstract: 'This is a demo event instance in a confirmed state.')
+
+        first_scheduled_event = create(:event, program: program, title: 'first_scheduled_event', state: 'confirmed', abstract: 'This is a demo scheduled event instance.')
+        second_scheduled_event = create(:event, program: program, title: 'second_scheduled_event', state: 'confirmed', abstract: 'This is a demo scheduled event instance.')
+        multiple_speaker_event = create(:event, program: program, title: 'multiple_speaker_event', state: 'confirmed', abstract: 'This is a demo scheduled event instance having multiple speakers.')
+
+        create(:event_user, event: multiple_speaker_event, user: user1, event_role: 'speaker')
+        create(:event_user, event: multiple_speaker_event, user: user2, event_role: 'speaker')
+
+        create(:event_schedule, event: first_scheduled_event, schedule: selected_schedule, start_time: conference.start_date + conference.start_hour.hours, room: conference_rooms.first)
+        create(:event_schedule, event: second_scheduled_event, schedule: selected_schedule, start_time: conference.start_date + conference.start_hour.hours + 15.minutes, room: conference_rooms.second)
+        create(:event_schedule, event: multiple_speaker_event, schedule: selected_schedule, start_time: conference.start_date + conference.start_hour.hours + 30.minutes, room: conference_rooms.third)
+        create(:event_schedule, event: first_scheduled_event, schedule: demo_schedule, start_time: conference.start_date + conference.start_hour.hours + 15.minutes, room: conference_rooms.third)
+        create(:event_schedule, event: second_scheduled_event, schedule: demo_schedule, start_time: conference.start_date + conference.start_hour.hours + 30.minutes, room: conference_rooms.third)
+        create(:event_schedule, event: multiple_speaker_event, schedule: demo_schedule, start_time: conference.start_date + conference.start_hour.hours, room: conference_rooms.first)
+
+        create(:registration, user: user1, conference: conference)
+        create(:registration, user: user2, conference: conference)
+    end
+
+    # This is a full conference demo instance that will happen in the future.
+    # By full conference it means all basic information about conference is already set.
+    conference = create(:full_conference, title: 'Open Source Event Manager Demo Conference', short_title: 'osemdemo', start_date: 2.days.from_now, end_date: 6.days.from_now, start_hour: 8, end_hour: 20, description: 'This is a full conference demo instance happening in the future. It contains open cfp, venue/rooms, submitted talks by multiple speakers, partly confirmed talks and multiple schedules.')
+    generate_program conference
+
+    # This is a full conference demo instance that has already happened.
+    # By full conference it means all basic information about conference is already set.
+    # Initially end date is set 6 days from now
+    # So that events can be created without any failure in validations.
+    conference = create(:full_conference, title: 'Jangouts Demo Conference', short_title: 'jangouts', start_date: 7.days.ago, end_date: 6.days.from_now, start_hour: 15, end_hour: 20, description: 'This is a full conference demo instance happened in the past. It contains open cfp, venue/rooms, submitted talks by multiple speakers, partly confirmed talks and multiple schedules.')
+    generate_program conference
+    conference.program.cfp.update_attributes!(start_date: 4.days.ago, end_date: 2.days.ago)
+    conference.update_attributes!(end_date: 1.day.ago)
+    conference.registration_period.update_attributes!(start_date: 9.days.ago, end_date: 8.days.ago)
+
+    # This is a conference that will happen in the future
+    # It only has a registration period and unscheduled events
+    registration_period = create(:registration_period)
+    conference = create(:conference, title: 'Portus Demo Conference', short_title: 'portus', registration_period: registration_period, start_date: 3.days.from_now, end_date: 7.days.from_now, start_hour: 10, end_hour: 15, description: 'This is a demo conference instance. No information about this conference is set by default.')
+    create(:event, program: conference.program, title: 'Demo Event', abstract: 'This is a demo event instance whose state not defined.')
+    create(:event, program: conference.program, title: 'Demo Rejected Event', state: 'rejected', abstract: 'This is demo event instance in a rejected state.')
+    create(:event, program: conference.program, title: 'Demo Unconfirmed Event', state: 'unconfirmed', abstract: 'This is a demo event instance in unconfirmed state.')
+    create(:event, program: conference.program, title: 'Demo Confirmed Event', state: 'confirmed', abstract: 'This is a demo event instance in a confirmed state.')
+
+    # This is a full conference demo instance that has already started.
+    # By full conference it means all basic information about conference is already set.
+    # Registration period of this conference is closed now.
+    registration_period = create(:registration_period, start_date: 4.days.ago, end_date: 2.days.ago)
+    conference = create(:full_conference, title: 'Yast Demo Conference', short_title: 'yast', registration_period: registration_period, start_date: 2.days.ago, end_date: 7.days.from_now, start_hour: 10, end_hour: 21, description: 'This is a full conference demo instance. Its registration period is closed.')
+    generate_program conference
+
+    # This is a full conference demo instance that will happen in the future.
+    # By full conference it means all basic information about conference is already set.
+    # Registration for this conference has reached its limit.
+    conference = create(:full_conference, title: 'Zypper Docker  Conference', short_title: 'zypper', registration_limit: 2, start_date: 3.days.from_now, end_date: 7.days.from_now, start_hour: 7, end_hour: 19, description: 'This is a full conference demo instance. Its registrations has reached the limit.')
+    generate_program conference
+    end
+end


### PR DESCRIPTION
Closes #1211 
Added demo data for:

- [x] Full conference happening in the future (with open cfp, venue/rooms, submitted talks by multiple speakers, partly confirmed talks)
- [x] Full conference in the past (with closed cfp, venue/rooms, submitted talks by multiple speakers, rejected talks, confirmed talks, multiple scheduled talks in various rooms)
- [x] Conference without venue/rooms, with submitted talks
- [x] Conference with closed registration, or with registrations that reached the limit
- [x] full range of events and  multiple schedules for all the above conferences



More suggestions needed!