### PR TITLE
Improve room creation using ajax

### DIFF
--- a/app/controllers/admin/rooms_controller.rb
+++ b/app/controllers/admin/rooms_controller.rb
@@ -3,6 +3,7 @@ module Admin
     load_and_authorize_resource :conference, find_by: :short_title
     load_and_authorize_resource :venue, through: :conference, singleton: true
     load_and_authorize_resource through: :venue
+    after_action :prepare_unobtrusive_flash, only: [:create]
 
     def index; end
 
@@ -14,12 +15,13 @@ module Admin
 
     def create
       @room = @venue.rooms.new(room_params)
-      if @room.save
-        redirect_to admin_conference_venue_rooms_path(conference_id: @conference.short_title),
-                    notice: 'Room successfully created.'
-      else
-        flash.now[:error] = "Creating Room failed: #{@room.errors.full_messages.join('. ')}."
-        render :new
+      respond_to do |format|
+        if @room.save
+          flash.now[:notice] = 'Room successfully created.'
+        else
+          flash.now[:error] = "Creating Room failed: #{@room.errors.full_messages.join('. ')}."
+        end
+        format.js
       end
     end
 

--- a/app/views/admin/rooms/_form.html.haml
+++ b/app/views/admin/rooms/_form.html.haml
@@ -8,8 +8,8 @@
         = @room.name
 .row
   .col-md-8
-    = semantic_form_for(@room, url: (@room.new_record? ? admin_conference_venue_rooms_path : admin_conference_venue_room_path(@conference.short_title, @room))) do |f|
-      = f.input :name, input_html: { autofocus: true}
-      = f.input :size, input_html: {size: 5}
+    = semantic_form_for(@room, url: (@room.new_record? ? admin_conference_venue_rooms_path : admin_conference_venue_room_path(@conference.short_title, @room)), remote: (true if @room.new_record?)) do |f|
+      = f.input :name, input_html: { autofocus: true}, id: 'room_name'
+      = f.input :size, input_html: {size: 5}, id: 'room_size'
       %p.text-right
         = f.action :submit, as: :button, button_html: { class: 'btn btn-primary' }

--- a/app/views/admin/rooms/create.js.erb
+++ b/app/views/admin/rooms/create.js.erb
@@ -1,0 +1,2 @@
+$('#room_name').val('');
+$('#room_size').val('');

--- a/app/views/layouts/_admin.html.haml
+++ b/app/views/layouts/_admin.html.haml
@@ -8,7 +8,7 @@
         -# Index admin sidebar
         = render 'layouts/admin_sidebar_index'
     .col-md-10
-      #messages
+      #messages.unobtrusive-flash-container
         =render 'layouts/messages'
       #content
         = yield

--- a/spec/controllers/admin/rooms_controller_spec.rb
+++ b/spec/controllers/admin/rooms_controller_spec.rb
@@ -48,13 +48,9 @@ describe Admin::RoomsController do
     end
 
     describe 'POST #create' do
-      context 'saves successfuly' do
+      context 'saves successfuly', js: true do
         before do
-          post :create, room: attributes_for(:room), conference_id: conference.short_title
-        end
-
-        it 'redirects to admin room index path' do
-          expect(response).to redirect_to admin_conference_venue_rooms_path(conference_id: conference.short_title)
+          xhr :post, :create, room: attributes_for(:room), conference_id: conference.short_title
         end
 
         it 'shows success message in flash notice' do
@@ -69,11 +65,7 @@ describe Admin::RoomsController do
       context 'save fails' do
         before do
           allow_any_instance_of(Room).to receive(:save).and_return(false)
-          post :create, room: attributes_for(:room), conference_id: conference.short_title
-        end
-
-        it 'renders new template' do
-          expect(response).to render_template('new')
+          xhr :post, :create, room: attributes_for(:room), conference_id: conference.short_title
         end
 
         it 'shows error in flash message' do

--- a/spec/features/rooms_spec.rb
+++ b/spec/features/rooms_spec.rb
@@ -23,11 +23,9 @@ feature Room do
       click_button 'Create Room'
 
       # Validations
-      expect(flash).to eq('Room successfully created.')
-      within('table#rooms') do
-        expect(page.has_content?('Auditorium')).to be true
-        expect(page.assert_selector('tr', count: 2)).to be true
-      end
+      expect(page).to have_css '#messages', text: 'Room successfully created.'
+      expect(page).to have_css '#room_size', text: ''
+      expect(page).to have_css '#room_name', text: ''
     end
 
     scenario 'updates a room', feature: true, js: true do


### PR DESCRIPTION
Creating multiple rooms is painful for following reasons

- Create action redirect to index page every time you create a new room.
- Need to again browse to new room page to create room.

Improvement

- Create multiple rooms on index page itself without refreshing index page.
- An Increase in work efficiency.

![screenshot from 2017-03-10 20-47-09](https://cloud.githubusercontent.com/assets/14261624/23802131/5de22722-05d8-11e7-9904-3c2de417a8ba.png)

**Updated Screenshot**
- Room's Index page

![screenshot from 2017-03-14 13-25-24](https://cloud.githubusercontent.com/assets/14261624/23891057/7c13c4e6-08ba-11e7-9981-6a362e9942b2.png)

- Room's New Page

![screenshot from 2017-03-14 13-25-39](https://cloud.githubusercontent.com/assets/14261624/23891086/916f739e-08ba-11e7-9db6-cede70dfe3fb.png)

@differentreality, Screenshots Updated