### PR TITLE
Fix jQuery version

### DIFF
--- a/app/assets/javascripts/application.js
+++ b/app/assets/javascripts/application.js
@@ -10,7 +10,7 @@
 // WARNING: THE FIRST BLANK LINE MARKS THE END OF WHAT'S TO BE PROCESSED, ANY BLANK LINE SHOULD
 // GO AFTER THE REQUIRES BELOW.
 //
-//= require jquery
+//= require jquery2
 //= require jquery_ujs
 //= require jquery.mobile.custom.min
 //= require jquery.ui.draggable


### PR DESCRIPTION
Draggable.js is not compatible with jQuery >= 3 which means that several UI elements are broken, but jquery-rails ships with jQuery >= 3 by default now. This patch makes OSEM use jQuery 2 again, so that Draggable.js works again.