### PR TITLE
Fix issue while creating or updating resources

### DIFF
--- a/app/helpers/application_helper.rb
+++ b/app/helpers/application_helper.rb
@@ -578,6 +578,7 @@ module ApplicationHelper
   end
 
   def quantity_left_of(resource)
+    return '-/-' if resource.quantity.blank?
     "#{resource.quantity - resource.used}/#{resource.quantity}"
   end
 

--- a/app/models/resource.rb
+++ b/app/models/resource.rb
@@ -1,10 +1,12 @@
 class Resource < ActiveRecord::Base
   belongs_to :conference
-  validate :used_less_than_quantity
+  validates :name, :used, :quantity, presence: true
+  validates :used, :quantity, numericality: { greater_than_or_equal_to: 0, only_integer: true }
+  validate :used_no_more_than_quantity
 
   private
 
-  def used_less_than_quantity
-    errors.add(:used, 'can not be higher than total quantity') unless used <= quantity
+  def used_no_more_than_quantity
+    errors.add(:used, 'cannot be higher than total quantity') if used.present? && quantity.present? && used > quantity
   end
 end

--- a/app/views/admin/resources/_form.html.haml
+++ b/app/views/admin/resources/_form.html.haml
@@ -9,7 +9,7 @@
   .col-md-8
     = semantic_form_for(@resource, :url => (@resource.new_record? ? admin_conference_resources_path : admin_conference_resource_path(@conference.short_title, @resource))) do |f|
       = f.input :name
-      = f.input :description, input_html: { rows: 5, data: { provide: "markdown-editable" } }
+      = f.input :description, input_html: { rows: 5, data: { provide: 'markdown-editable' } }
       = f.input :used
       = f.input :quantity
       %p.text-right

--- a/lib/tasks/normalize_resources.rake
+++ b/lib/tasks/normalize_resources.rake
@@ -1,0 +1,12 @@
+namespace :data do
+  desc 'Update resources with nil quantity/used fields'
+  task normalize_resources: :environment do
+    Resource.where('used is ? or quantity is ?', nil, nil).each do |resource|
+      resource.used = 0 if resource.used.blank?
+      resource.quantity = resource.used if resource.quantity.blank?
+      unless resource.save
+        puts "Failed to update resource #{resource.name} (ID #{resource.id})"
+      end
+    end
+  end
+end

--- a/spec/models/resource_spec.rb
+++ b/spec/models/resource_spec.rb
@@ -4,6 +4,24 @@ describe Resource do
   let(:conference) { create(:conference) }
   let(:resource) { create :resource }
 
+  it { is_expected.to validate_presence_of(:name) }
+
+  it { is_expected.to validate_presence_of(:used) }
+
+  it { is_expected.to validate_presence_of(:quantity) }
+
+  it { is_expected.to validate_numericality_of(:used) }
+
+  it { is_expected.to validate_numericality_of(:quantity) }
+
+  it { is_expected.not_to allow_value(-1).for(:used) }
+
+  it { is_expected.to allow_value(0).for(:used) }
+
+  it { is_expected.not_to allow_value(-1).for(:quantity) }
+
+  it { is_expected.to allow_value(0).for(:quantity) }
+
   it 'has a valid factory' do
     expect(build(:resource)).to be_valid
   end


### PR DESCRIPTION
Previously on creating a new resource with empty form raised error
`undefined method '<=' for nil::NilClass`
Tried to fix it by adding an extra check for presence of fields, simultaneously set a default value of `quantity` in form to 0.

Still following problem prevails : 

- [x] If a user forcefully submits an empty form we need to check to avoid raising an exception 
`undefined method '-' for nil:NilClass`.
- [x] We can also add a default value 0 to `quantity`


Addresses #1394 