### PR TITLE
Removed the extra condition for displaying the first speaker image

### DIFF
--- a/app/views/schedules/_schedule_item.html.haml
+++ b/app/views/schedules/_schedule_item.html.haml
@@ -9,11 +9,6 @@
 
       = event.title
 
-    - if speaker = event.speakers.first
-      = image_tag speaker.gravatar_url, class: "img-circle pull-right speaker-pic", |
-                                        alt: speaker.name, |
-                                        title: speaker.name, |
-                                        style: "height: #{ speaker_height(@rooms) }px; width: #{ speaker_width(@rooms) }px;"
     - event.speakers_ordered.each do |speaker|
       = image_tag speaker.gravatar_url, :class => "img-circle pull-right speaker-pic", |
                                         :alt => speaker.name, |


### PR DESCRIPTION
Removed the if statement in schedule_item.html.haml file which was generating an extra img_tag for the first speaker

Fixes #1454