### PR TITLE
Reverting #1297 as it broke our heroku deployment

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -25,5 +25,4 @@ before_script:
   - RAILS_ENV=test bundle exec rake db:migrate --trace
 script:
   - 'bundle exec rubocop -Dc .rubocop.yml'
-  - "bundle exec rake factory_girl:lint RAILS_ENV='test'"
   - 'bundle exec rspec --color --format documentation'

--- a/INSTALL.md
+++ b/INSTALL.md
@@ -36,6 +36,7 @@ There are a couple of environment variables you can set to configure OSEM.
 | OSEM_TRANSIFEX_APIKEY 	| *string* 			| Use this api key for [transifex](https://www.transifex.com/). See TRANSLATION.md for details. |
 | OSEM_ERRBIT_HOST 		| errbit.opensuse.org 		| The [errbit](https://github.com/errbit/errbit) host to post exceptions to |
 | OSEM_ERRBIT_APIKEY 		| *string* 			| The api key for the errbit host |
+| OSEM_FACTORY_LINT		| *boolean* (true/false)        | Setting this to false will disable linting of factories before running spec
 | OSEM_GOOGLE_KEY | *string*			| OMNIAUTH Developer Key for GOOGLE
 | OSEM_GOOGLE_SECRET | *string*			| OMNIAUTH Developer Secret for GOOGLE
 | OSEM_FACEBOOK_KEY | *string*		| OMNIAUTH Developer Key for Facebook

--- a/dotenv.example
+++ b/dotenv.example
@@ -42,6 +42,10 @@ OSEM_GITHUB_SECRET=''
 STRIPE_PUBLISHABLE_KEY=''
 STRIPE_SECRET_KEY=''
 
+# Disable linting of factories in the test suite.
+# Speeds up turn around times of tests
+OSEM_FACTORY_LINT="false"
+
 # The smtp configuration. See the rails guides for more
 # http://guides.rubyonrails.org/action_mailer_basics.html#action-mailer-configuration
 OSEM_SMTP_ADDRESS=""

--- a/lib/tasks/factory_girl.rake
+++ b/lib/tasks/factory_girl.rake
@@ -4,7 +4,6 @@ namespace :factory_girl do
     if Rails.env.test?
       begin
         DatabaseCleaner.start
-        mock_commercial_request
         FactoryGirl.lint
       ensure
         DatabaseCleaner.clean

--- a/lib/tasks/factory_girl.rake
+++ b/lib/tasks/factory_girl.rake
@@ -1,4 +1,3 @@
-require_relative '../../spec/support/external_request'
 namespace :factory_girl do
   desc "Verify that all FactoryGirl factories are valid"
   task lint: :environment do

--- a/lib/tasks/migrate_config.rake
+++ b/lib/tasks/migrate_config.rake
@@ -26,6 +26,7 @@ namespace :data do
       dot_env.puts "OSEM_ICHAIN_ENABLED=\"#{CONFIG['authentication']['ichain']['enabled']}\"" if CONFIG.has_key?(:authentication)
       dot_env.puts "OSEM_TRANSIFEX_APIKEY=\"#{CONFIG['transifex_live_api_key']}\""
       dot_env.puts "OSEM_ERRBIT_HOST=\"#{CONFIG['errbit_host']}\""
+      dot_env.puts "OSEM_FACTORY_LINT=\"#{CONFIG['factory_girl_lint']}\""
       dot_env.puts "OSEM_SMTP_ADDRESS=\"#{CONFIG['mail_address']}\""
       dot_env.puts "OSEM_SMTP_PORT=\"#{CONFIG['mail_port']}\""
       dot_env.puts "OSEM_SMTP_USERNAME=\"#{CONFIG['mail_username']}\""

--- a/spec/support/database_cleaner.rb
+++ b/spec/support/database_cleaner.rb
@@ -1,16 +1,6 @@
 RSpec.configure do |config|
-  config.before(:suite) do
+  config.before(:each) do
     DatabaseCleaner.clean_with(:truncation)
     Rails.application.load_seed
-  end
-
-  config.before(:each) do |example|
-    DatabaseCleaner.strategy = (example.metadata[:js] == true) ? :truncation : :transaction
-    DatabaseCleaner.start
-  end
-
-  config.after(:each) do |example|
-    DatabaseCleaner.clean
-    Rails.application.load_seed if example.metadata[:js] == true
   end
 end

--- a/spec/support/factory_girl.rb
+++ b/spec/support/factory_girl.rb
@@ -1,0 +1,12 @@
+require_relative 'external_request'
+
+RSpec.configure do |config|
+
+  config.before(:suite) do
+    if ENV['OSEM_FACTORY_LINT'] != 'false'
+      mock_commercial_request
+      FactoryGirl.lint
+    end
+  end
+
+end


### PR DESCRIPTION
The problem is the 

``
require_relative '../../spec/support/external_request' 
``
 lib/tasks/factory_girl.rake which requires webmock. However, webmock is only available in the test group in the Gemfile and Heroku runs in production environment.

@Ana06 @siddhantbajaj
