### PR TITLE
Docker support for production use

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,2 @@
+Dockerfile
+docker-compose.*

--- a/.gitignore
+++ b/.gitignore
@@ -36,3 +36,4 @@ pickle-email-*.html
 .env.development
 .env.test
 .env.local
+docker-compose.{env,yml}

--- a/.gitignore
+++ b/.gitignore
@@ -36,4 +36,5 @@ pickle-email-*.html
 .env.development
 .env.test
 .env.local
-docker-compose.{env,yml}
+docker-compose.env
+docker-compose.yml

--- a/Dockerfile
+++ b/Dockerfile
@@ -4,7 +4,7 @@ MAINTAINER TheAssassin <theassassin@users.noreply.github.com>
 
 # required for compiling assets
 RUN apt-get update && \
-    apt-get install -y nodejs nodejs-legacy mariadb-client
+    apt-get install -y nodejs nodejs-legacy mariadb-client imagemagick
 
 # used to run the container without root permissions
 RUN adduser --home /osem/ --system --group --disabled-login --disabled-password osem

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,46 @@
+FROM ruby:2.3
+
+MAINTAINER TheAssassin <theassassin@users.noreply.github.com>
+
+# required for compiling assets
+RUN apt-get update && \
+    apt-get install -y nodejs nodejs-legacy mariadb-client
+
+# used to run the container without root permissions
+RUN adduser --home /osem/ --system --group --disabled-login --disabled-password osem
+
+# required to detect when the database is up and running in init.sh
+RUN cd /usr/bin && \
+    wget https://github.com/jwilder/dockerize/releases/download/v0.3.0/dockerize-linux-amd64-v0.3.0.tar.gz -O dockerize.tar.gz && \
+    echo "36e8319cdf9d2b07340f456ec61cfa0f495ec6c130b02ad9c116fd55a5c43fa1  dockerize.tar.gz" | sha256sum -c && \
+    tar -xf dockerize.tar.gz && \
+    rm dockerize.tar.gz
+
+# explicitly add Gemfile and install dependencies using bundler to make use of
+# Docker's caching
+WORKDIR /osem/
+RUN gem install puma
+COPY Gemfile /osem/
+COPY Gemfile.lock /osem/
+RUN bundle install --without test development
+
+# add OSEM files and prepare them for use inside a Docker container
+COPY . /osem/
+RUN chown osem.osem /osem/ -R && \
+    mv /osem/config/database.yml.docker /osem/config/database.yml
+
+# data directory is used to cache the secret key in a file
+ENV DATA_DIR /data
+RUN install -d -m 0700 -o osem $DATA_DIR
+VOLUME ["$DATA_DIR"]
+
+USER osem
+EXPOSE 9292
+
+COPY docker/init.sh /init.sh
+
+# a user could override this if they wanted to serve the static files directly
+# from a webserver
+ENV RAILS_SERVE_STATIC_FILES 1
+
+CMD ["bash", "/init.sh"]

--- a/Dockerfile
+++ b/Dockerfile
@@ -19,7 +19,6 @@ RUN cd /usr/bin && \
 # explicitly add Gemfile and install dependencies using bundler to make use of
 # Docker's caching
 WORKDIR /osem/
-RUN gem install puma
 COPY Gemfile /osem/
 COPY Gemfile.lock /osem/
 RUN bundle install --without test development

--- a/INSTALL.md
+++ b/INSTALL.md
@@ -32,7 +32,9 @@ You can deploy OSEM using [Docker](https://docker.com/) and [Docker-Compose](htt
 
 *This is just a short guide and does not explain how to use Docker and/or Docker-Compose. You need some experience with these tools to be able to deploy OSEM with Docker properly.*
 
-First of all, copy `docker-compose.yml.example` to `docker-compose.yml` and `docker-compose.env.example` to `docker-compose.env`.
+First of all, copy `docker-compose.yml.example` to `docker-compose.yml` and `docker-compose.env.example` to `docker-compose.env`. You should immediately change
+`docker-compose.env`'s permissions to `0600` to make sure all the passphrases in it are kept secret.
+(Tip: the easiest and most secure way to do it is to do it with a single command, for example `install -m 0600 docker-compose.env.example docker-compose.env`).
 
 There are two configurations to deploy OSEM with Docker: *evaluation mode* and *production mode*.
 

--- a/INSTALL.md
+++ b/INSTALL.md
@@ -11,7 +11,9 @@ OSEM is an [semantic versioned](http://semver.org/) app. That means given a vers
 ## Download
 You can find the latest OSEM releases on our [release page](https://github.com/openSUSE/osem/releases/latest) ([older release here](https://github.com/openSUSE/osem/releases))
 
+
 ## Deploy
+
 OSEM is a *Ruby on Rails* application. We recommend to run OSEM in production with [mod_passenger](https://www.phusionpassenger.com/download/#open_source)
 and the [apache web-server](https://www.apache.org/). There are tons of guides on how to deploy rails apps on various
 base operating systems. [Check Google](https://encrypted.google.com/search?hl=en&q=ruby%20on%20rails%20apache%20passenger) ;-)
@@ -23,6 +25,53 @@ If you have an heroku account you can also
 <a href="https://heroku.com/deploy?template=https://github.com/openSUSE/osem/tree/v1.0">
   <img src="https://www.herokucdn.com/deploy/button.svg" alt="Deploy">
 </a>
+
+### Deploy with Docker
+
+You can deploy OSEM using [Docker](https://docker.com/) and [Docker-Compose](https://docs.docker.com/compose/overview/).
+
+*This is just a short guide and does not explain how to use Docker and/or Docker-Compose. You need some experience with these tools to be able to deploy OSEM with Docker properly.*
+
+First of all, copy `docker-compose.yml.example` to `docker-compose.yml` and `docker-compose.env.example` to `docker-compose.env`.
+
+There are two configurations to deploy OSEM with Docker: *evaluation mode* and *production mode*.
+
+#### Evaluation mode
+
+If you want to evaluate OSEM to see if it fits your needs, the default configuration in `docker-compose.env` will work perfectly fine for you.
+For convenience reasons, `docker-compose.yml` already contains a [MailHog](https://github.com/mailhog/MailHog) service configuration. MailHog
+is going to catch every email sent by OSEM and displays them on a special web service. Thus, it eliminitates the need to set up an SMTP server just to try out OSEM.
+Just point your browser to http://localhost:8025 to get access to registration confirmation links etc.
+
+Run `docker-compose up --build` to start the services. On first run, it will take a few minutes to initialize the database. Thus, wait a few minutes before you open up
+http://localhost:9292 in your browser.
+
+#### Production mode
+
+To deploy OSEM for production, you have to make a few changes to `docker-compose.yml`. First, remove (or comment) the `mailhog` service, as it is only useful for evaluation and
+cannot be used for production.
+You can change the forwarded port from port `9292` to any other value if this port is already in use or you just want to use another one.
+
+Next, you have to modify `docker-compose.env`. This file works as a Docker-like replacement for the regular Rails `.env` files described below.
+You can configure any of the configuration values shown in the **Configure** section below in it. The most essential variables are already configured to standard
+values in `docker-compose.env` which you most likely want to change.
+
+First, you need to modify the email related settings. You need a working SMTP server for OSEM to send out registration confirmation mails etc.
+
+For security reasons, the following variables have to be changed, too:
+
+  - `MYSQL_PASSWORD`
+  - `MYSQL_ROOT_PASSWORD`
+  - `SECRET_KEY_BASE`
+
+These variables need to be set to the correct values at first, as they are used to initialize everything. Modification of these variables after installation and initialization is more
+complicated and out of this document's scope.
+
+As with any other Docker-Compose configuration, run `docker-compose up --build` (or `docker-compose up --build -d` to run in background) to start the services. During the first
+start, the database has to be initialized which can take several minutes. The web service is by default exposed on localhost only as it is intended to be served by a reverse proxy (for SSL
+termination, caching etc.).
+You should not directly expose the web server port unless you have a good reason to do so.
+
 
 ## Configure
 There are a couple of environment variables you can set to configure OSEM. Check out the *dotenv.example* file.

--- a/config/database.yml.docker
+++ b/config/database.yml.docker
@@ -1,0 +1,7 @@
+production:
+  adapter: mysql2
+  host: <%= ENV['DATABASE_HOST'] %>
+  port: <%= ENV['DATABASE_PORT'] %>
+  username: <%= ENV['MYSQL_USER'] %>
+  password: <%= ENV['MYSQL_PASSWORD'] %>
+  database: <%= ENV['MYSQL_DATABASE'] %>

--- a/docker-compose.env.example
+++ b/docker-compose.env.example
@@ -32,6 +32,7 @@ SECRET_KEY_BASE=changemechangemechangeme
 # you should comment out or remove the mailhog service from docker-compose.yml,
 # too
 OSEM_EMAIL_ADDRESS=osem@mailhog
+OSEM_SMTP_AUTHENTICATION=login
 OSEM_SMTP_ADDRESS=mailhog
 OSEM_SMTP_PORT=1025
 OSEM_SMTP_USERNAME=mailhog

--- a/docker-compose.env.example
+++ b/docker-compose.env.example
@@ -1,0 +1,38 @@
+## database related variables ##
+
+# variables prefixed with MYSQL_ are used by both database and web containers
+# variables prefixed with DATABASE_ are used exlusively by the web container
+
+MYSQL_DATABASE=osem
+MYSQL_USER=osem
+MYSQL_PASSWORD=changemeimmediately
+MYSQL_ROOT_PASSWORD=changemeevenmoreimmediately
+
+# the following settings should not be modified unless the database service
+# is renamed in docker-compose.yml or you plan to use an external database
+DATABASE_HOST=database
+DATABASE_PORT=3306
+
+
+## OSEM options ##
+# you can configure any option described in this document here instead of
+# having to create a .env file:
+# https://github.com/openSUSE/osem/blob/master/dotenv.example
+
+OSEM_NAME=Dockerized OSEM
+OSEM_HOSTNAME=http://localhost:9292
+OSEM_ERRBIT_HOST=localhost
+SECRET_KEY_BASE=changemechangemechangeme
+
+# these settings work for the MailHog server that is enabled by default in
+# docker-compose.yml
+# if you do not plan to use MailHog (you most likely don't want to), you need
+# to change these settings to use an external working mailserver, otherwise
+# your users are going to see the HTTP status 500 page
+# you should comment out or remove the mailhog service from docker-compose.yml,
+# too
+OSEM_EMAIL_ADDRESS=osem@mailhog
+OSEM_SMTP_ADDRESS=mailhog
+OSEM_SMTP_PORT=1025
+OSEM_SMTP_USERNAME=mailhog
+OSEM_SMTP_PASSWORD=mailhog

--- a/docker-compose.yml.example
+++ b/docker-compose.yml.example
@@ -1,0 +1,29 @@
+version: "2"
+
+services:
+  database:
+    image: mariadb:10.1
+    env_file: docker-compose.env
+    volumes:
+      - database:/var/lib/mysql
+
+  mailhog:
+    image: mailhog/mailhog:latest
+    ports:
+      - "127.0.0.1:8025:8025"
+
+  web:
+    build: .
+    env_file: docker-compose.env
+    depends_on:
+      - database
+      - mailhog
+    ports:
+      - "127.0.0.1:9292:9292"
+    volumes:
+      - "web:/data"
+
+# these named volumes are used to persist data
+volumes:
+  database:
+  web:

--- a/docker/init.sh
+++ b/docker/init.sh
@@ -31,13 +31,16 @@ user=$MYSQL_USER
 password=$MYSQL_PASSWORD
 ABC
 
-if [ $(echo "show tables;" | dockerize -wait tcp://$DATABASE_HOST:$DATABASE_PORT -timeout 60s mysql --host $DATABASE_HOST --port $DATABASE_PORT $MYSQL_DATABASE | wc -l) -le 1 ]; then
+echo ">>> Waiting for database to get ready to connect..."
+dockerize -wait tcp://$DATABASE_HOST:$DATABASE_PORT -timeout 60s true
+
+if [ $(echo "show tables;" | mysql --host $DATABASE_HOST --port $DATABASE_PORT $MYSQL_DATABASE | wc -l) -le 1 ]; then
     echo ">>> Initializing database..."
-    dockerize -wait tcp://$DATABASE_HOST:$DATABASE_PORT -timeout 60s bundle exec rake db:schema:load
+    bundle exec rake db:schema:load
 fi
 
 echo ">>> Upgrading database..."
-dockerize -wait tcp://$DATABASE_HOST:$DATABASE_PORT -timeout 60s bundle exec rake db:migrate
+bundle exec rake db:migrate
 
 rm .my.cnf
 

--- a/docker/init.sh
+++ b/docker/init.sh
@@ -1,0 +1,45 @@
+#! /bin/bash
+
+set -e
+
+# data directory is required for caching the secret key in a file
+if [ "$DATA_DIR" == "" ]; then
+    echo -n "Error: DATA_DIR environment variable not set!"
+    echo "Are you sure you are running this script in a Docker container?"
+    exit 1
+fi
+
+SECRET_KEY_FILE="$DATA_DIR/secret_key"
+
+if [ ! -f "$SECRET_KEY_FILE" ]; then
+    install -m 0600 /dev/null "$SECRET_KEY_FILE"
+    SECRET_KEY=$(cat /dev/urandom | tr -dc 'a-zA-Z0-9' | fold -w 100 | head -n 1)
+    echo "$key" > "$SECRET_KEY_FILE"
+    chmod -w "$SECRET_KEY_FILE"
+else
+    SECRET_KEY=$(cat "$SECRET_KEY_FILE")
+fi
+
+export SECRET_KEY
+export RAILS_ENV=production
+
+install -m 0600 /dev/null .my.cnf
+cat > .my.cnf <<ABC
+[client]
+user=$MYSQL_USER
+password=$MYSQL_PASSWORD
+ABC
+
+if [ $(echo "show tables;" | mysql --host $DATABASE_HOST --port $DATABASE_PORT $MYSQL_DATABASE | wc -l) -le 1 ]; then
+    echo ">>> Initializing database..."
+    dockerize -wait tcp://$DATABASE_HOST:$DATABASE_PORT -timeout 60s bundle exec rake db:schema:load
+fi
+
+echo ">>> Upgrading database..."
+dockerize -wait tcp://$DATABASE_HOST:$DATABASE_PORT -timeout 60s bundle exec rake db:migrate
+
+echo ">>> Precompiling assets..."
+bundle exec rake assets:precompile
+
+echo ">>> Starting application server..."
+exec puma -e production

--- a/docker/init.sh
+++ b/docker/init.sh
@@ -38,6 +38,8 @@ fi
 echo ">>> Upgrading database..."
 dockerize -wait tcp://$DATABASE_HOST:$DATABASE_PORT -timeout 60s bundle exec rake db:migrate
 
+rm .my.cnf
+
 echo ">>> Precompiling assets..."
 bundle exec rake assets:precompile
 

--- a/docker/init.sh
+++ b/docker/init.sh
@@ -42,4 +42,4 @@ echo ">>> Precompiling assets..."
 bundle exec rake assets:precompile
 
 echo ">>> Starting application server..."
-exec puma -e production
+exec bundle exec rails server -e production -p 9292

--- a/docker/init.sh
+++ b/docker/init.sh
@@ -45,4 +45,4 @@ echo ">>> Precompiling assets..."
 bundle exec rake assets:precompile
 
 echo ">>> Starting application server..."
-exec bundle exec rails server -e production -p 9292
+exec bundle exec rails server -e production -b 0.0.0.0 -p 9292

--- a/docker/init.sh
+++ b/docker/init.sh
@@ -12,8 +12,9 @@ fi
 SECRET_KEY_FILE="$DATA_DIR/secret_key"
 
 if [ ! -f "$SECRET_KEY_FILE" ]; then
+    echo ">>> Creating a new secret key file..."
     install -m 0600 /dev/null "$SECRET_KEY_FILE"
-    SECRET_KEY=$(cat /dev/urandom | tr -dc 'a-zA-Z0-9' | fold -w 100 | head -n 1)
+    SECRET_KEY=$(bundle exec rails secret)
     echo "$key" > "$SECRET_KEY_FILE"
     chmod -w "$SECRET_KEY_FILE"
 else

--- a/docker/init.sh
+++ b/docker/init.sh
@@ -14,7 +14,7 @@ SECRET_KEY_FILE="$DATA_DIR/secret_key"
 if [ ! -f "$SECRET_KEY_FILE" ]; then
     echo ">>> Creating a new secret key file..."
     install -m 0600 /dev/null "$SECRET_KEY_FILE"
-    SECRET_KEY=$(bundle exec rails secret)
+    SECRET_KEY=$(bundle exec rake secret)
     echo "$key" > "$SECRET_KEY_FILE"
     chmod -w "$SECRET_KEY_FILE"
 else

--- a/docker/init.sh
+++ b/docker/init.sh
@@ -31,7 +31,7 @@ user=$MYSQL_USER
 password=$MYSQL_PASSWORD
 ABC
 
-if [ $(echo "show tables;" | mysql --host $DATABASE_HOST --port $DATABASE_PORT $MYSQL_DATABASE | wc -l) -le 1 ]; then
+if [ $(echo "show tables;" | dockerize -wait tcp://$DATABASE_HOST:$DATABASE_PORT -timeout 60s mysql --host $DATABASE_HOST --port $DATABASE_PORT $MYSQL_DATABASE | wc -l) -le 1 ]; then
     echo ">>> Initializing database..."
     dockerize -wait tcp://$DATABASE_HOST:$DATABASE_PORT -timeout 60s bundle exec rake db:schema:load
 fi


### PR DESCRIPTION
This commit adds a Docker infrastructure that is ready for production use. It is meant to simplify the deployment of OSEM for everyone who wants to host their own instances.

It includes many features like data persistence, automatic secret key generation and persistence and automatic database initialization and upgrading. This should make updating the Docker container as easy as
possible.

This is the first version, and although it is very stable (as far as I can tell from about two days of extensive testing), this might not yet fit OSEM's needs completely, so I regard it as a draft at the moment.

Feel free to comment and make suggestions, I'd like to make this as good and easy to use as possible, as I am one of the potential end users who are going to profit from this commit a lot.

This PR would close #1377 when being merged.