### PR TITLE
Add user path to Attendee and Speaker avatar in registration show page

### DIFF
--- a/app/views/conference_registrations/show.html.haml
+++ b/app/views/conference_registrations/show.html.haml
@@ -142,7 +142,7 @@
           Registered
           = word_pluralize(@conference.participants.count, 'Attendee')
         - @conference.participants.each do |participant|
-          = image_tag(participant.gravatar_url(size: '25'), title: "#{participant.name}!", class: 'img-circle')
+          = link_to image_tag(participant.gravatar_url(size: '25'), title: "#{participant.name}!", class: 'img-circle'), user_path(participant)
     .col-md-4.col-md-offset-2
       - if @conference.program.speakers.confirmed.any?
         %h4
@@ -153,4 +153,4 @@
           Confirmed
           = word_pluralize(@conference.program.speakers.confirmed.count, 'Speaker')
         - @conference.program.speakers.confirmed.each do |speaker|
-          = image_tag(speaker.gravatar_url(size: '25'), title: "#{speaker.name}!", class: 'img-circle')
+          = link_to image_tag(speaker.gravatar_url(size: '25'), title: "#{speaker.name}!", class: 'img-circle'), user_path(speaker)


### PR DESCRIPTION
Avatars of attendee and speaker are not linked to their respective attendee and speaker. Add a link to the avatar to give more information of attendee and speaker.