### PR TITLE
Toast notifications

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -20,8 +20,6 @@ gem 'responders', '~> 2.0'
 # as the database for Active Record
 gem 'mysql2'
 
-# for toastr notifications
-gem 'toastr-rails'
 # for observing records
 gem 'rails-observers'
 

--- a/Gemfile
+++ b/Gemfile
@@ -20,6 +20,8 @@ gem 'responders', '~> 2.0'
 # as the database for Active Record
 gem 'mysql2'
 
+# for toastr notifications
+gem 'toastr-rails'
 # for observing records
 gem 'rails-observers'
 

--- a/Gemfile
+++ b/Gemfile
@@ -48,6 +48,7 @@ gem 'omniauth-github'
 # as authorization framework
 gem 'cancancan'
 
+gem 'toastr_rails'
 # for roles
 gem 'rolify'
 

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -497,8 +497,6 @@ GEM
     timecop (0.7.1)
     timers (1.1.0)
     tins (1.6.0)
-    toastr-rails (1.0.3)
-      railties (>= 3.1.0)
     transitions (0.1.12)
     ttfunk (1.1.1)
     turbolinks (2.5.3)
@@ -630,7 +628,6 @@ DEPENDENCIES
   stripe
   stripe-ruby-mock
   timecop
-  toastr-rails
   transitions
   turbolinks
   uglifier (>= 1.3.0)

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -497,6 +497,7 @@ GEM
     timecop (0.7.1)
     timers (1.1.0)
     tins (1.6.0)
+    toastr_rails (2.1.3)
     transitions (0.1.12)
     ttfunk (1.1.1)
     turbolinks (2.5.3)
@@ -628,6 +629,7 @@ DEPENDENCIES
   stripe
   stripe-ruby-mock
   timecop
+  toastr_rails
   transitions
   turbolinks
   uglifier (>= 1.3.0)
@@ -637,4 +639,4 @@ DEPENDENCIES
   whenever
 
 BUNDLED WITH
-   1.14.5
+   1.14.3

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -497,6 +497,8 @@ GEM
     timecop (0.7.1)
     timers (1.1.0)
     tins (1.6.0)
+    toastr-rails (1.0.3)
+      railties (>= 3.1.0)
     transitions (0.1.12)
     ttfunk (1.1.1)
     turbolinks (2.5.3)
@@ -628,6 +630,7 @@ DEPENDENCIES
   stripe
   stripe-ruby-mock
   timecop
+  toastr-rails
   transitions
   turbolinks
   uglifier (>= 1.3.0)
@@ -637,4 +640,4 @@ DEPENDENCIES
   whenever
 
 BUNDLED WITH
-   1.14.3
+   1.14.5

--- a/app/assets/javascripts/application.js
+++ b/app/assets/javascripts/application.js
@@ -58,7 +58,7 @@ $(document).ready(function() {
 		'debug': false,
 		'newestOnTop': false,
 		'progressBar': true,
-		'positionClass': 'toast-bottom-center',
+		'positionClass': 'toast-top-center',
 		'preventDuplicates': true,
 		'onclick': null,
 		'showDuration': '300',

--- a/app/assets/javascripts/application.js
+++ b/app/assets/javascripts/application.js
@@ -11,6 +11,7 @@
 // GO AFTER THE REQUIRES BELOW.
 //
 //= require jquery
+//= require toastr_rails
 //= require jquery_ujs
 //= require jquery.mobile.custom.min
 //= require jquery.ui.draggable
@@ -52,6 +53,23 @@ $(document).ready(function() {
 		return false;
 	});
 
+	toastr.options = {
+		'closeButton': false,
+		'debug': false,
+		'newestOnTop': false,
+		'progressBar': true,
+		'positionClass': 'toast-bottom-center',
+		'preventDuplicates': true,
+		'onclick': null,
+		'showDuration': '300',
+		'hideDuration': '100',
+		'timeOut': '5000',
+		'extendedTimeOut': '1000',
+		'showEasing': 'swing',
+		'hideEasing': 'linear',
+		'showMethod': 'fadeIn',
+		'hideMethod': 'fadeOut'
+	};
 	$('body').smoothScroll({
 		delegateSelector: 'a.smoothscroll'
 	});

--- a/app/assets/javascripts/application.js
+++ b/app/assets/javascripts/application.js
@@ -46,13 +46,32 @@
 //= require unobtrusive_flash
 //= require unobtrusive_flash_bootstrap
 //= require countable
+//= require toastr
 
 $(document).ready(function() {
-    $('a[disabled=disabled]').click(function(event){
-        return false;
-    });
+	$('a[disabled=disabled]').click(function(event){
+		return false;
+	});
 
-    $('body').smoothScroll({
-        delegateSelector: 'a.smoothscroll'
-    });
+	$('body').smoothScroll({
+		delegateSelector: 'a.smoothscroll'
+	});
+
+	toastr.options = {
+		"closeButton": false,
+		"debug": false,
+		"newestOnTop": false,
+		"progressBar": true,
+		"positionClass": "toast-top-right",
+		"preventDuplicates": false,
+		"onclick": null,
+		"showDuration": "300",
+		"hideDuration": "1000",
+		"timeOut": "5000",
+		"extendedTimeOut": "1000",
+		"showEasing": "swing",
+		"hideEasing": "linear",
+		"showMethod": "fadeIn",
+		"hideMethod": "fadeOut"
+	}
 });

--- a/app/assets/javascripts/application.js
+++ b/app/assets/javascripts/application.js
@@ -46,7 +46,6 @@
 //= require unobtrusive_flash
 //= require unobtrusive_flash_bootstrap
 //= require countable
-//= require toastr
 
 $(document).ready(function() {
 	$('a[disabled=disabled]').click(function(event){
@@ -56,22 +55,4 @@ $(document).ready(function() {
 	$('body').smoothScroll({
 		delegateSelector: 'a.smoothscroll'
 	});
-
-	toastr.options = {
-		"closeButton": false,
-		"debug": false,
-		"newestOnTop": false,
-		"progressBar": true,
-		"positionClass": "toast-top-right",
-		"preventDuplicates": false,
-		"onclick": null,
-		"showDuration": "300",
-		"hideDuration": "1000",
-		"timeOut": "5000",
-		"extendedTimeOut": "1000",
-		"showEasing": "swing",
-		"hideEasing": "linear",
-		"showMethod": "fadeIn",
-		"hideMethod": "fadeOut"
-	}
 });

--- a/app/assets/stylesheets/application.css
+++ b/app/assets/stylesheets/application.css
@@ -15,5 +15,4 @@
  *= require leaflet
  *= require bootstrap3-switch
  *= require osem-payments
- *= require toastr
 */

--- a/app/assets/stylesheets/application.css
+++ b/app/assets/stylesheets/application.css
@@ -15,4 +15,5 @@
  *= require leaflet
  *= require bootstrap3-switch
  *= require osem-payments
+ *= require toastr
 */

--- a/app/assets/stylesheets/application.css
+++ b/app/assets/stylesheets/application.css
@@ -15,4 +15,5 @@
  *= require leaflet
  *= require bootstrap3-switch
  *= require osem-payments
+ *= require toastr_rails
 */

--- a/app/helpers/application_helper.rb
+++ b/app/helpers/application_helper.rb
@@ -133,21 +133,6 @@ module ApplicationHelper
     result
   end
 
-  def bootstrap_class_for(flash_type)
-    case flash_type
-    when 'success'
-      'alert-success'
-    when 'error'
-      'alert-danger'
-    when 'alert'
-      'alert-warning'
-    when 'notice'
-      'alert-info'
-    else
-      'alert-warning'
-    end
-  end
-
   def label_for(event_state)
     result = ''
     case event_state

--- a/app/helpers/application_helper.rb
+++ b/app/helpers/application_helper.rb
@@ -148,6 +148,17 @@ module ApplicationHelper
     end
   end
 
+  def toast_bootstrap_flash
+    flash_messages = []
+    flash.each do |type, message|
+      type = 'success' if type == 'notice'
+      type = 'error'   if type == 'alert'
+      text = "<script>toastr.#{type}('#{message}');</script>"
+      flash_messages << text.html_safe if message
+    end
+    flash_messages.join("\n").html_safe
+  end
+
   def label_for(event_state)
     result = ''
     case event_state

--- a/app/helpers/application_helper.rb
+++ b/app/helpers/application_helper.rb
@@ -148,36 +148,6 @@ module ApplicationHelper
     end
   end
 
-  def toast_bootstrap_flash
-    flash_messages = []
-    flash.each do |type, message|
-      type = 'success' if type == 'notice'
-      type = 'error'   if type == 'alert'
-      text = "<script>
-          toastr.options = {
-            'closeButton': false,
-            'debug': false,
-            'newestOnTop': false,
-            'progressBar': true,
-            'positionClass': 'toast-bottom-center',
-            'preventDuplicates': true,
-            'onclick': null,
-            'showDuration': '300',
-            'hideDuration': '100',
-            'timeOut': '5000',
-            'extendedTimeOut': '1000',
-            'showEasing': 'swing',
-            'hideEasing': 'linear',
-            'showMethod': 'fadeIn',
-            'hideMethod': 'fadeOut'
-          };
-          toastr.#{type}('#{message}');
-      </script>"
-      flash_messages << text.html_safe if message
-    end
-    flash_messages.join("\n").html_safe
-  end
-
   def label_for(event_state)
     result = ''
     case event_state

--- a/app/helpers/application_helper.rb
+++ b/app/helpers/application_helper.rb
@@ -153,7 +153,26 @@ module ApplicationHelper
     flash.each do |type, message|
       type = 'success' if type == 'notice'
       type = 'error'   if type == 'alert'
-      text = "<script>toastr.#{type}('#{message}');</script>"
+      text = "<script>
+          toastr.options = {
+            'closeButton': false,
+            'debug': false,
+            'newestOnTop': false,
+            'progressBar': true,
+            'positionClass': 'toast-bottom-center',
+            'preventDuplicates': true,
+            'onclick': null,
+            'showDuration': '300',
+            'hideDuration': '100',
+            'timeOut': '5000',
+            'extendedTimeOut': '1000',
+            'showEasing': 'swing',
+            'hideEasing': 'linear',
+            'showMethod': 'fadeIn',
+            'hideMethod': 'fadeOut'
+          };
+          toastr.#{type}('#{message}');
+      </script>"
       flash_messages << text.html_safe if message
     end
     flash_messages.join("\n").html_safe

--- a/app/views/layouts/_messages.html.haml
+++ b/app/views/layouts/_messages.html.haml
@@ -7,11 +7,3 @@
     JavaScript is not enabled
   %p
     OSEM requires JavaScript to be enabled to function. Please turn on JavaScript in your browser's settings and reload the page to continue.
-- flash.each do |type, message|
-  .row
-    .col-md-12
-      %div{:class=>"alert alert-dismissable #{bootstrap_class_for(type)}", :id=>"flash"}
-        .button.close{"data-dismiss" => "alert", "aria-hidden"=>"true"}
-          &times;
-        %p
-          = message

--- a/app/views/layouts/application.html.haml
+++ b/app/views/layouts/application.html.haml
@@ -22,6 +22,7 @@
     = yield(:head)
   %body
     = render 'layouts/navigation'
+    = toast_bootstrap_flash
     -# Admin area
     - if controller.class.name.split("::").first=="Admin"
       = render 'layouts/admin'

--- a/app/views/layouts/application.html.haml
+++ b/app/views/layouts/application.html.haml
@@ -6,7 +6,6 @@
     %meta{:content => "", :name => "description"}
     %meta{:content => "", :name => "author"}
     = stylesheet_link_tag "application", :media => "all"
-    = stylesheet_link_tag "https://cdnjs.cloudflare.com/ajax/libs/toastr.js/latest/toastr.min.css"
     = javascript_include_tag "application"
 
     = csrf_meta_tags
@@ -19,11 +18,10 @@
       };
     = content_for(:script_head)
     = javascript_include_tag "//cdn.transifex.com/live.js"
-    = javascript_include_tag "https://cdnjs.cloudflare.com/ajax/libs/toastr.js/latest/toastr.min.js"
     = yield(:head)
   %body
     = render 'layouts/navigation'
-    = toast_bootstrap_flash
+    = render 'toastr_rails/flash'
     -# Admin area
     - if controller.class.name.split("::").first=="Admin"
       = render 'layouts/admin'

--- a/app/views/layouts/application.html.haml
+++ b/app/views/layouts/application.html.haml
@@ -6,6 +6,7 @@
     %meta{:content => "", :name => "description"}
     %meta{:content => "", :name => "author"}
     = stylesheet_link_tag "application", :media => "all"
+    = stylesheet_link_tag "https://cdnjs.cloudflare.com/ajax/libs/toastr.js/latest/toastr.min.css"
     = javascript_include_tag "application"
 
     = csrf_meta_tags
@@ -18,7 +19,7 @@
       };
     = content_for(:script_head)
     = javascript_include_tag "//cdn.transifex.com/live.js"
-
+    = javascript_include_tag "https://cdnjs.cloudflare.com/ajax/libs/toastr.js/latest/toastr.min.js"
     = yield(:head)
   %body
     = render 'layouts/navigation'


### PR DESCRIPTION
Enabled toast notifications using [toastr](https://github.com/CodeSeven/toastr) instead of previously used bootstrap flash messages.
Includes both flash messages and new toastr messages for comparison.
The toast notification shown can be significantly styled according to needs and convenience. :smile: 

Addresses #1331 
