### PR TITLE
Fix #1406. Registration form consistency with User model

### DIFF
--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -53,7 +53,7 @@ class User < ActiveRecord::Base
 
   scope :admin, -> { where(is_admin: true) }
 
-  validates :email, presence: true
+  validates :email, :password, :password_confirmation, presence: true
 
   validates :username,
             uniqueness: {

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -53,7 +53,8 @@ class User < ActiveRecord::Base
 
   scope :admin, -> { where(is_admin: true) }
 
-  validates :email, :password, :password_confirmation, presence: true
+  validates :email, presence: true
+  validates :password, :password_confirmation, presence: true, on: :create
 
   validates :username,
             uniqueness: {

--- a/app/views/devise/ichain_sessions/new.html.haml
+++ b/app/views/devise/ichain_sessions/new.html.haml
@@ -10,11 +10,8 @@
             = f.input :url, as: :hidden, input_html: { value: @back_url }
             = f.input :context, as: :hidden, input_html: { value: @context }
             = f.input :proxypath, as: :hidden, input_html: { value: @proxypath }
-
             = f.input :username, input_html: { autofocus: true }
             = f.input :password, as: :password
-
             %p.text-right
               = f.action :submit, as: :button, label: 'Sign In', button_html: { class: 'btn btn-success' }
-
             = render partial: 'devise/shared/help'

--- a/app/views/devise/registrations/edit.html.haml
+++ b/app/views/devise/registrations/edit.html.haml
@@ -2,21 +2,22 @@
   .row
     .col-md-12
       .page-header
-        %h1 Edit your Account
+        %h1 Edit Your Account
   .row
     .col-md-12
       = semantic_form_for(resource, as: resource_name, url: registration_path(resource_name), html: { method: :put }) do |f|
         = f.input :username, required: false, input_html: { autocomplete: 'off' }
         = f.input :email, required: false, input_html: { autocomplete: 'off' }
-        = f.input :email_public
+        = f.input :email_public, label: "Make my email public"
         = f.input :password, hint: "(Leave blank if you don't want to change it)", input_html: { autocomplete: 'off' }
         = f.input :password_confirmation, input_html: { autocomplete: 'off' }
         = f.inputs name: 'OpenID' do
-          %h4
-            Currently the following openIDs are associated with your account
-          - @openids.each do |openid|
-            %li= "#{openid.provider}:#{openid.email}"
-            %br
+          - if @openids.present?
+            %h4
+              Currently the following openIDs are associated with your account
+              - @openids.each do |openid|
+                %li= "#{openid.provider}:#{openid.email}"
+                %br
           %h4
             To add an openID with a different email address to your account, sign in with your
             openID while logged in to OSEM

--- a/app/views/devise/registrations/new.html.haml
+++ b/app/views/devise/registrations/new.html.haml
@@ -9,7 +9,7 @@
           = semantic_form_for(resource, as: resource_name, url: registration_path(resource_name)) do |f|
             = f.input :username, input_html: { required: true }
             = f.input :email, input_html: { required: true }
-            = f.input :name, input_html: { required: true }
+            = f.input :name
             = f.input :password, input_html: { required: true }
             = f.input :password_confirmation, input_html: { required: true }
             %p.text-right

--- a/app/views/devise/sessions/new.html.haml
+++ b/app/views/devise/sessions/new.html.haml
@@ -7,7 +7,7 @@
             Sign In
         .panel-body
           = semantic_form_for(resource, as: resource_name, url: session_path(resource_name)) do |f|
-            = f.input :login
+            = f.input :login, label: "Username / Email"
             = f.input :password
             - if devise_mapping.rememberable?
               %p.text-right.small

--- a/app/views/users/edit.html.haml
+++ b/app/views/users/edit.html.haml
@@ -11,7 +11,7 @@
         .control-label
           = "Avatar"
         = image_tag(@user.gravatar_url(size: '48'), title: "Yo #{@user.name}!", alt: '')
-        = link_to 'Change your avatar here', 'https://gravatar.com'
+        = link_to 'Change your avatar here', 'https://gravatar.com', target: :_blank
         = f.input :affiliation, as: :string,
           hint: 'This could be a company, a user group, or nothing at all.'
         = f.input :biography, input_html: { rows: 5, data: { provide: 'markdown-editable' } },


### PR DESCRIPTION
There is an inconsistent situation with User model and new registration form.

-  "Name" field stands for the real name of users, however it's not clear if a full name, first name or last name expected.

The issue (#1406) is because of lack of necessary validations on password and password_confirmation. Beside this, there is no validation about "name" on the User model and it seems like name is an optional field:

```
  def name
    self[:name].blank? ? username : self[:name]
  end
```

So it is probably best to remove { required: true } tag for 'name', and, add necessary validations for password and password_confirmation.