### PR TITLE
Fixes #1188 set timezone to conference`s timezone

### DIFF
--- a/app/controllers/admin/events_controller.rb
+++ b/app/controllers/admin/events_controller.rb
@@ -7,14 +7,6 @@ module Admin
 
     before_action :get_event, except: [:index, :create, :reports]
 
-    # FIXME: The timezome should only be applied on output, otherwise
-    # you get lost in timezone conversions...
-    # around_filter :set_timezone_for_this_request
-
-    def set_timezone_for_this_request(&block)
-      Time.use_zone(@conference.timezone, &block)
-    end
-
     def index
       @events = @program.events
       @tracks = @program.tracks

--- a/app/controllers/schedules_controller.rb
+++ b/app/controllers/schedules_controller.rb
@@ -3,6 +3,14 @@ class SchedulesController < ApplicationController
   before_action :respond_to_options
   load_and_authorize_resource :conference, find_by: :short_title
   load_resource :program, through: :conference, singleton: true, except: :index
+  around_action :use_timezone_for_this_request
+
+  # FIXME: The timezome should only be applied on output, otherwise
+  # you get lost in timezone conversions...
+
+  def use_timezone_for_this_request(&block)
+    Time.use_zone(@conference.timezone, &block)
+  end
 
   def show
     @rooms = @conference.venue.rooms if @conference.venue


### PR DESCRIPTION
Fixes #1188 
This sets the timezone for all the requests to the conference`s timezone.
I have also removed the method set_timezone_for_this_request in this PR as we were not using it .