### PR TITLE
Add description to xml. fixes #1435

### DIFF
--- a/app/views/schedules/show.xml.haml
+++ b/app/views/schedules/show.xml.haml
@@ -27,6 +27,7 @@
                 %subtitle= event.subtitle
                 %track= event.track.name if event.track
                 %abstract= event.abstract
+                %description= event.abstract
                 %recording
                   %license/
                   %optout=false #FIXME


### PR DESCRIPTION
Add field description with the content of abstract to schedule show xml.  Fix #1435 