### PR TITLE
Add place autocomplete

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -85,7 +85,9 @@ gem 'jquery-ui-rails', '~> 4.2.1'
 gem 'iso-639'
 
 # geocoder 
-gem 'geocoder'
+# gem 'geocoder'
+##execute gem install geocoder serverside and uncomment the above line
+
 
 # frontend javascripts
 source 'https://rails-assets.org' do

--- a/Gemfile
+++ b/Gemfile
@@ -84,11 +84,6 @@ gem 'jquery-ui-rails', '~> 4.2.1'
 # for languages validation
 gem 'iso-639'
 
-# geocoder 
-# gem 'geocoder'
-##execute gem install geocoder serverside and uncomment the above line
-
-
 # frontend javascripts
 source 'https://rails-assets.org' do
   # for placeholder images

--- a/Gemfile
+++ b/Gemfile
@@ -239,3 +239,5 @@ group :development, :test do
   # as debugger
   gem 'byebug'
 end
+
+gem 'geocoder'

--- a/Gemfile
+++ b/Gemfile
@@ -84,6 +84,9 @@ gem 'jquery-ui-rails', '~> 4.2.1'
 # for languages validation
 gem 'iso-639'
 
+# geocoder 
+gem 'geocoder'
+
 # frontend javascripts
 source 'https://rails-assets.org' do
   # for placeholder images
@@ -239,5 +242,3 @@ group :development, :test do
   # as debugger
   gem 'byebug'
 end
-
-gem 'geocoder'

--- a/app/models/venue.rb
+++ b/app/models/venue.rb
@@ -13,8 +13,11 @@ class Venue < ActiveRecord::Base
 
   before_save :send_mail_notification
 
-  def address
-    "#{street}, #{city}, #{country_name}"
+  geocoded_by :full_address
+  after_validation :geocode
+
+  def full_address
+    "#{street}, #{city}, #{country}"
   end
 
   def country_name
@@ -35,7 +38,7 @@ class Venue < ActiveRecord::Base
   def notify_on_venue_changed?
     return false unless conference.try(:email_settings).try(:send_on_venue_updated)
     # do not notify unless the address changed
-    return false unless name_changed? || street_changed? || city_changed? || country_changed?
+    return false unless self.name_changed? || self.street_changed? || self.city_changed? || self.country_changed?
     # do not notify unless the mail content is set up
     (!conference.email_settings.venue_updated_subject.blank? && !conference.email_settings.venue_updated_body.blank?)
   end

--- a/app/views/admin/venues/_form.html.haml
+++ b/app/views/admin/venues/_form.html.haml
@@ -15,7 +15,7 @@
         = semantic_form_for(@venue, url: admin_conference_venue_path(@conference.short_title)) do |f|
           = f.inputs :name, :website
           = f.input :description, input_html: { rows: 5, cols: 20, data: { provide: 'markdown-editable' } }, hint: markdown_hint
-          = f.inputs :street, :postalcode, :city, :country, :latitude, :longitude
+          = f.inputs :street, :postalcode, :city, :country
           = f.action :submit, as: :button, button_html: { class: 'btn btn-primary' }
 
     #commercials-content.tab-pane

--- a/app/views/admin/venues/_venue_map.html.haml
+++ b/app/views/admin/venues/_venue_map.html.haml
@@ -1,0 +1,34 @@
+#map{style: "height: 500px;" }
+- popup = "<h3>#{@conference.venue.name}</h3><br>#{@conference.venue.street}<br>#{@conference.venue.city}<br>#{@conference.venue.country_name}"
+- content_for(:script_body) do
+  :javascript
+    // create a map in the "map" div, set the view to a given place and zoom
+    var map = L.map('map', { scrollWheelZoom: false }).setView([#{@conference.venue.latitude}, #{@conference.venue.longitude}], 11);
+    // add an OpenStreetMap tile layer
+    L.tileLayer('//{s}.tile.openstreetmap.org/{z}/{x}/{y}.png', {
+      attribution: 'Map data &copy; <a href="http://openstreetmap.org">OpenStreetMap</a> contributors, <a href="http://creativecommons.org/licenses/by-sa/2.0/">CC-BY-SA</a>, Imagery © <a href="http://mapbox.com">Mapbox</a>',
+      maxZoom: 18
+    }).addTo(map);
+    // add a marker in the given location, attach some popup content to it and open the popup
+    L.marker([#{@conference.venue.latitude}, #{@conference.venue.longitude}]).addTo(map)
+      .bindPopup("#{popup}")
+      .openPopup();
+    // Turn scrollwheel on when user clicks
+    map.on('focus', function(e) {
+      map.scrollWheelZoom.enable();
+    });
+    // Turn scrollwheel off once the map isn't in the viewport anymore
+    $('#map').waypoint({
+      handler: function(direction) {
+        map.scrollWheelZoom.disable();
+        //alert('map');
+      },
+      offset: '90%'
+    });
+    $('#map').waypoint({
+      handler: function(direction) {
+        map.scrollWheelZoom.disable();
+        //alert('map');
+      },
+      offset: '10%'
+    });

--- a/app/views/admin/venues/show.html.haml
+++ b/app/views/admin/venues/show.html.haml
@@ -41,3 +41,5 @@
     .col-md-12.text-right
       = link_to(new_admin_conference_venue_path(@conference.short_title), class: 'btn btn-primary') do
         Create Venue
+
+


### PR DESCRIPTION
Existing:
Latitude and longitude values are entered. These values are inserted to the Venues database and the map is generated. The entry of latitude and longitude values is an overhead for the user. 


Modified:
The geocode package is installed. The text areas for latitude and longitude inputs are eliminated. Based on the address specified, latitude and longitude values are automatically generated and entered to the Venues database. The map is now displayed based on the computed values. User need not explicitly enter latitude and longitude values.
