### PR TITLE
Normalize openid mock accounts' credentials and add tests

### DIFF
--- a/config/environments/development.rb
+++ b/config/environments/development.rb
@@ -54,9 +54,9 @@ Osem::Application.configure do
                               provider: 'facebook',
                               uid: 'facebook-test-uid-1',
                               info: {
-                                name: 'admin admin',
-                                email: 'admin@email.com',
-                                username: 'admin_admin'
+                                name: 'facebook user',
+                                email: 'user-facebook@example.com',
+                                username: 'user_facebook'
                               },
                               credentials: {
                                 token: 'fb_mock_token',
@@ -69,9 +69,9 @@ Osem::Application.configure do
                               provider: 'google',
                               uid: 'google-test-uid-1',
                               info: {
-                                name: 'simple user',
-                                email: 'user0@email.com',
-                                username: 'simple_user0'
+                                name: 'google user',
+                                email: 'user-google@example.com',
+                                username: 'user_google'
                               },
                               credentials: {
                                 token: 'google_mock_token',
@@ -84,9 +84,9 @@ Osem::Application.configure do
                               provider: 'suse',
                               uid: 'suse-test-uid-1',
                               info: {
-                                name: 'another user',
-                                email: 'user1@email.com',
-                                username: 'another_user'
+                                name: 'suse user',
+                                email: 'user-suse@example.com',
+                                username: 'user_suse'
                               },
                               credentials: {
                                 token: 'suse_mock_token',
@@ -99,9 +99,9 @@ Osem::Application.configure do
                               provider: 'github',
                               uid: 'github-test-uid-1',
                               info: {
-                                name: 'someother user',
-                                email: 'user2@email.com',
-                                username: 'someother_user'
+                                name: 'github user',
+                                email: 'user-github@example.com',
+                                username: 'user_github'
                               },
                               credentials: {
                                 token: 'github_mock_token',

--- a/spec/features/omniauth_spec.rb
+++ b/spec/features/omniauth_spec.rb
@@ -18,13 +18,13 @@ feature Openid do
       within('#openidlinks') do
         click_link 'omniauth-google'
       end
-      expect(flash).to eq('test-1@gmail.com signed in successfully with google')
+      expect(flash).to eq('test-1@example.com signed in successfully with google')
       expect(Openid.count).to eq(expected_count_openid)
       expect(User.count).to eq(expected_count_user)
     end
 
     scenario 'signs in an existing user' do
-      create(:user, email: 'test-participant-1@google.com')
+      create(:user, email: 'test-participant-1@example.com')
       expected_count_openid = Openid.count + 1
       expected_count_user = User.count
       visit '/accounts/sign_in'
@@ -33,7 +33,7 @@ feature Openid do
       within('#openidlinks') do
         click_link 'omniauth-google'
       end
-      expect(flash).to eq('test-participant-1@google.com signed in successfully with google')
+      expect(flash).to eq('test-participant-1@example.com signed in successfully with google')
       expect(Openid.count).to eq(expected_count_openid)
       expect(User.count).to eq(expected_count_user)
     end
@@ -51,7 +51,7 @@ feature Openid do
 
     scenario 'adds openid to existing user' do
       # Sign in user
-      user = create(:user, email: 'test-participant-1@google.com')
+      user = create(:user, email: 'test-participant-1@example.com')
       sign_in user
 
       # Add openID to current user
@@ -63,15 +63,15 @@ feature Openid do
       within('#openidlinks') do
         click_link 'omniauth-google'
       end
-      expect(flash).to eq('test-participant-1@google.com signed in successfully with google')
+      expect(flash).to eq('test-participant-1@example.com signed in successfully with google')
       expect(Openid.count).to eq(expected_count_openid)
       expect(User.count).to eq(expected_count_user)
-      expect(Openid.where(email: 'test-1@gmail.com').first.nil?).to eq(false)
+      expect(Openid.where(email: 'test-1@example.com').first.nil?).to eq(false)
     end
 
     scenario 'signs in with openID using the same email as another associated openid' do
       # Sign in user
-      create(:user, email: 'test-participant-1@google.com')
+      create(:user, email: 'test-participant-1@example.com')
       expected_count_openid = Openid.count + 1
       expected_count_user = User.count
       visit '/accounts/sign_in'
@@ -80,7 +80,7 @@ feature Openid do
       within('#openidlinks') do
         click_link 'omniauth-google'
       end
-      expect(flash).to eq('test-participant-1@google.com signed in successfully with google')
+      expect(flash).to eq('test-participant-1@example.com signed in successfully with google')
       expect(Openid.count).to eq(expected_count_openid)
       expect(User.count).to eq(expected_count_user)
 
@@ -93,11 +93,11 @@ feature Openid do
       within('#openidlinks') do
         click_link 'omniauth-google'
       end
-      expect(flash).to eq('test-participant-1@google.com signed in successfully with google')
+      expect(flash).to eq('test-participant-1@example.com signed in successfully with google')
       expect(Openid.count).to eq(expected_count_openid)
       expect(User.count).to eq(expected_count_user)
-      expect(Openid.where(email: 'test-participant-1@google.com').first.nil?).to eq(false)
-      expect(Openid.where(email: 'test-1@gmail.com').first.nil?).to eq(false)
+      expect(Openid.where(email: 'test-participant-1@example.com').first.nil?).to eq(false)
+      expect(Openid.where(email: 'test-1@example.com').first.nil?).to eq(false)
 
       # Sign in with different openID using same email (test-1@gmail.com)
       sign_out
@@ -109,12 +109,12 @@ feature Openid do
       within('#openidlinks') do
         click_link 'omniauth-facebook'
       end
-      expect(flash).to eq('test-participant-1@google.com signed in successfully with facebook')
+      expect(flash).to eq('test-participant-1@example.com signed in successfully with facebook')
       expect(Openid.count).to eq(expected_count_openid)
       expect(User.count).to eq(expected_count_user)
       last_openid = Openid.last
       expect(last_openid.uid).to eq('facebook-test-uid-1')
-      expect(last_openid.email).to eq('test-1@gmail.com')
+      expect(last_openid.email).to eq('test-1@example.com')
     end
   end
 

--- a/spec/models/user_spec.rb
+++ b/spec/models/user_spec.rb
@@ -426,4 +426,10 @@ describe User do
       expect(user.events_registrations).to eq [@events_registration1, @events_registration2]
     end
   end
+
+  describe '.omniauth_providers' do
+    it 'contains providers' do
+      expect(User.omniauth_providers).to eq [:suse, :google, :facebook, :github]
+    end
+  end
 end

--- a/spec/support/omniauth_macros.rb
+++ b/spec/support/omniauth_macros.rb
@@ -14,7 +14,7 @@ module OmniauthMacros
                               uid: 'google-test-uid-1',
                               info: {
                                 name: 'new user name',
-                                email: 'test-1@gmail.com'
+                                email: 'test-1@example.com'
                               },
                               credentials: {
                                 token: 'mock_token',
@@ -30,7 +30,7 @@ module OmniauthMacros
                               uid: 'facebook-test-uid-1',
                               info: {
                                 name: 'new user fb name',
-                                email: 'test-1@gmail.com'
+                                email: 'test-1@example.com'
                               },
                               credentials: {
                                 token: 'mock_token',
@@ -48,7 +48,7 @@ module OmniauthMacros
                               uid: 'google-test-uid-participant-1',
                               info: {
                                 name: 'existing user participant name',
-                                email: 'test-participant-1@google.com'
+                                email: 'test-participant-1@example.com'
                               },
                               credentials: {
                                 token: 'mock_token',
@@ -66,7 +66,7 @@ module OmniauthMacros
                               uid: 'google-test-uid-admin-1',
                               info: {
                                 name: 'existing user admin name',
-                                email: 'test-admin-1@google.com'
+                                email: 'test-admin-1@example.com'
                               },
                               credentials: {
                                 token: 'mock_token',

--- a/spec/support/omniauth_macros.rb
+++ b/spec/support/omniauth_macros.rb
@@ -2,10 +2,14 @@ module OmniauthMacros
   # The mock_auth configuration allows you to set per-provider (or default)
   # authentication hashes to return during integration testing.
 
-  Rails.application.secrets.google_key = 'test key google'
-  Rails.application.secrets.google_secret = 'test secret google'
-  Rails.application.secrets.facebook_key = 'test key facebook'
-  Rails.application.secrets.facebook_secret = 'test secret facebook'
+  ENV['OSEM_GOOGLE_KEY'] = 'test key google'
+  ENV['OSEM_GOOGLE_SECRET'] = 'test secret google'
+  ENV['OSEM_FACEBOOK_KEY'] = 'test key facebook'
+  ENV['OSEM_FACEBOOK_SECRET'] = 'test secret facebook'
+  ENV['OSEM_SUSE_KEY'] = 'test key suse'
+  ENV['OSEM_SUSE_SECRET'] = 'test secret suse'
+  ENV['OSEM_GITHUB_KEY'] = 'test key github'
+  ENV['OSEM_GITHUB_SECRET'] = 'test secret github'
 
   def mock_auth_new_user
     OmniAuth.config.mock_auth[:google] =
@@ -71,6 +75,73 @@ module OmniauthMacros
                               credentials: {
                                 token: 'mock_token',
                                 secret: 'mock_secret'
+                              }
+                            )
+  end
+
+  # We use these mock accounts to ensure that the ones which are available in
+  # development are valid, to test omniauth actions and verify that a mock
+  # account is available for every supported omniauth provider.
+  # These must be identical to the ones in /config/environments/development.rb
+  # Remember to keep them in sync with development.rb
+  def mock_auth_accounts
+    OmniAuth.config.mock_auth[:facebook] =
+      OmniAuth::AuthHash.new(
+                              provider: 'facebook',
+                              uid: 'facebook-test-uid-1',
+                              info: {
+                                name: 'facebook user',
+                                email: 'user-facebook@example.com',
+                                username: 'user_facebook'
+                              },
+                              credentials: {
+                                token: 'fb_mock_token',
+                                secret: 'fb_mock_secret'
+                              }
+                            )
+
+    OmniAuth.config.mock_auth[:google] =
+      OmniAuth::AuthHash.new(
+                              provider: 'google',
+                              uid: 'google-test-uid-1',
+                              info: {
+                                name: 'google user',
+                                email: 'user-google@example.com',
+                                username: 'user_google'
+                              },
+                              credentials: {
+                                token: 'google_mock_token',
+                                secret: 'google_mock_secret'
+                              }
+                            )
+
+    OmniAuth.config.mock_auth[:suse] =
+      OmniAuth::AuthHash.new(
+                              provider: 'suse',
+                              uid: 'suse-test-uid-1',
+                              info: {
+                                name: 'suse user',
+                                email: 'user-suse@example.com',
+                                username: 'user_suse'
+                              },
+                              credentials: {
+                                token: 'suse_mock_token',
+                                secret: 'suse_mock_secret'
+                              }
+                            )
+
+    OmniAuth.config.mock_auth[:github] =
+      OmniAuth::AuthHash.new(
+                              provider: 'github',
+                              uid: 'github-test-uid-1',
+                              info: {
+                                name: 'github user',
+                                email: 'user-github@example.com',
+                                username: 'user_github'
+                              },
+                              credentials: {
+                                token: 'github_mock_token',
+                                secret: 'github_mock_secret'
                               }
                             )
   end


### PR DESCRIPTION
Issue:
1. The emails of the mock accounts use email.com which is neither reserved nor controlled by osem
2. The credentials of the mock accounts are arbitrary, thus they don't indicate to the user/developer the provider with which they are associated (in the web interface)
3. The available specs don't test signup for every supported provider

Solution:
1.  Change email.com to example.com
2. Change the credentials to comply with the following patterns:
    * name: 'provider user'
    * email: 'user-provider@example.com'
    * username: 'userProvider'
3. Add relevant tests and a "trap" to catch changes to the supported providers (addition, renaming, removal)

Closes #1365 