### PR TITLE
Fixed paper trail inconsistent results for numeric values.

### DIFF
--- a/app/controllers/admin/events_controller.rb
+++ b/app/controllers/admin/events_controller.rb
@@ -50,8 +50,8 @@ module Admin
       @ratings = @event.votes.includes(:user)
       @difficulty_levels = @program.difficulty_levels
       @versions = @event.versions |
-       PaperTrail::Version.where(item_type: 'Commercial').where_object(commercialable_id: @event.id, commercialable_type: 'Event') |
-       PaperTrail::Version.where(item_type: 'Commercial').where_object_changes(commercialable_id: @event.id, commercialable_type: 'Event') |
+       PaperTrail::Version.where(item_type: 'Commercial').where('object LIKE ?', "%commercialable_id: #{@event.id}\ncommercialable_type: Event%") |
+       PaperTrail::Version.where(item_type: 'Commercial').where('object_changes LIKE ?', "%commercialable_id:\n- \n- #{@event.id}\ncommercialable_type:\n- \n- Event%") |
        PaperTrail::Version.where(item_type: 'Vote').where('object_changes LIKE ?', "%\nevent_id:\n- \n- #{@event.id}\n%") |
        PaperTrail::Version.where(item_type: 'Vote').where('object LIKE ?', "%\nevent_id: #{@event.id}\n%")
     end

--- a/spec/controllers/admin/events_controller_spec.rb
+++ b/spec/controllers/admin/events_controller_spec.rb
@@ -1,0 +1,26 @@
+require 'spec_helper'
+
+describe Admin::EventsController do
+  let(:conference) { create(:conference) }
+  let(:organizer_role) { Role.find_by(name: 'organizer', resource: conference) }
+  let(:organizer) { create(:user, role_ids: organizer_role.id) }
+  let!(:event_without_commercial) { create(:event, program: conference.program) }
+  let!(:event_with_commercial) { create(:event, program: conference.program) }
+  let!(:event_commercial) { create(:event_commercial, commercialable: event_with_commercial, url: 'https://www.youtube.com/watch?v=M9bq_alk-sw') }
+
+  with_versioning do
+    describe 'GET #show' do
+      before :each do
+        sign_in(organizer)
+        get :show, id: event_without_commercial.id, conference_id: conference.short_title
+      end
+
+      it 'assigns versions' do
+        versions = event_without_commercial.versions
+        expect(event_without_commercial.id).to eq event_commercial.id
+        expect(event_commercial.id).not_to eq event_commercial.commercialable_id
+        expect(assigns(:versions)).to eq versions
+      end
+    end
+  end
+end


### PR DESCRIPTION
There is a known issue in paper_trail that whenever we Query the 'versions.object' column (or 'object_changes' column), like this:

```
PaperTrail::Version.where_object(attr1: val1, attr2: val2)
PaperTrail::Version.where_object_changes(attr1: val1)
```
it evaluates inconsistent results for numeric values due to limitations of SQL wildcard matchers against the serialized objects.

So to fix this issue I have manually formed the where query instead of using where_object and where_object_changes. I have also added test for the same.

To recreate this issue you can create 2 events like this:
`Event_without_commercial{id:1}, Event_with_commercial{id:2}`
a event commercial:
`event_commercial{id:1, event_id:2}`
version for this commercial will be like:
`Version{object_change: "...id:1...commercialable_id:2"}`
**So this version will be shown in the history of both the events.**  

closes #1307 