### PR TITLE
Add helper function for speaker selection

### DIFF
--- a/app/controllers/admin/events_controller.rb
+++ b/app/controllers/admin/events_controller.rb
@@ -62,7 +62,6 @@ module Admin
       @comments = @event.root_comments
       @comment_count = @event.comment_threads.count
       @user = @event.submitter
-      @users = User.all.order(:name)
       @url = admin_conference_program_event_path(@conference.short_title, @event)
       @languages = @program.languages_list
     end
@@ -80,7 +79,6 @@ module Admin
     end
 
     def update
-      @users = User.all.order(:name)
       @languages = @program.languages_list
       if @event.update_attributes(event_params)
 
@@ -99,7 +97,6 @@ module Admin
 
     def create
       @url = admin_conference_program_events_path(@conference.short_title, @event)
-      @users = User.all.order(:name)
       @languages = @program.languages_list
       @event.submitter = current_user
 
@@ -115,7 +112,6 @@ module Admin
     def new
       @url = admin_conference_program_events_path(@conference.short_title, @event)
       @languages = @program.languages_list
-      @users = User.all.order(:name)
     end
 
     def accept

--- a/app/controllers/proposals_controller.rb
+++ b/app/controllers/proposals_controller.rb
@@ -25,7 +25,6 @@ class ProposalsController < ApplicationController
 
   def edit
     @url = conference_program_proposal_path(@conference.short_title, params[:id])
-    @users = User.all.order(:name)
     @languages = @program.languages_list
   end
 
@@ -61,7 +60,6 @@ class ProposalsController < ApplicationController
 
   def update
     @url = conference_program_proposal_path(@conference.short_title, params[:id])
-    @users = User.all.order(:name)
 
     if @event.update(event_params)
       redirect_to conference_program_proposals_path(conference_id: @conference.short_title),

--- a/app/helpers/application_helper.rb
+++ b/app/helpers/application_helper.rb
@@ -602,4 +602,11 @@ module ApplicationHelper
   def speaker_links(event)
     event.speakers.map{ |speaker| link_to speaker.name, admin_user_path(speaker) }.join(', ').html_safe
   end
+
+  def speaker_selector_input(form)
+    users = User.active.pluck(:id, :name, :username, :email).map { |user| [user[0], user[1].blank? ? user[2] : user[1], user[2], user[3]] }.sort_by { |user| user[1].downcase }
+    form.input :speakers, as: :select,
+                          collection: options_for_select(users.map {|user| ["#{user[1]} (#{user[2]}) #{user[3]}", user[0]]}, @event.speakers.map(&:id)),
+                          include_blank: false, label: 'Speakers', input_html: { class: 'select-help-toggle', multiple: 'true' }
+  end
 end

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -53,6 +53,7 @@ class User < ActiveRecord::Base
   accepts_nested_attributes_for :roles
 
   scope :admin, -> { where(is_admin: true) }
+  scope :active, -> { where(is_disabled: false) }
 
   validates :email, presence: true
 

--- a/app/views/proposals/_proposal_form.html.haml
+++ b/app/views/proposals/_proposal_form.html.haml
@@ -4,9 +4,7 @@
 
     = f.input :subtitle, as: :string
 
-    = f.input :speakers, as: :select,
-      collection: options_for_select(@users.map {|user| ["#{user.name} (#{user.email})", user.id]}, @event.speakers.map(&:id)),
-      include_blank: false, label: 'Speakers', input_html: { class: 'select-help-toggle', multiple: 'true' }
+    = speaker_selector_input f
 
     - if @program.tracks.any?
       = f.input :track_id, as: :select,

--- a/spec/factories/users.rb
+++ b/spec/factories/users.rb
@@ -29,6 +29,7 @@ FactoryGirl.define do
       Quisque cursus facilisis consequat. Etiam volutpat ligula turpis, at
       gravida.
     EOS
+    is_disabled false
 
     after(:create) do |user|
       user.is_admin = false
@@ -43,6 +44,10 @@ FactoryGirl.define do
         user.is_admin = true
         user.save!
       end
+    end
+
+    trait :disabled do
+      is_disabled true
     end
   end
 

--- a/spec/models/user_spec.rb
+++ b/spec/models/user_spec.rb
@@ -10,6 +10,7 @@ describe User do
   let(:volunteers_coordinator_role) { Role.find_by(name: 'volunteers_coordinator', resource: conference) }
   let(:organizer) { create(:user, role_ids: [organizer_role.id]) }
   let(:user) { create(:user) }
+  let(:user_disabled) { create(:user, :disabled) }
 
   let(:event1) { create(:event, program: conference.program) }
   let(:another_conference) { create(:conference) }
@@ -72,6 +73,16 @@ describe User do
 
       it 'excludes users without admin flag' do
         expect(User.admin).not_to include(user)
+      end
+    end
+
+    describe '.active' do
+      it 'includes users without is_disabled flag' do
+        expect(User.active).to include(user)
+      end
+
+      it 'excludes users with is_disabled flag' do
+        expect(User.active).not_to include(user_disabled)
       end
     end
 


### PR DESCRIPTION
The line '@users = User.all.order(:name)' was replicated a lot of times in EventsController and ProposalsController. So, it has been removed and a helper function was added ('speaker_selector_input') that generates the field where the @users variable was used.
Also, the query has been made more specific by keeping only the required fields and excluding disabled users.

The 'select' method was used instead of 'pluck' because the latter returns an array of arrays, therefore it would make the code less readable, since array indeces would have to be used instead of the more human friendly '.name, .email, .id'

Fix #1455