### PR TITLE
Refactor authorization for schedule and event action of Conferences Controller

### DIFF
--- a/app/controllers/admin/schedules_controller.rb
+++ b/app/controllers/admin/schedules_controller.rb
@@ -3,7 +3,7 @@ module Admin
     # By authorizing 'conference' resource, we can ensure there will be no unauthorized access to
     # the schedule of a conference, which should not be accessed in the first place
     load_and_authorize_resource :conference, find_by: :short_title
-    load_and_authorize_resource :program, through: :conference, singleton: true
+    load_resource :program, through: :conference, singleton: true
     load_and_authorize_resource :schedule, through: :program
     load_resource :event_schedules, through: :schedule
     load_resource :selected_schedule, through: :program, singleton: true

--- a/app/controllers/admin/schedules_controller.rb
+++ b/app/controllers/admin/schedules_controller.rb
@@ -3,7 +3,7 @@ module Admin
     # By authorizing 'conference' resource, we can ensure there will be no unauthorized access to
     # the schedule of a conference, which should not be accessed in the first place
     load_and_authorize_resource :conference, find_by: :short_title
-    load_resource :program, through: :conference, singleton: true
+    load_and_authorize_resource :program, through: :conference, singleton: true
     load_and_authorize_resource :schedule, through: :program
     load_resource :event_schedules, through: :schedule
     load_resource :selected_schedule, through: :program, singleton: true

--- a/app/controllers/schedules_controller.rb
+++ b/app/controllers/schedules_controller.rb
@@ -3,15 +3,12 @@ class SchedulesController < ApplicationController
   before_action :respond_to_options
   load_resource :conference, find_by: :short_title
   load_resource :program, through: :conference, singleton: true, except: :index
+  before_action :presence_of_selected_schedule
   load_and_authorize_resource :selected_schedule, through: :program, singleton: true
 
   def show
     @rooms = @conference.venue.rooms if @conference.venue
     schedules = @program.selected_event_schedules
-    unless schedules
-      redirect_to events_conference_schedule_path(@conference.short_title)
-    end
-
     @events_xml = schedules.map(&:event).group_by{ |event| event.time.to_date } if schedules
     @dates = @conference.start_date..@conference.end_date
     @step_minutes = @program.schedule_interval.minutes
@@ -48,5 +45,10 @@ class SchedulesController < ApplicationController
     respond_to do |format|
       format.html { head :ok }
     end if request.options?
+  end
+
+  def presence_of_selected_schedule
+    return if @program.selected_event_schedules
+    redirect_to root_path, notice: 'Program is yet to be scheduled.'
   end
 end

--- a/app/controllers/schedules_controller.rb
+++ b/app/controllers/schedules_controller.rb
@@ -1,9 +1,9 @@
 class SchedulesController < ApplicationController
-  load_and_authorize_resource
   protect_from_forgery with: :null_session
   before_action :respond_to_options
   load_resource :conference, find_by: :short_title
   load_resource :program, through: :conference, singleton: true, except: :index
+  load_and_authorize_resource :selected_schedule, through: :program, singleton: true
 
   def show
     @rooms = @conference.venue.rooms if @conference.venue

--- a/app/models/ability.rb
+++ b/app/models/ability.rb
@@ -33,10 +33,6 @@ class Ability
     can [:show], Conference do |conference|
       conference.splashpage && conference.splashpage.public == true
     end
-    # Can view the schedule
-    can [:schedule, :events], Conference do |conference|
-      conference.program.cfp && conference.program.schedule_public
-    end
 
     can :show, Event do |event|
       event.state == 'confirmed'

--- a/app/views/conferences/_conference_details.html.haml
+++ b/app/views/conferences/_conference_details.html.haml
@@ -21,7 +21,7 @@
             - if !@conference || @conference != conference
               - if conference.splashpage && conference.splashpage.public
                 = link_to "View Conference", conference_path(conference.short_title), class: 'btn btn-default'
-            - if conference.program and conference.program.schedule_public
+            - if conference.program and conference.program.selected_event_schedules and conference.program.schedule_public
               = link_to "Schedule", conference_schedule_path(conference.short_title), class: 'btn btn-default'
             - if conference.registration_open?
               - if conference.user_registered?(current_user)

--- a/spec/models/ability_spec.rb
+++ b/spec/models/ability_spec.rb
@@ -24,6 +24,9 @@ describe 'User' do
     let(:conference_public) { create(:full_conference, splashpage: create(:splashpage, public: true)) }
     let!(:conference_public_cfp) { create(:cfp, program: conference_public.program) }
 
+    let(:schedule_public) { create(:schedule, program: create(:program, schedule_public: true))}
+    let(:schedule_not_public) { create(:schedule, program: create(:program, schedule_public: false))}
+
     let(:event_confirmed) { create(:event, state: 'confirmed') }
     let(:event_unconfirmed) { create(:event) }
 
@@ -51,12 +54,8 @@ describe 'User' do
       it{ should be_able_to(:show, conference_public)}
       it{ should_not be_able_to(:show, conference_not_public)}
 
-      it do
-          conference_public.program.schedule_public = true
-          conference_public.program.save
-          should be_able_to(:schedule, conference_public)
-      end
-      it{ should_not be_able_to(:schedule, conference_not_public)}
+      it{ should be_able_to(:show, schedule_public) }
+      it{ should_not be_able_to(:show, schedule_not_public) }
 
       it{ should be_able_to(:show, event_confirmed)}
       it{ should_not be_able_to(:show, event_unconfirmed)}

--- a/spec/models/ability_spec.rb
+++ b/spec/models/ability_spec.rb
@@ -24,6 +24,7 @@ describe 'User' do
     let(:conference_public) { create(:full_conference, splashpage: create(:splashpage, public: true)) }
     let!(:conference_public_cfp) { create(:cfp, program: conference_public.program) }
 
+    # Other schedule which is either public or not_public.
     let(:schedule_public) { create(:schedule, program: create(:program, schedule_public: true))}
     let(:schedule_not_public) { create(:schedule, program: create(:program, schedule_public: false))}
 
@@ -101,6 +102,9 @@ describe 'User' do
       it{ should_not be_able_to(:new, Registration.new(conference_id: conference_with_closed_registration.id))}
       it{ should_not be_able_to(:create, Registration.new(conference_id: conference_with_closed_registration.id))}
 
+      it{ should be_able_to(:show, schedule_public) }
+      it{ should_not be_able_to(:show, schedule_not_public) }
+
       it{ should be_able_to(:index, Ticket) }
       it{ should be_able_to(:manage, TicketPurchase.new(user_id: user.id)) }
 
@@ -135,6 +139,9 @@ describe 'User' do
       it{ should be_able_to(:manage, :all) }
       it{ should_not be_able_to(:destroy, my_conference.program) }
       it{ should_not be_able_to(:destroy, my_venue) }
+
+      it{ should be_able_to(:show, schedule_public) }
+      it{ should be_able_to(:show, schedule_not_public) }
     end
 
     shared_examples 'user with any role' do
@@ -218,6 +225,9 @@ describe 'User' do
       it{ should be_able_to(:manage, my_conference.tickets.first) }
       it{ should_not be_able_to(:manage, conference_public.tickets.first) }
 
+      it{ should be_able_to(:show, schedule_public) }
+      it{ should_not be_able_to(:show, schedule_not_public) }
+
       it{ should be_able_to(:manage, my_registration) }
       it{ should_not be_able_to(:manage, other_registration) }
 
@@ -289,6 +299,9 @@ describe 'User' do
       it{ should_not be_able_to(:manage, my_conference.tickets.first) }
       it{ should_not be_able_to(:manage, conference_public.tickets.first) }
 
+      it{ should be_able_to(:show, schedule_public) }
+      it{ should_not be_able_to(:show, schedule_not_public) }
+
       it{ should_not be_able_to(:manage, my_registration) }
       it{ should_not be_able_to(:manage, other_registration) }
 
@@ -356,6 +369,9 @@ describe 'User' do
       it{ should_not be_able_to(:manage, my_conference.tickets.first) }
       it{ should_not be_able_to(:manage, conference_public.tickets.first) }
 
+      it{ should be_able_to(:show, schedule_public) }
+      it{ should_not be_able_to(:show, schedule_not_public) }
+
       it{ should be_able_to(:manage, my_registration) }
       it{ should_not be_able_to(:manage, other_registration) }
 
@@ -422,6 +438,9 @@ describe 'User' do
       it{ should_not be_able_to(:manage, conference_public.sponsorship_levels.first) }
       it{ should_not be_able_to(:manage, my_conference.tickets.first) }
       it{ should_not be_able_to(:manage, conference_public.tickets.first) }
+
+      it{ should be_able_to(:show, schedule_public) }
+      it{ should_not be_able_to(:show, schedule_not_public) }
 
       it{ should_not be_able_to(:manage, registration) }
       it{ should_not be_able_to(:manage, other_registration) }


### PR DESCRIPTION
Remove can ability for `schedule` and `events` action in `ability.rb` as both the actions are no longer present in `conferences_controller`. Replace `load_and_authorize_resource` with `load_resource` for `program` in the `schedules_controller`.

Closes #1457