### PR TITLE
Added link to lodging section in splashpage's navbar. Fixes #1458

### DIFF
--- a/app/views/conferences/_lodging.html.haml
+++ b/app/views/conferences/_lodging.html.haml
@@ -1,3 +1,7 @@
+= content_for :splash_nav do
+  %li
+    %a.smoothscroll{ href: '#lodging' } Lodging
+
 .container
   .row
     .col-md-12.text-center


### PR DESCRIPTION
This commit adds the lodging link in the navbar of the splashpage. This link scrolls down to the lodging section. Fixes #1458 .