### PR TITLE
Add increment and decrement functionality to left resource quantity 

### DIFF
--- a/app/assets/javascripts/application.js
+++ b/app/assets/javascripts/application.js
@@ -57,3 +57,5 @@ $(document).ready(function() {
         delegateSelector: 'a.smoothscroll'
     });
 });
+
+UnobtrusiveFlash.flashOptions['timeout'] = 3000;

--- a/app/assets/stylesheets/osem.css.scss
+++ b/app/assets/stylesheets/osem.css.scss
@@ -94,3 +94,8 @@ p.comment-body {
 .box{
   height: 230px;
 }
+
+.quantity_left{
+  height: 3em;
+  width: 9em;
+}

--- a/app/views/admin/resources/_update_links.html.haml
+++ b/app/views/admin/resources/_update_links.html.haml
@@ -1,0 +1,17 @@
+= link_to admin_conference_resource_path(conference.short_title,
+  resource, increment_used_resource_flag: 0), method: :put,
+  title: "Free 1 #{resource.name}",
+  class: "btn btn-primary #{'disabled' if resource.used <= 0}",
+  remote: true do
+  %span.fa.fa-minus.fa-2x.update_action
+%button.btn.btn-default.quantity_left.disabled.action-btn
+  %span{ id: "resource_left_#{resource.id}" }
+    = quantity_left_of(resource)
+= link_to admin_conference_resource_path(conference.short_title,
+  resource, increment_used_resource_flag: 1), method: :put,
+  title: "Use 1 #{resource.name}",
+  class: "btn btn-primary #{'disabled' if resource.used >= resource.quantity}",
+  remote: true do
+  %span.fa.fa-plus.fa-2x.update_action
+
+

--- a/app/views/admin/resources/index.html.haml
+++ b/app/views/admin/resources/index.html.haml
@@ -10,7 +10,7 @@
       %table.table.table-hover.datatable
         %thead
           %th Name
-          %th Left( Left/Total )
+          %th Remaining / Total
           %th Used
           %th Actions
         %tbody
@@ -20,9 +20,18 @@
                 = link_to(admin_conference_resource_path(@conference.short_title, resource.id)) do
                   = resource.name
                 %td
-                  = quantity_left_of(resource)
+                  .btn-group.hidden-sm.hidden-xs
+                    %span{ id: "group_large_update_actions_#{resource.id}" }
+                      = render partial: 'update_links',
+                          locals: { conference: @conference, resource: resource }
+
+                  .btn-group-vertical.visible-sm.visible-xs
+                    %span{ id: "group_small_update_actions_#{resource.id}" }
+                      = render partial: 'update_links',
+                          locals: { conference: @conference, resource: resource}
                 %td
-                  = resource.used
+                  %span{ id: "resource_used_#{resource.id}" }
+                    = resource.used
                 %td
                   .btn-group
                     = link_to 'Edit', edit_admin_conference_resource_path(@conference.short_title, resource.id),
@@ -33,4 +42,5 @@
 .row
   .col-md-12
     = link_to 'Add Resource', new_admin_conference_resource_path, class: 'btn btn-success pull-right', disabled: !(can? :create, Resource.new(conference_id: @conference_id))
+
 

--- a/app/views/admin/resources/update.js.erb
+++ b/app/views/admin/resources/update.js.erb
@@ -1,0 +1,5 @@
+$('<%= "#group_large_update_actions_#{@resource.id.to_s}" %>').html('<%= j render partial: "update_links", locals: { conference: @conference, resource: @resource} %>');
+$('<%= "#group_small_update_actions_#{@resource.id.to_s}" %>').html('<%= j render partial: "update_links", locals: { conference: @conference, resource: @resource} %>');
+$('<%= "#resource_left_#{@resource.id.to_s}" %>').text('<%= "#{@resource.quantity - @resource.used }/#{@resource.quantity}"%>').fadeIn();
+$('<%= "#resource_used_#{@resource.id.to_s}" %>').text(<%=@resource.used%>).fadeIn();
+

--- a/app/views/layouts/_admin.html.haml
+++ b/app/views/layouts/_admin.html.haml
@@ -8,7 +8,7 @@
         -# Index admin sidebar
         = render 'layouts/admin_sidebar_index'
     .col-md-10
-      #messages
+      .unobtrusive-flash-container#messages
         =render 'layouts/messages'
       #content
         = yield

--- a/spec/features/resource_spec.rb
+++ b/spec/features/resource_spec.rb
@@ -33,7 +33,7 @@ feature Resource do
       click_button 'Update Resource'
       resource.reload
 
-      expect(flash).to eq('Resource successfully updated.')
+      expect(page).to have_css('#messages'), text('Resource successfully updated.')
       expect(resource.name).to eq('changed_name')
     end
 


### PR DESCRIPTION
Addresses issue #1284 . Improve resource show page with an addition of increment and decrement functionality for Available quantity and Total left quantity using Ajax. 
![increment](https://cloud.githubusercontent.com/assets/14261624/23084601/2845759c-f589-11e6-9dfa-f3f8622b2b73.png)
