### PR TITLE
Allow confirmed speakers to register even when the registration period is closed

### DIFF
--- a/app/models/ability.rb
+++ b/app/models/ability.rb
@@ -80,7 +80,7 @@ class Ability
 
     can [:new, :create], Registration do |registration|
       conference = registration.conference
-      conference.registration_open? && !conference.registration_limit_exceeded?
+      conference.registration_open? && !conference.registration_limit_exceeded? || conference.program.speakers.confirmed.include?(user)
     end
 
     can :index, Ticket

--- a/app/models/conference.rb
+++ b/app/models/conference.rb
@@ -594,8 +594,15 @@ class Conference < ActiveRecord::Base
     (email_settings.conference_registration_dates_updated_subject.present? && email_settings.conference_registration_dates_updated_body.present?)
   end
 
+  ##
+  # Checks if the registration limit has been exceeded
+  # Additionally, it takes into account the confirmed speakers that haven't registered yet
+  #
+  # ====Returns
+  # * +True+ -> If the registration limit has been reached or exceeded
+  # * +False+ -> If the registration limit hasn't been exceeded
   def registration_limit_exceeded?
-    registration_limit > 0 && registrations.count >= registration_limit
+    registration_limit > 0 && registrations.count + program.speakers.confirmed.count - program.speakers.confirmed.registered(program.conference).count >= registration_limit
   end
 
   # Returns an hexadecimal color given a collection. The returned color changed

--- a/app/models/program.rb
+++ b/app/models/program.rb
@@ -46,6 +46,10 @@ class Program < ActiveRecord::Base
     def confirmed
       joins(:events).where(events: { state: :confirmed })
     end
+
+    def registered(conference)
+      joins(:registrations).where('registrations.conference_id = ?', conference.id)
+    end
   end
 
   accepts_nested_attributes_for :event_types, allow_destroy: true

--- a/app/views/admin/conferences/edit.html.haml
+++ b/app/views/admin/conferences/edit.html.haml
@@ -24,5 +24,5 @@
         = f.input :start_hour, input_html: {size: 2, type: 'number', min: 0, max: 23}
         = f.input :end_hour, input_html: {size: 2, type: 'number', min: 1, max: 24}
       = f.inputs name: 'Registrations' do
-        = f.input :registration_limit, as: :number, in: 0..9999, hint: 'Limit the number of registrations to the conference (0 no limit). You currently have ' + pluralize(@conference.registrations.count, 'registration')
+        = f.input :registration_limit, as: :number, in: 0..9999, hint: 'Limit the number of registrations to the conference (0 no limit). Please note that the registration limit doesn\'t apply to speakers of confirmed events (they will still be able to register even if it has been reached). You currently have ' + pluralize(@conference.registrations.count, 'registration')
       = f.action :submit, as: :button, button_html: {class: 'btn btn-primary'}

--- a/app/views/conferences/_conference_details.html.haml
+++ b/app/views/conferences/_conference_details.html.haml
@@ -27,8 +27,8 @@
               - if conference.user_registered?(current_user)
                 = link_to "My Registration", conference_conference_registration_path(conference.short_title), class: 'btn btn-default'
               - else
-                = link_to "Register", new_conference_conference_registration_path(conference.short_title), class: "btn btn-default", disabled: conference.registration_limit_exceeded?
-                - if conference.registration_limit_exceeded?
+                = link_to "Register", new_conference_conference_registration_path(conference.short_title), class: "btn btn-default", disabled: cannot?(:new, Registration.new(conference_id: conference.id))
+                - if cannot?(:new, Registration.new(conference_id: conference.id)) && conference.registration_limit_exceeded?
                   Sorry, no places left
             - if !current_user.nil? && current_user.proposal_count(conference) > 0
               = link_to "My Proposals", conference_program_proposals_path(conference.short_title), class: 'btn btn-default'


### PR DESCRIPTION
Speakers of confirmed events should be able to register regardless of the registration period and the registration limit.

This pr:
* Gives to confirmed speakers the ability to register even when normal users can't
* Provisions for registrations of speakers, so as not to exceed the registration limit

Related issues: #829, #802 