### PR TITLE
Fixes #1343, Allow viewing public schedule without login

### DIFF
--- a/app/controllers/schedules_controller.rb
+++ b/app/controllers/schedules_controller.rb
@@ -1,7 +1,8 @@
 class SchedulesController < ApplicationController
+  load_and_authorize_resource
   protect_from_forgery with: :null_session
   before_action :respond_to_options
-  load_and_authorize_resource :conference, find_by: :short_title
+  load_resource :conference, find_by: :short_title
   load_resource :program, through: :conference, singleton: true, except: :index
 
   def show

--- a/app/models/ability.rb
+++ b/app/models/ability.rb
@@ -62,6 +62,10 @@ class Ability
       can [:new, :create], Event do |event|
         event.program.cfp_open? && event.new_record?
       end
+
+      can [:show, :events], Schedule do |schedule|
+        schedule.program.schedule_public
+      end
     end
   end
 


### PR DESCRIPTION
Fixes #1343 

Allow viewing public schedule without login.

![schedule](https://cloud.githubusercontent.com/assets/14261624/23795661/b944df2c-05bc-11e7-9250-9f779311fef1.png)
