### PR TITLE
Ignore html_safe in application helper

### DIFF
--- a/.rubocop_todo.yml
+++ b/.rubocop_todo.yml
@@ -183,6 +183,7 @@ Rails/OutputSafety:
   Exclude:
     - 'app/helpers/format_helper.rb'
     - 'app/models/commercial.rb'
+    - 'app/helpers/application_helper.rb'
 
 # Offense count: 10
 # Cop supports --auto-correct.


### PR DESCRIPTION
Exclude the application helper from the Rails/OutputSafety cop until a proper rewrite happens