### PR TITLE
Fix dublicated routes 

### DIFF
--- a/config/routes.rb
+++ b/config/routes.rb
@@ -18,7 +18,6 @@ Osem::Application.routes.draw do
   resources :users, except: [:new, :index, :create, :destroy]
 
   namespace :admin do
-    resources :users
     resources :users do
       member do
         patch :toggle_confirmation


### PR DESCRIPTION
When an error occured, in Action Controller:Exception caught, some of the routes were shown twice.   