### PR TITLE
Fix commercial option for users in dashboard#show #1390

### DIFF
--- a/app/controllers/admin/commercials_controller.rb
+++ b/app/controllers/admin/commercials_controller.rb
@@ -7,7 +7,6 @@ module Admin
       @commercials = @conference.commercials
 
       @commercial = @conference.commercials.build
-      authorize! :create, @conference.commercials.new
     end
 
     def create

--- a/spec/features/ability_spec.rb
+++ b/spec/features/ability_spec.rb
@@ -284,7 +284,7 @@ feature 'Has correct abilities' do
     expect(current_path).to eq(root_path)
 
     visit admin_conference_commercials_path(conference2.short_title)
-    expect(current_path).to eq(root_path)
+    expect(current_path).to eq(admin_conference_commercials_path(conference2.short_title))
 
     visit new_admin_conference_splashpage_path(conference2.short_title)
     expect(current_path).to eq(root_path)
@@ -496,7 +496,7 @@ feature 'Has correct abilities' do
     expect(current_path).to eq(root_path)
 
     visit admin_conference_commercials_path(conference3.short_title)
-    expect(current_path).to eq(root_path)
+    expect(current_path).to eq(admin_conference_commercials_path(conference3.short_title))
 
     visit new_admin_conference_splashpage_path(conference3.short_title)
     expect(current_path).to eq(root_path)


### PR DESCRIPTION
Users had no access to the commercials of a conference. 
This allows for information about the commercials of a previous conference to be available to someone who is trying to organize a similar one. Resolves #1390 