### PR TITLE
Adds Style/Tab cop to rubocop.yml

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -88,6 +88,10 @@ Style/SpaceAroundOperators:
 Style/StringLiterals:
   Enabled: true
 
+# This cop checks for tabs where spaces should be used.
+Style/Tab:
+  Enabled: true
+
 # Avoid trailing blank lines
 Style/TrailingBlankLines:
   Enabled: true

--- a/.rubocop_todo.yml
+++ b/.rubocop_todo.yml
@@ -609,17 +609,6 @@ Style/SymbolProc:
     - 'spec/controllers/admin/conferences_controller_spec.rb'
     - 'spec/support/flash.rb'
 
-# Offense count: 23
-# Cop supports --auto-correct.
-Style/Tab:
-  Exclude:
-    - 'db/migrate/20141031225545_add_require_handicapped_access_to_questions.rb'
-    - 'db/migrate/20141031225606_add_attending_with_partner_to_questions.rb'
-    - 'db/migrate/20141031225620_add_staying_at_suggested_hotel_to_questions.rb'
-    - 'db/migrate/20141031225635_add_attending_social_events_to_questions.rb'
-    - 'db/migrate/20141118162030_change_lodging_association_to_conference.rb'
-    - 'spec/features/campaign_spec.rb'
-    - 'spec/features/event_types_spec.rb'
 
 # Offense count: 26
 # Cop supports --auto-correct.

--- a/db/migrate/20141031225545_add_require_handicapped_access_to_questions.rb
+++ b/db/migrate/20141031225545_add_require_handicapped_access_to_questions.rb
@@ -75,11 +75,11 @@ class AddRequireHandicappedAccessToQuestions < ActiveRecord::Migration
       TempConferencesQuestions.find_or_create_by!(conference_id: c.id, question_id: q.id)
 
       TempRegistration.where(conference_id: c.id).each do |r|
-	if r.handicapped_access_required
-	  TempQanswerRegistration.find_or_create_by!(registration_id: r.id, qanswer_id: qa_yes.id)
-	else
-	  TempQanswerRegistration.find_or_create_by!(registration_id: r.id, qanswer_id: qa_no.id)
-	end
+        if r.handicapped_access_required
+          TempQanswerRegistration.find_or_create_by!(registration_id: r.id, qanswer_id: qa_yes.id)
+        else
+          TempQanswerRegistration.find_or_create_by!(registration_id: r.id, qanswer_id: qa_no.id)
+        end
       end
     end
     remove_column :registrations, :handicapped_access_required, :boolean

--- a/db/migrate/20141031225606_add_attending_with_partner_to_questions.rb
+++ b/db/migrate/20141031225606_add_attending_with_partner_to_questions.rb
@@ -75,11 +75,11 @@ class AddAttendingWithPartnerToQuestions < ActiveRecord::Migration
       TempConferencesQuestions.find_or_create_by!(conference_id: c.id, question_id: q.id)
 
       TempRegistration.where(conference_id: c.id).each do |r|
-	if r.attending_with_partner
-	  TempQanswerRegistration.find_or_create_by!(registration_id: r.id, qanswer_id: qa_yes.id)
-	else
-	  TempQanswerRegistration.find_or_create_by!(registration_id: r.id, qanswer_id: qa_no.id)
-	end
+        if r.attending_with_partner
+          TempQanswerRegistration.find_or_create_by!(registration_id: r.id, qanswer_id: qa_yes.id)
+        else
+          TempQanswerRegistration.find_or_create_by!(registration_id: r.id, qanswer_id: qa_no.id)
+        end
       end
     end
     remove_column :registrations, :attending_with_partner, :boolean

--- a/db/migrate/20141031225620_add_staying_at_suggested_hotel_to_questions.rb
+++ b/db/migrate/20141031225620_add_staying_at_suggested_hotel_to_questions.rb
@@ -75,11 +75,11 @@ class AddStayingAtSuggestedHotelToQuestions < ActiveRecord::Migration
       TempConferencesQuestions.find_or_create_by!(conference_id: c.id, question_id: q.id)
 
       TempRegistration.where(conference_id: c.id).each do |r|
-	if r.using_affiliated_lodging
-	  TempQanswerRegistration.find_or_create_by!(registration_id: r.id, qanswer_id: qa_yes.id)
-	else
-	  TempQanswerRegistration.find_or_create_by!(registration_id: r.id, qanswer_id: qa_no.id)
-	end
+        if r.using_affiliated_lodging
+          TempQanswerRegistration.find_or_create_by!(registration_id: r.id, qanswer_id: qa_yes.id)
+        else
+          TempQanswerRegistration.find_or_create_by!(registration_id: r.id, qanswer_id: qa_no.id)
+        end
       end
     end
     remove_column :registrations, :using_affiliated_lodging, :boolean

--- a/db/migrate/20141031225635_add_attending_social_events_to_questions.rb
+++ b/db/migrate/20141031225635_add_attending_social_events_to_questions.rb
@@ -75,11 +75,11 @@ class AddAttendingSocialEventsToQuestions < ActiveRecord::Migration
       TempConferencesQuestions.find_or_create_by!(conference_id: c.id, question_id: q.id)
 
       TempRegistration.where(conference_id: c.id).each do |r|
-	if r.attending_social_events
-	  TempQanswerRegistration.find_or_create_by!(registration_id: r.id, qanswer_id: qa_yes.id)
-	else
-	  TempQanswerRegistration.find_or_create_by!(registration_id: r.id, qanswer_id: qa_no.id)
-	end
+        if r.attending_social_events
+          TempQanswerRegistration.find_or_create_by!(registration_id: r.id, qanswer_id: qa_yes.id)
+        else
+          TempQanswerRegistration.find_or_create_by!(registration_id: r.id, qanswer_id: qa_no.id)
+        end
       end
     end
     remove_column :registrations, :attending_social_events, :boolean

--- a/db/migrate/20141118162030_change_lodging_association_to_conference.rb
+++ b/db/migrate/20141118162030_change_lodging_association_to_conference.rb
@@ -21,7 +21,7 @@ class ChangeLodgingAssociationToConference < ActiveRecord::Migration
         venue = TempVenue.find_by(conference_id: conference.id)
         lodgings = TempLodging.where(venue_id: venue.id)
         lodgings.each do |lodging|
-	  lodging.update_attributes(conference_id: conference.id)
+          lodging.update_attributes(conference_id: conference.id)
         end
       end
     end

--- a/spec/features/event_types_spec.rb
+++ b/spec/features/event_types_spec.rb
@@ -38,7 +38,7 @@ feature EventType do
 
       # Remove event type
       within('tr', text: 'Party') do
-	click_link 'Delete'
+        click_link 'Delete'
       end
       expect(flash).to eq('Event type successfully deleted.')
 


### PR DESCRIPTION
This cop checks syntax for hard tabs. 

Style/Tab offense exclusions are removed from rubocop_todo.yml.

Cop offenses have been corrected.

Fixes #1428 