### PR TITLE
use flash.now instead of flash before calling render

### DIFF
--- a/app/controllers/admin/campaigns_controller.rb
+++ b/app/controllers/admin/campaigns_controller.rb
@@ -15,7 +15,7 @@ module Admin
         redirect_to admin_conference_campaigns_path(conference_id: @conference.short_title),
                     notice: 'Campaign successfully created.'
       else
-        flash[:error] = 'Campaign creation failed. ' + @campaign.errors.full_messages.to_sentence
+        flash.now[:error] = 'Campaign creation failed. ' + @campaign.errors.full_messages.to_sentence
         render action: 'new'
       end
     end
@@ -29,7 +29,7 @@ module Admin
         redirect_to admin_conference_campaigns_path(conference_id: @conference.short_title),
                     notice: "Campaign '#{@campaign.name}' successfully updated."
       else
-        flash[:error] = "Campaign update failed.  #{@campaign.errors.full_messages.to_sentence}"
+        flash.now[:error] = "Campaign update failed.  #{@campaign.errors.full_messages.to_sentence}"
         render action: 'edit'
       end
     end

--- a/app/controllers/admin/cfps_controller.rb
+++ b/app/controllers/admin/cfps_controller.rb
@@ -21,7 +21,7 @@ module Admin
         redirect_to admin_conference_program_cfp_path,
                     notice: 'Call for papers successfully created.'
       else
-        flash[:error] = "Creating the call for papers failed. #{@cfp.errors.full_messages.join('. ')}."
+        flash.now[:error] = "Creating the call for papers failed. #{@cfp.errors.full_messages.join('. ')}."
         render :new
       end
     end
@@ -37,7 +37,7 @@ module Admin
         redirect_to admin_conference_program_cfp_path(@conference.short_title),
                     notice: 'Call for papers successfully updated.'
       else
-        flash[:error] = "Updating call for papers failed. #{@cfp.errors.to_a.join('. ')}."
+        flash.now[:error] = "Updating call for papers failed. #{@cfp.errors.to_a.join('. ')}."
         render :new
       end
     end

--- a/app/controllers/admin/conferences_controller.rb
+++ b/app/controllers/admin/conferences_controller.rb
@@ -73,7 +73,7 @@ module Admin
         redirect_to admin_conference_path(id: @conference.short_title),
                     notice: 'Conference was successfully created.'
       else
-        flash[:error] = 'Could not create conference. ' + @conference.errors.full_messages.to_sentence
+        flash.now[:error] = 'Could not create conference. ' + @conference.errors.full_messages.to_sentence
         render action: 'new'
       end
     end

--- a/app/controllers/admin/difficulty_levels_controller.rb
+++ b/app/controllers/admin/difficulty_levels_controller.rb
@@ -20,7 +20,7 @@ module Admin
         redirect_to admin_conference_program_difficulty_levels_path(conference_id: @conference.short_title),
                     notice: 'Difficulty level successfully created.'
       else
-        flash[:error] = "Creating difficulty level failed: #{@difficulty_level.errors.full_messages.join('. ')}."
+        flash.now[:error] = "Creating difficulty level failed: #{@difficulty_level.errors.full_messages.join('. ')}."
         render :new
       end
     end
@@ -30,7 +30,7 @@ module Admin
         redirect_to admin_conference_program_difficulty_levels_path(conference_id: @conference.short_title),
                     notice: 'Difficulty level successfully updated.'
       else
-        flash[:error] = "Update difficulty level failed: #{@difficulty_level.errors.full_messages.join('. ')}."
+        flash.now[:error] = "Update difficulty level failed: #{@difficulty_level.errors.full_messages.join('. ')}."
         render :edit
       end
     end

--- a/app/controllers/admin/event_types_controller.rb
+++ b/app/controllers/admin/event_types_controller.rb
@@ -18,7 +18,7 @@ module Admin
         redirect_to admin_conference_program_event_types_path(conference_id: @conference.short_title),
                     notice: 'Event type successfully created.'
       else
-        flash[:error] = "Creating event type failed: #{@event_type.errors.full_messages.join('. ')}."
+        flash.now[:error] = "Creating event type failed: #{@event_type.errors.full_messages.join('. ')}."
         render :new
       end
     end
@@ -28,7 +28,7 @@ module Admin
         redirect_to admin_conference_program_event_types_path(conference_id: @conference.short_title),
                     notice: 'Event type successfully updated.'
       else
-        flash[:error] = "Update event type failed: #{@event_type.errors.full_messages.join('. ')}."
+        flash.now[:error] = "Update event type failed: #{@event_type.errors.full_messages.join('. ')}."
         render :edit
       end
     end

--- a/app/controllers/admin/events_controller.rb
+++ b/app/controllers/admin/events_controller.rb
@@ -89,7 +89,7 @@ module Admin
         end
       else
         @url = admin_conference_program_event_path(@conference.short_title, @event)
-        flash[:error] = 'Update not successful. ' + @event.errors.full_messages.to_sentence
+        flash.now[:error] = 'Update not successful. ' + @event.errors.full_messages.to_sentence
         render :edit
       end
     end

--- a/app/controllers/admin/lodgings_controller.rb
+++ b/app/controllers/admin/lodgings_controller.rb
@@ -16,7 +16,7 @@ module Admin
         redirect_to admin_conference_lodgings_path(conference_id: @conference.short_title),
                     notice: 'Lodging successfully created.'
       else
-        flash[:error] = "Creating Lodging failed: #{@lodging.errors.full_messages.join('. ')}."
+        flash.now[:error] = "Creating Lodging failed: #{@lodging.errors.full_messages.join('. ')}."
         render :new
       end
     end
@@ -28,7 +28,7 @@ module Admin
         redirect_to admin_conference_lodgings_path(conference_id: @conference.short_title),
                     notice: 'Lodging successfully updated.'
       else
-        flash[:error] = "Update Lodging failed: #{@lodging.errors.full_messages.join('. ')}."
+        flash.now[:error] = "Update Lodging failed: #{@lodging.errors.full_messages.join('. ')}."
         render :edit
       end
     end

--- a/app/controllers/admin/programs_controller.rb
+++ b/app/controllers/admin/programs_controller.rb
@@ -27,7 +27,7 @@ module Admin
       else
         respond_to do |format|
           format.html do
-            flash[:error] = "Updating program failed. #{@program.errors.to_a.join('. ')}."
+            flash.now[:error] = "Updating program failed. #{@program.errors.to_a.join('. ')}."
             render :new
           end
           format.js { render json: { errors: "The selected schedule couldn't been updated #{@program.errors.to_a.join('. ')}" }, status: 422 }

--- a/app/controllers/admin/registration_periods_controller.rb
+++ b/app/controllers/admin/registration_periods_controller.rb
@@ -16,7 +16,7 @@ module Admin
         redirect_to admin_conference_registration_period_path(@conference.short_title),
                     notice: 'Registration Period successfully updated.'
       else
-        flash[:error] = "An error prohibited the Registration Period from being saved: #{@registration_period.errors.full_messages.join('. ')}."
+        flash.now[:error] = "An error prohibited the Registration Period from being saved: #{@registration_period.errors.full_messages.join('. ')}."
         render :new
       end
     end
@@ -36,7 +36,7 @@ module Admin
         redirect_to admin_conference_registration_period_path(@conference.short_title),
                     notice: 'Registration Period successfully updated.'
       else
-        flash[:error] = 'An error prohibited the Registration Period from being saved: ' \
+        flash.now[:error] = 'An error prohibited the Registration Period from being saved: ' \
         "#{@registration_period.errors.full_messages.join('. ')}."
         render :edit
       end

--- a/app/controllers/admin/registrations_controller.rb
+++ b/app/controllers/admin/registrations_controller.rb
@@ -24,7 +24,7 @@ module Admin
         redirect_to admin_conference_registrations_path(@conference.short_title),
                     notice: "Successfully updated registration for #{@registration.user.email}!"
       else
-        flash[:error] = "An error prohibited the Registration for #{@registration.user.email}: "\
+        flash.now[:error] = "An error prohibited the Registration for #{@registration.user.email}: "\
                         "#{@registration.errors.full_messages.join('. ')}."
         render :edit
       end

--- a/app/controllers/admin/resources_controller.rb
+++ b/app/controllers/admin/resources_controller.rb
@@ -17,7 +17,7 @@ module Admin
         redirect_to admin_conference_resources_path(conference_id: @conference.short_title),
                     notice: 'Resource successfully created.'
       else
-        flash[:error] = "Creating resource failed: #{@resource.errors.full_messages.join('. ')}."
+        flash.now[:error] = "Creating resource failed: #{@resource.errors.full_messages.join('. ')}."
         render :new
       end
     end
@@ -27,7 +27,7 @@ module Admin
         redirect_to admin_conference_resources_path(conference_id: @conference.short_title),
                     notice: 'Resource successfully updated.'
       else
-        flash[:error] = "Resource update failed: #{@resource.errors.full_messages.join('. ')}."
+        flash.now[:error] = "Resource update failed: #{@resource.errors.full_messages.join('. ')}."
         render :edit
       end
     end

--- a/app/controllers/admin/roles_controller.rb
+++ b/app/controllers/admin/roles_controller.rb
@@ -27,7 +27,7 @@ module Admin
                     notice: 'Successfully updated role ' + @role.name
       else
         @role.name = role_name
-        flash[:error] = 'Could not update role! ' + @role.errors.full_messages.to_sentence
+        flash.now[:error] = 'Could not update role! ' + @role.errors.full_messages.to_sentence
         render :edit
       end
     end

--- a/app/controllers/admin/rooms_controller.rb
+++ b/app/controllers/admin/rooms_controller.rb
@@ -18,7 +18,7 @@ module Admin
         redirect_to admin_conference_venue_rooms_path(conference_id: @conference.short_title),
                     notice: 'Room successfully created.'
       else
-        flash[:error] = "Creating Room failed: #{@room.errors.full_messages.join('. ')}."
+        flash.now[:error] = "Creating Room failed: #{@room.errors.full_messages.join('. ')}."
         render :new
       end
     end
@@ -28,7 +28,7 @@ module Admin
         redirect_to admin_conference_venue_rooms_path(conference_id: @conference.short_title),
                     notice: 'Room successfully updated.'
       else
-        flash[:error] = "Update Room failed: #{@room.errors.full_messages.join('. ')}."
+        flash.now[:error] = "Update Room failed: #{@room.errors.full_messages.join('. ')}."
         render :edit
       end
     end

--- a/app/controllers/admin/sponsors_controller.rb
+++ b/app/controllers/admin/sponsors_controller.rb
@@ -20,7 +20,7 @@ module Admin
         redirect_to admin_conference_sponsors_path(conference_id: @conference.short_title),
                     notice: 'Sponsor successfully created.'
       else
-        flash[:error] = "Creating sponsor failed: #{@sponsor.errors.full_messages.join('. ')}."
+        flash.now[:error] = "Creating sponsor failed: #{@sponsor.errors.full_messages.join('. ')}."
         render :new
       end
     end
@@ -31,7 +31,7 @@ module Admin
                     conference_id: @conference.short_title),
                     notice: 'Sponsor successfully updated.'
       else
-        flash[:error] = "Update sponsor failed: #{@sponsor.errors.full_messages.join('. ')}."
+        flash.now[:error] = "Update sponsor failed: #{@sponsor.errors.full_messages.join('. ')}."
         render :edit
       end
     end

--- a/app/controllers/admin/sponsorship_levels_controller.rb
+++ b/app/controllers/admin/sponsorship_levels_controller.rb
@@ -19,7 +19,7 @@ module Admin
         redirect_to admin_conference_sponsorship_levels_path(conference_id: @conference.short_title),
                     notice: 'Sponsorship level successfully created.'
       else
-        flash[:error] = "Creating Sponsorship Level failed: #{@sponsorship_level.errors.full_messages.join('. ')}."
+        flash.now[:error] = "Creating Sponsorship Level failed: #{@sponsorship_level.errors.full_messages.join('. ')}."
         render :new
       end
     end
@@ -30,7 +30,7 @@ module Admin
                     conference_id: @conference.short_title),
                     notice: 'Sponsorship level successfully updated.'
       else
-        flash[:error] = "Update Sponsorship level failed: #{@sponsorship_level.errors.full_messages.join('. ')}."
+        flash.now[:error] = "Update Sponsorship level failed: #{@sponsorship_level.errors.full_messages.join('. ')}."
         render :edit
       end
     end

--- a/app/controllers/admin/targets_controller.rb
+++ b/app/controllers/admin/targets_controller.rb
@@ -15,7 +15,7 @@ module Admin
         redirect_to admin_conference_targets_path(conference_id: @conference.short_title),
                     notice: 'Target successfully created.'
       else
-        flash[:error] = "Creating target failed: #{@target.errors.full_messages.join('. ')}."
+        flash.now[:error] = "Creating target failed: #{@target.errors.full_messages.join('. ')}."
         render :new
       end
     end
@@ -27,7 +27,7 @@ module Admin
         redirect_to admin_conference_targets_path(conference_id: @conference.short_title),
                     notice: 'Target successfully updated.'
       else
-        flash[:error] = "Target update failed: #{@target.errors.full_messages.join('. ')}."
+        flash.now[:error] = "Target update failed: #{@target.errors.full_messages.join('. ')}."
         render :edit
       end
     end

--- a/app/controllers/admin/tickets_controller.rb
+++ b/app/controllers/admin/tickets_controller.rb
@@ -17,7 +17,7 @@ module Admin
         redirect_to admin_conference_tickets_path(conference_id: @conference.short_title),
                     notice: 'Ticket successfully created.'
       else
-        flash[:error] = "Creating Ticket failed: #{@ticket.errors.full_messages.join('. ')}."
+        flash.now[:error] = "Creating Ticket failed: #{@ticket.errors.full_messages.join('. ')}."
         render :new
       end
     end
@@ -29,7 +29,7 @@ module Admin
         redirect_to admin_conference_tickets_path(conference_id: @conference.short_title),
                     notice: 'Ticket successfully updated.'
       else
-        flash[:error] = "Ticket update failed: #{@ticket.errors.full_messages.join('. ')}."
+        flash.now[:error] = "Ticket update failed: #{@ticket.errors.full_messages.join('. ')}."
         render :edit
       end
     end

--- a/app/controllers/admin/tracks_controller.rb
+++ b/app/controllers/admin/tracks_controller.rb
@@ -23,7 +23,7 @@ module Admin
         redirect_to admin_conference_program_tracks_path(conference_id: @conference.short_title),
                     notice: 'Track successfully created.'
       else
-        flash[:error] = "Creating Track failed: #{@track.errors.full_messages.join('. ')}."
+        flash.now[:error] = "Creating Track failed: #{@track.errors.full_messages.join('. ')}."
         render :new
       end
     end
@@ -35,7 +35,7 @@ module Admin
         redirect_to admin_conference_program_tracks_path(conference_id: @conference.short_title),
                     notice: 'Track successfully updated.'
       else
-        flash[:error] = "Track update failed: #{@track.errors.full_messages.join('. ')}."
+        flash.now[:error] = "Track update failed: #{@track.errors.full_messages.join('. ')}."
         render :edit
       end
     end

--- a/app/controllers/admin/venues_controller.rb
+++ b/app/controllers/admin/venues_controller.rb
@@ -27,7 +27,7 @@ module Admin
         redirect_to admin_conference_venue_path(conference_id: @conference.short_title),
                     notice: 'Venue was successfully updated.'
       else
-        flash[:error] = "Update venue failed: #{@venue.errors.full_messages.join('. ')}."
+        flash.now[:error] = "Update venue failed: #{@venue.errors.full_messages.join('. ')}."
         render :edit
       end
     end

--- a/app/controllers/conference_registrations_controller.rb
+++ b/app/controllers/conference_registrations_controller.rb
@@ -65,7 +65,7 @@ class ConferenceRegistrationsController < ApplicationController
                     notice: 'You are now registered and will be receiving E-Mail notifications.'
       end
     else
-      flash[:error] = "Could not create your registration for #{@conference.title}: "\
+      flash.now[:error] = "Could not create your registration for #{@conference.title}: "\
                         "#{@registration.errors.full_messages.join('. ')}."
       render :new
     end
@@ -76,7 +76,7 @@ class ConferenceRegistrationsController < ApplicationController
       redirect_to  conference_conference_registration_path(@conference.short_title),
                    notice: 'Registration was successfully updated.'
     else
-      flash[:error] = "Could not update your registration for #{@conference.title}: "\
+      flash.now[:error] = "Could not update your registration for #{@conference.title}: "\
                         "#{@registration.errors.full_messages.join('. ')}."
       render :edit
     end

--- a/app/controllers/payments_controller.rb
+++ b/app/controllers/payments_controller.rb
@@ -23,7 +23,7 @@ class PaymentsController < ApplicationController
     else
       @total_amount_to_pay = Ticket.total_price(@conference, current_user, paid: false)
       @unpaid_ticket_purchases = current_user.ticket_purchases.unpaid.by_conference(@conference)
-      flash[:error] = @payment.errors.full_messages.to_sentence + ' Please try again with correct credentials.'
+      flash.now[:error] = @payment.errors.full_messages.to_sentence + ' Please try again with correct credentials.'
       render :new
     end
   end

--- a/app/controllers/proposals_controller.rb
+++ b/app/controllers/proposals_controller.rb
@@ -40,7 +40,7 @@ class ProposalsController < ApplicationController
       if @user.save
         sign_in(@user)
       else
-        flash[:error] = "Could not save user: #{@user.errors.full_messages.join(', ')}"
+        flash.now[:error] = "Could not save user: #{@user.errors.full_messages.join(', ')}"
         render action: 'new'
         return
       end
@@ -57,7 +57,7 @@ class ProposalsController < ApplicationController
       ahoy.track 'Event submission', title: 'New submission'
       redirect_to conference_program_proposals_path(@conference.short_title), notice: 'Proposal was successfully submitted.'
     else
-      flash[:error] = "Could not submit proposal: #{@event.errors.full_messages.join(', ')}"
+      flash.now[:error] = "Could not submit proposal: #{@event.errors.full_messages.join(', ')}"
       render action: 'new'
     end
   end
@@ -69,7 +69,7 @@ class ProposalsController < ApplicationController
       redirect_to conference_program_proposals_path(conference_id: @conference.short_title),
                   notice: 'Proposal was successfully updated.'
     else
-      flash[:error] = "Could not update proposal: #{@event.errors.full_messages.join(', ')}"
+      flash.now[:error] = "Could not update proposal: #{@event.errors.full_messages.join(', ')}"
       render action: 'edit'
     end
   end

--- a/app/controllers/users_controller.rb
+++ b/app/controllers/users_controller.rb
@@ -15,7 +15,7 @@ class UsersController < ApplicationController
     if @user.update(user_params)
       redirect_to @user, notice: 'User was successfully updated.'
     else
-      flash[:error] = "An error prohibited your Profile from being saved: #{@user.errors.full_messages.join('. ')}."
+      flash.now[:error] = "An error prohibited your Profile from being saved: #{@user.errors.full_messages.join('. ')}."
       render :edit
     end
   end


### PR DESCRIPTION
the flash messages are used incorrectly in OSEM controllers in those cases where controller method just renders a template after setting the flash message, accordingly to the Rails official documentation, one should use flash.now in such cases:
http://guides.rubyonrails.org/action_controller_overview.html#the-flash

the code in its current state can produce a misleading flash message output on the pages where the message is not relevant to the page being displayed, here is the scenario to reproduce the issue:
1 - go to any form which may produce flash messages on template render 
2 - provoke the error (e.g. by providing invalid form data)
3 - submit the form
4 - observe the error in the re-rendered form
5 - open some other OSEM page in the different tab - observe the duplicate flash error message

this bug was discussed with @differentreality in the project IRC chat and we agreed that this should be fixed, this PR has the necessary changes.

Sincerely
Eugene/CommandPrompt Inc.
