### PR TITLE
Enable Performance/StringReplacement Rubocop cop

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -104,7 +104,7 @@ Style/TrailingBlankLines:
 Style/TrailingWhitespace:
   Enabled: true
 
-#This cop checks for numeric comparisons that can be replaced by a predicate method.
+# This cop checks for numeric comparisons that can be replaced by a predicate method.
 Style/ZeroLengthPredicate:
   Enabled: true
 
@@ -182,4 +182,10 @@ Rails:
 
 # Avoid use of old-style attribute validation
 Rails/Validation:
+  Enabled: true
+
+#################### Performance ###############################
+
+# Identifies places where gsub can be replaced by tr or delete.
+Performance/StringReplacement:
   Enabled: true

--- a/.rubocop_todo.yml
+++ b/.rubocop_todo.yml
@@ -48,12 +48,6 @@ Metrics/ModuleLength:
 Metrics/PerceivedComplexity:
   Max: 15
 
-# Offense count: 1
-# Cop supports --auto-correct.
-Performance/StringReplacement:
-  Exclude:
-    - 'spec/support/save_feature_failures.rb'
-
 # Offense count: 13
 # Cop supports --auto-correct.
 # Configuration parameters: EnforcedStyle, SupportedStyles, Include.


### PR DESCRIPTION
Enabled the performance/stringreplacement rubocop in the .rubocop.yml file and removed it from .rubocop_todo.yml. This cop checks for instances where gsub can be replaced with tr or delete. Supports auto correct, but there weren't any offenses.

Closes #1444 