### PR TITLE
Add permission to access admin/shedule by cfp #1432

### DIFF
--- a/app/models/ability.rb
+++ b/app/models/ability.rb
@@ -198,6 +198,7 @@ class Ability
     can :manage, Track, program: { conference_id: conf_ids_for_cfp }
     can :manage, DifficultyLevel, program: { conference_id: conf_ids_for_cfp }
     can :manage, EmailSettings, conference_id: conf_ids_for_cfp
+    can :manage, Schedule, program: { conference_id: conf_ids_for_cfp }
     can :manage, Room, venue: { conference_id: conf_ids_for_cfp }
     can :show, Venue, conference_id: conf_ids_for_cfp
     can :show, Commercial, commercialable_type: 'Venue', commercialable_id: Venue.where(conference_id: conf_ids_for_cfp).pluck(:id)

--- a/spec/features/ability_spec.rb
+++ b/spec/features/ability_spec.rb
@@ -129,7 +129,7 @@ feature 'Has correct abilities' do
     expect(page).to have_link('Commercials', href: "/admin/conferences/#{conference2.short_title}/commercials")
     expect(page).to have_link('Events', href: "/admin/conferences/#{conference2.short_title}/program/events")
     expect(page).to_not have_link('Registrations', href: "/admin/conferences/#{conference2.short_title}/registrations")
-    expect(page).to_not have_link('Schedules', href: "/admin/conferences/#{conference2.short_title}/schedules")
+    expect(page).to have_link('Schedules', href: "/admin/conferences/#{conference2.short_title}/schedules")
     expect(page).to_not have_link('Campaigns', href: "/admin/conferences/#{conference2.short_title}/campaigns")
     expect(page).to_not have_link('Goals', href: "/admin/conferences/#{conference2.short_title}/targets")
     expect(page).to have_link('Venue', href: "/admin/conferences/#{conference2.short_title}/venue")
@@ -161,7 +161,7 @@ feature 'Has correct abilities' do
     expect(current_path).to eq(admin_conference_program_events_path(conference2.short_title))
 
     visit admin_conference_schedules_path(conference2.short_title)
-    expect(current_path).to eq(root_path)
+    expect(current_path).to eq(admin_conference_schedules_path(conference2.short_title))
 
     visit admin_conference_campaigns_path(conference2.short_title)
     expect(current_path).to eq(root_path)

--- a/spec/models/ability_spec.rb
+++ b/spec/models/ability_spec.rb
@@ -274,7 +274,7 @@ describe 'User' do
       it{ should_not be_able_to(:manage, conference_public.questions.first) }
       it{ should be_able_to(:manage, my_conference.program.cfp) }
       it{ should_not be_able_to(:manage, conference_public.program.cfp) }
-      it{ should_not be_able_to(:manage, my_schedule) }
+      it{ should be_able_to(:manage, my_schedule) }
       it{ should_not be_able_to(:manage, other_schedule) }
       it{ should_not be_able_to(:manage, my_event_schedule) }
       it{ should_not be_able_to(:manage, other_event_schedule) }


### PR DESCRIPTION
Modified app/models so users with cfp role have the ability to access to admin/schedules as well . Resolves #1432 