### PR TITLE
Fix registration sorting

### DIFF
--- a/app/views/admin/registrations/index.html.haml
+++ b/app/views/admin/registrations/index.html.haml
@@ -56,7 +56,7 @@
               -if @conference.questions.any?
                 %td
                   = link_to 'Questions','#', class: 'btn btn-success question-btn', 'data-id' => index, 'data-name' => registration.name
-              %td
+              %td{ 'data-order' => registration.attended.to_s }
                 = check_box_tag "#{@conference.short_title}_#{registration.id}", registration.id, registration.attended,
                   class: 'switch-checkbox', method: :patch,
                   url: toggle_attendance_admin_conference_registration_path(@conference.short_title, id: registration.id)+"?attended=",


### PR DESCRIPTION
When clicking on 'Actions' in order to change the sorting of the lines nothing happens.
Now, the lines are sorted by the value of registration.attended (if the attendee is absent or present)