### PR TITLE
Enable Style/ZeroLengthPredicate Rubocop cop

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -92,6 +92,10 @@ Style/TrailingBlankLines:
 Style/TrailingWhitespace:
   Enabled: true
 
+#This cop checks for numeric comparisons that can be replaced by a predicate method.
+Style/ZeroLengthPredicate:
+  Enabled: true
+
 #################### Metrics ###############################
 
 # Avoid deep blocks nesting

--- a/.rubocop_todo.yml
+++ b/.rubocop_todo.yml
@@ -680,8 +680,3 @@ Style/UnneededInterpolation:
 Style/WordArray:
   EnforcedStyle: percent
   MinSize: 3
-
-# Offense count: 1
-Style/ZeroLengthPredicate:
-  Exclude:
-    - 'app/models/conference.rb'

--- a/app/models/conference.rb
+++ b/app/models/conference.rb
@@ -464,7 +464,7 @@ class Conference < ActiveRecord::Base
     result = Conference.where('start_date > ?', Time.now).
         select('id, short_title, color, start_date')
 
-    if result.length == 0
+    if result.empty?
       result = Conference.
           select('id, short_title, color, start_date').limit(2).
           order(start_date: :desc)


### PR DESCRIPTION
This cop checks for numeric comparisons that can be replaced by a predicate method. It supports autocorrection, so all the offenses where automatically solved.

Closes #1416