### PR TITLE
Fix admin/resources inherit

### DIFF
--- a/app/controllers/admin/resources_controller.rb
+++ b/app/controllers/admin/resources_controller.rb
@@ -1,5 +1,5 @@
 module Admin
-  class ResourcesController < ApplicationController
+  class ResourcesController < Admin::BaseController
     load_and_authorize_resource :conference, find_by: :short_title
     load_and_authorize_resource :resource, only: [:show, :edit, :update, :destroy]
 


### PR DESCRIPTION
Issue  #1427 admin/resources_controller.rb inherited ApplicationController instead of Admin::BaseController