### PR TITLE
Fix SyntaxError in SchedulesController#events

### DIFF
--- a/app/views/schedules/_event.html.haml
+++ b/app/views/schedules/_event.html.haml
@@ -18,7 +18,7 @@
       presented by #{event.speaker_names}
     %p
       = markdown(truncate(event.abstract, length: 400))
-      = link_to 'more', conference_program_proposal_path(@conference.short_title, event.id) if event.abstract.length > 400=>
+      = link_to 'more', conference_program_proposal_path(@conference.short_title, event.id) if event.abstract.length > 400
     - if event_schedule.present?
       %span.track
         %span.fa.fa-clock-o


### PR DESCRIPTION
Remove unexpected `=>` from `app/views/schedules/_event.html.haml` to resolve syntax error.

Closes #1404