### PR TITLE
Fix Travis-Ci build error

### DIFF
--- a/.rubocop_todo.yml
+++ b/.rubocop_todo.yml
@@ -14,7 +14,7 @@ Bundler/OrderedGems:
   Exclude:
     - 'Gemfile'
 
-# Offense count: 28
+# Offense count: 29
 Lint/AmbiguousBlockAssociation:
   Exclude:
     - 'app/models/comment.rb'
@@ -28,6 +28,7 @@ Lint/AmbiguousBlockAssociation:
     - 'spec/controllers/proposals_controller_spec.rb'
     - 'spec/controllers/schedules_controller_spec.rb'
     - 'spec/models/user_spec.rb'
+    - 'spec/controllers/admin/users_controller_spec.rb'
 
 # Offense count: 1
 # Cop supports --auto-correct.
@@ -80,10 +81,12 @@ Metrics/LineLength:
 Metrics/MethodLength:
   Max: 56
 
-# Offense count: 1
+# Offense count: 2
 # Configuration parameters: CountComments.
 Metrics/ModuleLength:
   Max: 472
+  Exclude:
+    - 'app/helpers/application_helper.rb'
 
 # Offense count: 14
 Metrics/PerceivedComplexity:


### PR DESCRIPTION
Rubocop offenses lead to failure of Travis-ci build. Offenses files are added as excluded files to respective offense in rubocop_todo.yml