### PR TITLE
Don't allow not_signed_in user to view private schedule

### DIFF
--- a/app/controllers/schedules_controller.rb
+++ b/app/controllers/schedules_controller.rb
@@ -1,9 +1,9 @@
 class SchedulesController < ApplicationController
-  load_and_authorize_resource
   protect_from_forgery with: :null_session
   before_action :respond_to_options
   load_resource :conference, find_by: :short_title
   load_resource :program, through: :conference, singleton: true, except: :index
+  load_and_authorize_resource :selected_schedule, through: :program, singleton: true
 
   def show
     @rooms = @conference.venue.rooms if @conference.venue


### PR DESCRIPTION
Fix bug i.e private schedule is viewable to `not_signed_in` user in the PR #1352  by fixing load_and_authorize of schedule in `schedules_controller`