### PR TITLE
Make the cfp more flexible

### DIFF
--- a/.haml-lint_todo.yml
+++ b/.haml-lint_todo.yml
@@ -171,6 +171,7 @@ linters:
       - "app/views/tickets/index.html.haml"
       - "app/views/users/edit.html.haml"
       - "app/views/users/show.html.haml"
+      - "app/views/admin/cfps/index.html.haml"
 
   # Offense count: 223
   InstanceVariables:
@@ -229,6 +230,7 @@ linters:
       - "app/views/schedules/_schedule.html.haml"
       - "app/views/schedules/_schedule_item.html.haml"
       - "app/views/schedules/_schedule_tabs.html.haml"
+      - "app/views/admin/cfps/_events_cfp.html.haml"
 
   # Offense count: 32
   IdNames:
@@ -247,6 +249,7 @@ linters:
       - "app/views/admin/users/_event_registrations.html.haml"
       - "app/views/admin/users/show.html.haml"
       - "app/views/users/edit.html.haml"
+      - "app/views/admin/cfps/_events_cfp.html.haml"
 
   # Offense count: 4
   UnnecessaryInterpolation:

--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -29,3 +29,4 @@ Metrics/ClassLength:
 Metrics/BlockLength:
   Exclude:
     - 'spec/models/conference_spec.rb'
+    - 'spec/features/ability_spec.rb'

--- a/.rubocop_todo.yml
+++ b/.rubocop_todo.yml
@@ -653,6 +653,7 @@ Style/PercentLiteralDelimiters:
     - 'app/models/contact.rb'
     - 'app/models/registration.rb'
     - 'app/models/subscription.rb'
+    - 'app/models/cfp.rb'
     - 'app/uploaders/picture_uploader.rb'
     - 'spec/models/ability_spec.rb'
     - 'spec/models/program_spec.rb'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -471,7 +471,7 @@ GEM
       sprockets (~> 2.8, < 2.12)
       sprockets-rails (~> 2.0)
     selectize-rails (0.12.4)
-    shoulda-matchers (2.6.1)
+    shoulda-matchers (2.8.0)
       activesupport (>= 3.0.0)
     simplecov (0.11.2)
       docile (~> 1.1.0)
@@ -653,4 +653,4 @@ DEPENDENCIES
   whenever
 
 BUNDLED WITH
-   1.14.5
+   1.15.1

--- a/app/controllers/admin/cfps_controller.rb
+++ b/app/controllers/admin/cfps_controller.rb
@@ -4,21 +4,23 @@ module Admin
     load_and_authorize_resource :program, through: :conference, singleton: true
     load_and_authorize_resource through: :program
 
+    def index; end
+
     def show; end
 
     def new
-      @cfp = @program.build_cfp
+      @cfp = @program.cfps.new
     end
 
     def edit; end
 
     def create
-      @cfp = @program.build_cfp(cfp_params)
+      @cfp = @program.cfps.new(cfp_params)
       send_mail_on_cfp_dates_updates = @cfp.notify_on_cfp_date_update?
 
       if @cfp.save
         ConferenceCfpUpdateMailJob.perform_later(@conference) if send_mail_on_cfp_dates_updates
-        redirect_to admin_conference_program_cfp_path,
+        redirect_to admin_conference_program_cfps_path,
                     notice: 'Call for papers successfully created.'
       else
         flash.now[:error] = "Creating the call for papers failed. #{@cfp.errors.full_messages.join('. ')}."
@@ -33,7 +35,7 @@ module Admin
 
       if @cfp.update_attributes(cfp_params)
         ConferenceCfpUpdateMailJob.perform_later(@conference) if send_mail_on_cfp_dates_updates
-        redirect_to admin_conference_program_cfp_path(@conference.short_title),
+        redirect_to admin_conference_program_cfps_path(@conference.short_title),
                     notice: 'Call for papers successfully updated.'
       else
         flash.now[:error] = "Updating call for papers failed. #{@cfp.errors.to_a.join('. ')}."
@@ -43,9 +45,9 @@ module Admin
 
     def destroy
       if @cfp.destroy
-        redirect_to admin_conference_program_cfp_path, notice: 'Call for Papers was successfully deleted.'
+        redirect_to admin_conference_program_cfps_path, notice: 'Call for Papers was successfully deleted.'
       else
-        redirect_to admin_conference_program_cfp_path, error: 'An error prohibited this Call for Papers from being destroyed: '\
+        redirect_to admin_conference_program_cfps_path, error: 'An error prohibited this Call for Papers from being destroyed: '\
         "#{@cfp.errors.full_messages.join('. ')}."
       end
     end
@@ -53,7 +55,7 @@ module Admin
     private
 
     def cfp_params
-      params.require(:cfp).permit(:start_date, :end_date)
+      params.require(:cfp).permit(:start_date, :end_date, :cfp_type)
     end
   end
 end

--- a/app/controllers/admin/cfps_controller.rb
+++ b/app/controllers/admin/cfps_controller.rb
@@ -2,7 +2,7 @@ module Admin
   class CfpsController < Admin::BaseController
     load_and_authorize_resource :conference, find_by: :short_title
     load_and_authorize_resource :program, through: :conference, singleton: true
-    load_and_authorize_resource through: :program, singleton: true
+    load_and_authorize_resource through: :program
 
     def show; end
 
@@ -27,7 +27,6 @@ module Admin
     end
 
     def update
-      @cfp = @program.cfp
       @cfp.assign_attributes(cfp_params)
 
       send_mail_on_cfp_dates_updates = @cfp.notify_on_cfp_date_update?

--- a/app/models/ability.rb
+++ b/app/models/ability.rb
@@ -139,6 +139,11 @@ class Ability
     cannot :destroy, Venue do |venue|
       venue.conference.program.events.where.not(room_id: nil).any?
     end
+
+    # Can't create cfp if there are no available cfp types
+    cannot [:new, :create], Cfp do |cfp|
+      cfp.program.remaining_cfp_types.empty?
+    end
   end
 
   def signed_in_with_organizer_role(user)
@@ -166,7 +171,7 @@ class Ability
     can :manage, Program, conference_id: conf_ids_for_organizer
     can :manage, Schedule, program: { conference_id: conf_ids_for_organizer }
     can :manage, EventSchedule, schedule: { program: { conference_id: conf_ids_for_organizer } }
-    can :manage, Cfp, program: { conference_id: conf_ids_for_organizer}
+    can :manage, Cfp, program: { conference_id: conf_ids_for_organizer }
     can :manage, Event, program: { conference_id: conf_ids_for_organizer}
     can :manage, EventType, program: { conference_id: conf_ids_for_organizer}
     can :manage, Track, program: { conference_id: conf_ids_for_organizer}

--- a/app/models/cfp.rb
+++ b/app/models/cfp.rb
@@ -81,12 +81,12 @@ class Cfp < ActiveRecord::Base
   private
 
   def before_end_of_conference
-    if program.conference && program.conference.end_date && end_date && (end_date > program.conference.end_date)
+    if program && program.conference && program.conference.end_date && end_date && (end_date > program.conference.end_date)
       errors
       .add(:end_date, "can't be after the conference end date (#{program.conference.end_date})")
     end
 
-    if program.conference && program.conference.end_date && start_date && (start_date > program.conference.end_date)
+    if program && program.conference && program.conference.end_date && start_date && (start_date > program.conference.end_date)
       errors
       .add(:start_date, "can't be after the conference end date (#{program.conference.end_date})")
     end

--- a/app/models/program.rb
+++ b/app/models/program.rb
@@ -135,7 +135,7 @@ class Program < ActiveRecord::Base
   # * +false+ -> If the CFP is not set or today isn't in the CFP period.
   # * +true+ -> If today is in the CFP period.
   def cfp_open?
-    cfp = cfps.events
+    cfp = self.cfp
 
     cfp.present? && (cfp.start_date..cfp.end_date).cover?(Date.current)
   end

--- a/app/models/program.rb
+++ b/app/models/program.rb
@@ -5,7 +5,7 @@ class Program < ActiveRecord::Base
 
   belongs_to :conference
 
-  has_one :cfp, dependent: :destroy
+  has_many :cfps, dependent: :destroy
   has_many :event_types, dependent: :destroy
   has_many :tracks, dependent: :destroy
   has_many :difficulty_levels, dependent: :destroy
@@ -135,7 +135,7 @@ class Program < ActiveRecord::Base
   # * +false+ -> If the CFP is not set or today isn't in the CFP period.
   # * +true+ -> If today is in the CFP period.
   def cfp_open?
-    cfp = self.cfp
+    cfp = cfps.events
 
     cfp.present? && (cfp.start_date..cfp.end_date).cover?(Date.current)
   end
@@ -161,6 +161,23 @@ class Program < ActiveRecord::Base
   def any_event_for_this_date?(date)
     parsed_date = DateTime.parse("#{date} 00:00").utc
     EventSchedule.where(schedule: selected_schedule).where(start_time: parsed_date..(parsed_date + 1)).any?
+  end
+
+  ##
+  # Provides backwards compatibility for when the program had one cfp
+  #
+  # ====Returns
+  # * +ActiveRecord+ -> The program's cfp with cfp_type == 'events'
+  def cfp
+    return nil if cfps.for_events.blank?
+    cfps.for_events
+  end
+
+  ##
+  # ====Returns
+  # * +Array+ -> The types of cfps for which a cfp doesn't exist yet
+  def remaining_cfp_types
+    Cfp::TYPES - cfps.pluck(:cfp_type)
   end
 
   private

--- a/app/models/registration.rb
+++ b/app/models/registration.rb
@@ -2,7 +2,6 @@ class Registration < ActiveRecord::Base
   belongs_to :user
   belongs_to :conference
 
-  has_and_belongs_to_many :events
   has_and_belongs_to_many :qanswers
   has_and_belongs_to_many :vchoices
 

--- a/app/views/admin/cfps/_events_cfp.html.haml
+++ b/app/views/admin/cfps/_events_cfp.html.haml
@@ -1,0 +1,38 @@
+%dt
+  Start Date:
+%dd#start_date
+  = @cfp.start_date.strftime('%A, %B %-d. %Y')
+%dt
+  End Date:
+%dd#end_date
+  = @cfp.end_date.strftime('%A, %B %-d. %Y')
+%dt
+  Days Left:
+%dd
+  = pluralize(@cfp.remaining_days, 'day')
+%dt
+  Event types:
+%dd
+  = event_types(@conference)
+%dt
+  Tracks:
+%dd
+  = tracks(@conference)
+%dt
+  Public Schedule
+%dd#schedule_public
+  - if @program.schedule_public
+    Yes
+  - else
+    No
+%dt
+  Schedule changeable?
+%dd#schedule_changes
+  - if @program.schedule_fluid
+    Yes
+  - else
+    No
+%dt
+  Rating Levels
+%dd#rating
+  = @program.rating

--- a/app/views/admin/cfps/_form.html.haml
+++ b/app/views/admin/cfps/_form.html.haml
@@ -4,8 +4,9 @@
       %h1 Call for Papers
 .row
   .col-md-8
-    = semantic_form_for(@cfp, url: admin_conference_program_cfp_path(@conference.short_title), html: {multipart: true}) do |f|
+    = semantic_form_for(@cfp, url: (@cfp.new_record? ? admin_conference_program_cfps_path : admin_conference_program_cfp_path(@conference.short_title, @cfp)), html: {multipart: true}) do |f|
       = f.input :start_date, as: :string, input_html: { id: 'registration-period-start-datepicker', start_date: @conference.start_date, end_date: @conference.end_date, readonly: 'readonly' }
       = f.input :end_date, as: :string, input_html: { id: 'registration-period-end-datepicker', readonly: 'readonly' }
+      = f.input :cfp_type, as: :select, collection: (@cfp.new_record? ? @program.remaining_cfp_types : [@cfp.cfp_type] + @program.remaining_cfp_types).map {|type| ["#{type.capitalize}", type]}, include_blank: false, label: 'Type', input_html: { class: 'select-help-toggle' }
       %p.text-right
         = f.action :submit, as: :button, button_html: { class: 'btn btn-primary' }

--- a/app/views/admin/cfps/index.html.haml
+++ b/app/views/admin/cfps/index.html.haml
@@ -30,7 +30,7 @@
                 .btn-group
                   = link_to 'Edit', edit_admin_conference_program_cfp_path(@conference.short_title, cfp.id), method: :get, class: 'btn btn-primary'
                   = link_to 'Delete', admin_conference_program_cfp_path(@conference.short_title, cfp.id), method: 'delete', class: 'btn btn-danger', data: { confirm: 'Are you sure you want to delete the CfP?' }
-- if @program.remaining_cfp_types.length > 0
+- if can? :new, @program.cfps.new
   .row
     .col-md-12.text-right
       = link_to 'Create Call for Papers', new_admin_conference_program_cfp_path(@conference.short_title), class: 'btn btn-primary'

--- a/app/views/admin/cfps/index.html.haml
+++ b/app/views/admin/cfps/index.html.haml
@@ -1,0 +1,36 @@
+.row
+  .col-md-12
+    .page-header
+      %h1 Call for Papers
+      %p.text-muted
+        Call for people to submit events to your conference
+- if @program.cfps
+  .row
+    .col-md-12
+      %table.table.table-hover.datatable#tickets
+        %thead
+          %th Type
+          %th Start Date
+          %th End Date
+          %th Days Left
+          %th Actions
+        %tbody
+          - @program.cfps.each do |cfp|
+            %tr
+              %td
+                = link_to(admin_conference_program_cfp_path(@conference.short_title, cfp.id)) do
+                  = cfp.cfp_type.capitalize
+              %td
+                = cfp.start_date.strftime('%A, %B %-d. %Y')
+              %td
+                = cfp.end_date.strftime('%A, %B %-d. %Y')
+              %td
+                = pluralize(cfp.remaining_days, 'day')
+              %td
+                .btn-group
+                  = link_to 'Edit', edit_admin_conference_program_cfp_path(@conference.short_title, cfp.id), method: :get, class: 'btn btn-primary'
+                  = link_to 'Delete', admin_conference_program_cfp_path(@conference.short_title, cfp.id), method: 'delete', class: 'btn btn-danger', data: { confirm: 'Are you sure you want to delete the CfP?' }
+- if @program.remaining_cfp_types.length > 0
+  .row
+    .col-md-12.text-right
+      = link_to 'Create Call for Papers', new_admin_conference_program_cfp_path(@conference.short_title), class: 'btn btn-primary'

--- a/app/views/admin/cfps/show.html.haml
+++ b/app/views/admin/cfps/show.html.haml
@@ -4,55 +4,13 @@
       %h1 Call for Papers
       %p.text-muted
         Call for people to submit events to your conference
-- if @cfp
-  .row
-    .col-md-8
-      %dl.dl-horizontal
-        %dt
-          Start Date:
-        %dd#start_date
-          = @cfp.start_date.strftime('%A, %B %-d. %Y')
-        %dt
-          End Date:
-        %dd#end_date
-          = @cfp.end_date.strftime('%A, %B %-d. %Y')
-        %dt
-          Days Left:
-        %dd
-          = pluralize(@cfp.remaining_days, 'day')
-        %dt
-          Event types:
-        %dd
-          = event_types(@conference)
-        %dt
-          Tracks:
-        %dd
-          = tracks(@conference)
-        %dt
-          Public Schedule
-        %dd#schedule_public
-          - if @program.schedule_public
-            Yes
-          - else
-            No
-        %dt
-          Schedule changeable?
-        %dd#schedule_changes
-          - if @program.schedule_fluid
-            Yes
-          - else
-            No
-        %dt
-          Rating Levels
-        %dd#rating
-          = @program.rating
-  .row
-    .col-md-12.text-right
-      = link_to(edit_admin_conference_program_cfp_path(@conference.short_title), class: 'btn btn-primary') do
-        Edit
-      = link_to(admin_conference_program_cfp_path(@conference.short_title), method: 'delete', class: 'btn btn-danger', data: { confirm: 'Are you sure you want to delete the CfP?' }) do
-        Delete
-- else
-  .row
-    .col-md-12.text-right
-      = link_to 'Create Call for Papers', new_admin_conference_program_cfp_path(@conference.short_title), class: 'btn btn-primary'
+.row
+  .col-md-8
+    %dl.dl-horizontal
+      = render "#{@cfp.cfp_type}_cfp"
+.row
+  .col-md-12.text-right
+    = link_to(edit_admin_conference_program_cfp_path(@conference.short_title, @cfp.id), class: 'btn btn-primary') do
+      Edit
+    = link_to(admin_conference_program_cfp_path(@conference.short_title, @cfp.id), method: 'delete', class: 'btn btn-danger', data: { confirm: 'Are you sure you want to delete the CfP?' }) do
+      Delete

--- a/app/views/admin/conferences/_todo_list.html.haml
+++ b/app/views/admin/conferences/_todo_list.html.haml
@@ -18,7 +18,7 @@
   %li{ 'class' => "list-group-item #{hidden_if_conference_over(conference)}  #{class_for_todo(conference_progress['cfp'])}" }
     %span{ 'class' => icon_for_todo(conference_progress['cfp']) }
     - if can? :update, Cfp.new(program_id: @program.id)
-      = link_to 'Set up call for papers', admin_conference_program_cfp_path(conference_progress['short_title'])
+      = link_to 'Set up call for papers', admin_conference_program_cfps_path(conference_progress['short_title'])
     - else
       Set up call for papers
   %li{'class'=>"list-group-item #{hidden_if_conference_over(conference)} #{class_for_todo(conference_progress['venue'])}"}

--- a/app/views/admin/versions/_object_desc_and_link.html.haml
+++ b/app/views/admin/versions/_object_desc_and_link.html.haml
@@ -85,7 +85,7 @@
           admin_conference_program_path(conference_id: Conference.find(version.conference_id).short_title)
 
 - when 'Cfp'
-  = 'cfp'
+  = 'cfp for'
   - cfp = current_or_last_object_state(version.item_type, version.item_id)
   = link_if_alive version, cfp.cfp_type,
           admin_conference_program_cfp_path(conference_id: Conference.find(version.conference_id).short_title, id: version.item_id)

--- a/app/views/admin/versions/_object_desc_and_link.html.haml
+++ b/app/views/admin/versions/_object_desc_and_link.html.haml
@@ -85,8 +85,10 @@
           admin_conference_program_path(conference_id: Conference.find(version.conference_id).short_title)
 
 - when 'Cfp'
-  = link_if_alive version, 'cfp',
-          admin_conference_program_cfp_path(conference_id: Conference.find(version.conference_id).short_title)
+  = 'cfp'
+  - cfp = current_or_last_object_state(version.item_type, version.item_id)
+  = link_if_alive version, cfp.cfp_type,
+          admin_conference_program_cfp_path(conference_id: Conference.find(version.conference_id).short_title, id: version.item_id)
 
 - when 'Track'
   = 'track'

--- a/app/views/layouts/_admin_sidebar.html.haml
+++ b/app/views/layouts/_admin_sidebar.html.haml
@@ -67,8 +67,8 @@
       - if @conference.program
         %ul
           - if can? :update, Cfp.new(program_id: @conference.program.id)
-            %li{class: active_nav_li(admin_conference_program_cfp_path(@conference.short_title))}
-              = link_to 'Call for Papers', admin_conference_program_cfp_path(@conference.short_title)
+            %li{class: active_nav_li(admin_conference_program_cfps_path(@conference.short_title))}
+              = link_to 'Call for Papers', admin_conference_program_cfps_path(@conference.short_title)
           - if can? :update, @conference.program.events.build
             %li{class: active_nav_li(admin_conference_program_events_path(@conference.short_title))}
               = link_to 'Events', admin_conference_program_events_path(@conference.short_title)

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -53,7 +53,7 @@ Osem::Application.routes.draw do
       end
       resource :registration_period
       resource :program do
-        resource :cfp
+        resources :cfps
         resources :tracks
         resources :event_types
         resources :difficulty_levels

--- a/db/migrate/20170530072155_add_type_to_cfps.rb
+++ b/db/migrate/20170530072155_add_type_to_cfps.rb
@@ -1,0 +1,15 @@
+class AddTypeToCfps < ActiveRecord::Migration
+  class TmpCfp < ActiveRecord::Base
+    self.table_name = 'cfps'
+  end
+
+  def change
+    add_column :cfps, :cfp_type, :string
+
+    TmpCfp.reset_column_information
+    TmpCfp.find_each do |cfp|
+      cfp.cfp_type = 'events'
+      cfp.save!
+    end
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -52,6 +52,7 @@ ActiveRecord::Schema.define(version: 20170603095900) do
     t.datetime "created_at"
     t.datetime "updated_at"
     t.integer  "program_id"
+    t.string   "cfp_type"
   end
 
   create_table "comments", force: :cascade do |t|

--- a/spec/controllers/admin/conferences_controller_spec.rb
+++ b/spec/controllers/admin/conferences_controller_spec.rb
@@ -177,10 +177,10 @@ describe Admin::ConferencesController do
         it 'assigns cfp_max an array with maximum weeks' do
           conference
           date = Date.new(2014, 05, 26)
-          conference.program.cfp = create(:cfp,
-                                          program: conference.program,
-                                          start_date: date,
-                                          end_date: date + 14)
+          create(:cfp,
+                 program: conference.program,
+                 start_date: date,
+                 end_date: date + 14)
           get :index
           expect(assigns(:cfp_weeks)).to match_array([1, 2, 3])
         end

--- a/spec/controllers/proposals_controller_spec.rb
+++ b/spec/controllers/proposals_controller_spec.rb
@@ -10,7 +10,7 @@ describe ProposalsController do
     describe 'GET #new' do
       before do
         # We allow new proposal only if program has open cfp
-        conference.program.update_attributes(cfp: create(:cfp))
+        create(:cfp, program: conference.program)
         get :new, conference_id: conference.short_title
       end
 
@@ -26,7 +26,7 @@ describe ProposalsController do
 
     describe 'POST #create' do
       # We allow proposal create only if program has open cfp
-      before { conference.program.update_attributes(cfp: create(:cfp)) }
+      before { create(:cfp, program: conference.program) }
 
       it 'assigns url variables' do
         post :create, event: attributes_for(:event, event_type_id: event_type.id),
@@ -192,7 +192,7 @@ describe ProposalsController do
     describe 'GET #new' do
       before do
         # We allow new proposal only if program has open cfp
-        conference.program.update_attributes(cfp: create(:cfp))
+        create(:cfp, program: conference.program)
         get :new, conference_id: conference.short_title
       end
 
@@ -223,7 +223,7 @@ describe ProposalsController do
 
     describe 'POST #create' do
       # We allow proposal create only if program has open cfp
-      before { conference.program.update_attributes(cfp: create(:cfp)) }
+      before { create(:cfp, program: conference.program) }
 
       it 'assigns url variables' do
         post :create, event: attributes_for(:event, event_type_id: event_type.id),

--- a/spec/factories/cfps.rb
+++ b/spec/factories/cfps.rb
@@ -4,6 +4,7 @@ FactoryGirl.define do
   factory :cfp do
     start_date { 1.day.ago }
     end_date { 6.days.from_now }
+    cfp_type 'events'
 
     program
   end

--- a/spec/factories/programs.rb
+++ b/spec/factories/programs.rb
@@ -5,5 +5,9 @@ FactoryGirl.define do
     schedule_public false
     schedule_fluid false
     conference
+
+    trait :with_cfp do
+      after(:create) { |program| create(:cfp, program: program) }
+    end
   end
 end

--- a/spec/features/ability_spec.rb
+++ b/spec/features/ability_spec.rb
@@ -40,7 +40,7 @@ feature 'Has correct abilities' do
     expect(page).to have_link('Rooms', href: "/admin/conferences/#{conference1.short_title}/venue/rooms")
     expect(page).to have_link('Lodgings', href: "/admin/conferences/#{conference1.short_title}/lodgings")
     expect(page).to have_link('Program', href: "/admin/conferences/#{conference1.short_title}/program")
-    expect(page).to have_link('Call for Papers', href: "/admin/conferences/#{conference1.short_title}/program/cfp")
+    expect(page).to have_link('Call for Papers', href: "/admin/conferences/#{conference1.short_title}/program/cfps")
     expect(page).to have_link('Events', href: "/admin/conferences/#{conference1.short_title}/program/events")
     expect(page).to have_link('Tracks', href: "/admin/conferences/#{conference1.short_title}/program/tracks")
     expect(page).to have_link('Event Types', href: "/admin/conferences/#{conference1.short_title}/program/event_types")
@@ -112,8 +112,8 @@ feature 'Has correct abilities' do
     visit new_admin_conference_program_cfp_path(conference1.short_title)
     expect(current_path).to eq(new_admin_conference_program_cfp_path(conference1.short_title))
 
-    visit edit_admin_conference_program_cfp_path(conference1.short_title)
-    expect(current_path).to eq(edit_admin_conference_program_cfp_path(conference1.short_title))
+    visit edit_admin_conference_program_cfp_path(conference1.short_title, conference1.program.cfp)
+    expect(current_path).to eq(edit_admin_conference_program_cfp_path(conference1.short_title, conference1.program.cfp))
 
     visit admin_conference_program_events_path(conference1.short_title)
     expect(current_path).to eq(admin_conference_program_events_path(conference1.short_title))
@@ -256,7 +256,7 @@ feature 'Has correct abilities' do
     expect(page).to have_link('Rooms', href: "/admin/conferences/#{conference2.short_title}/venue/rooms")
     expect(page).to_not have_link('Lodgings', href: "/admin/conferences/#{conference2.short_title}/lodgings")
     expect(page).to have_link('Program', href: "/admin/conferences/#{conference2.short_title}/program")
-    expect(page).to have_link('Call for Papers', href: "/admin/conferences/#{conference2.short_title}/program/cfp")
+    expect(page).to have_link('Call for Papers', href: "/admin/conferences/#{conference2.short_title}/program/cfps")
     expect(page).to have_link('Events', href: "/admin/conferences/#{conference2.short_title}/program/events")
     expect(page).to have_link('Tracks', href: "/admin/conferences/#{conference2.short_title}/program/tracks")
     expect(page).to have_link('Event Types', href: "/admin/conferences/#{conference2.short_title}/program/event_types")
@@ -324,8 +324,8 @@ feature 'Has correct abilities' do
     visit new_admin_conference_program_cfp_path(conference2.short_title)
     expect(current_path).to eq(new_admin_conference_program_cfp_path(conference2.short_title))
 
-    visit edit_admin_conference_program_cfp_path(conference2.short_title)
-    expect(current_path).to eq(edit_admin_conference_program_cfp_path(conference2.short_title))
+    visit edit_admin_conference_program_cfp_path(conference2.short_title, conference2.program.cfp)
+    expect(current_path).to eq(edit_admin_conference_program_cfp_path(conference2.short_title, conference2.program.cfp))
 
     visit admin_conference_program_events_path(conference2.short_title)
     expect(current_path).to eq(admin_conference_program_events_path(conference2.short_title))
@@ -537,7 +537,7 @@ feature 'Has correct abilities' do
     visit new_admin_conference_program_cfp_path(conference3.short_title)
     expect(current_path).to eq(root_path)
 
-    visit edit_admin_conference_program_cfp_path(conference3.short_title)
+    visit edit_admin_conference_program_cfp_path(conference3.short_title, conference3.program.cfp)
     expect(current_path).to eq(root_path)
 
     visit admin_conference_program_events_path(conference3.short_title)

--- a/spec/features/ability_spec.rb
+++ b/spec/features/ability_spec.rb
@@ -110,7 +110,12 @@ feature 'Has correct abilities' do
     expect(current_path).to eq(edit_admin_conference_program_path(conference1.short_title))
 
     visit new_admin_conference_program_cfp_path(conference1.short_title)
-    expect(current_path).to eq(new_admin_conference_program_cfp_path(conference1.short_title))
+    expect(current_path).to eq root_path
+
+    conference1.program.cfp.destroy!
+    visit new_admin_conference_program_cfp_path(conference1.short_title)
+    expect(current_path).to eq new_admin_conference_program_cfp_path(conference1.short_title)
+    create(:cfp, program: conference1.program)
 
     visit edit_admin_conference_program_cfp_path(conference1.short_title, conference1.program.cfp)
     expect(current_path).to eq(edit_admin_conference_program_cfp_path(conference1.short_title, conference1.program.cfp))
@@ -322,7 +327,12 @@ feature 'Has correct abilities' do
     expect(current_path).to eq(edit_admin_conference_program_path(conference2.short_title))
 
     visit new_admin_conference_program_cfp_path(conference2.short_title)
-    expect(current_path).to eq(new_admin_conference_program_cfp_path(conference2.short_title))
+    expect(current_path).to eq root_path
+
+    conference2.program.cfp.destroy!
+    visit new_admin_conference_program_cfp_path(conference2.short_title)
+    expect(current_path).to eq new_admin_conference_program_cfp_path(conference2.short_title)
+    create(:cfp, program: conference2.program)
 
     visit edit_admin_conference_program_cfp_path(conference2.short_title, conference2.program.cfp)
     expect(current_path).to eq(edit_admin_conference_program_cfp_path(conference2.short_title, conference2.program.cfp))

--- a/spec/features/cfp_spec.rb
+++ b/spec/features/cfp_spec.rb
@@ -31,6 +31,8 @@ feature Conference do
       # Validations
       expect(flash)
           .to eq('Call for papers successfully created.')
+
+      visit admin_conference_program_cfp_path(conference.short_title, conference.program.cfp)
       expect(find('#start_date').text).to eq(today.strftime('%A, %B %-d. %Y'))
       expect(find('#end_date').text).to eq((today + 6).strftime('%A, %B %-d. %Y'))
 
@@ -38,11 +40,11 @@ feature Conference do
     end
 
     scenario 'update cfp', feature: true, js: true do
-      conference.program.cfp = create(:cfp)
+      create(:cfp, program: conference.program)
       expected_count = Cfp.count
 
       sign_in organizer
-      visit admin_conference_program_cfp_path(conference.short_title)
+      visit admin_conference_program_cfp_path(conference.short_title, conference.program.cfp)
       click_link 'Edit'
 
       # Validate update with empty start date will not saved
@@ -65,6 +67,8 @@ feature Conference do
       # Validations
       expect(flash)
           .to eq('Call for papers successfully updated.')
+
+      visit admin_conference_program_cfp_path(conference.short_title, conference.program.cfp)
       expect(find('#start_date').text).to eq(today.strftime('%A, %B %-d. %Y'))
       expect(find('#end_date').text).to eq((today + 14).strftime('%A, %B %-d. %Y'))
       expect(Cfp.count).to eq(expected_count)

--- a/spec/features/versions_spec.rb
+++ b/spec/features/versions_spec.rb
@@ -38,9 +38,9 @@ feature 'Version' do
     cfp.destroy
 
     visit admin_revision_history_path
-    expect(page).to have_text("Someone (probably via the console) created new cfp in conference #{conference.short_title}")
-    expect(page).to have_text("Someone (probably via the console) updated start date and end date of cfp in conference #{conference.short_title}")
-    expect(page).to have_text("Someone (probably via the console) deleted cfp in conference #{conference.short_title}")
+    expect(page).to have_text("Someone (probably via the console) created new cfp for events in conference #{conference.short_title}")
+    expect(page).to have_text("Someone (probably via the console) updated start date and end date of cfp for events in conference #{conference.short_title}")
+    expect(page).to have_text("Someone (probably via the console) deleted cfp for events in conference #{conference.short_title}")
   end
 
   scenario 'display changes in registration_period', feature: true, versioning: true, js: true do

--- a/spec/models/ability_spec.rb
+++ b/spec/models/ability_spec.rb
@@ -10,7 +10,6 @@ describe 'User' do
     let(:user){ nil }
 
     let!(:my_conference) { create(:full_conference) }
-    let!(:my_cfp) { create(:cfp, program: my_conference.program) }
     let(:my_venue) { my_conference.venue || create(:venue, conference: my_conference) }
     let(:my_registration) { create(:registration, conference: my_conference, user: admin) }
 
@@ -22,7 +21,6 @@ describe 'User' do
 
     let(:conference_not_public) { create(:conference, splashpage: create(:splashpage, public: false)) }
     let(:conference_public) { create(:full_conference, splashpage: create(:splashpage, public: true)) }
-    let!(:conference_public_cfp) { create(:cfp, program: conference_public.program) }
 
     let(:event_confirmed) { create(:event, state: 'confirmed') }
     let(:event_unconfirmed) { create(:event) }
@@ -32,7 +30,7 @@ describe 'User' do
     let(:resource) { create(:resource, conference: my_conference)}
     let(:registration) { create(:registration) }
 
-    let(:program_with_cfp) { create(:program, cfp: create(:cfp)) }
+    let(:program_with_cfp) { create(:program, :with_cfp) }
     let(:program_without_cfp) { create(:program) }
     let(:conference_with_open_registration) { create(:conference) }
     let!(:open_registration_period) { create(:registration_period, conference: conference_with_open_registration, start_date: Date.current - 6.days) }

--- a/spec/models/conference_spec.rb
+++ b/spec/models/conference_spec.rb
@@ -48,7 +48,7 @@ describe Conference do
       subject.start_date = Date.today + 6.weeks
       subject.end_date = Date.today + 7.weeks
       subject.save
-      subject.program.cfp = create(:cfp, start_date: Date.today - 3.weeks)
+      create(:cfp, start_date: Date.today - 3.weeks, program: subject.program)
 
       create(:event, program: subject.program, created_at: Date.today)
       options = {}
@@ -115,7 +115,7 @@ describe Conference do
       }
       subject.events_per_week = db_data
       subject.save
-      subject.program.cfp = create(:cfp, start_date: Date.today - 3.weeks)
+      create(:cfp, start_date: Date.today - 3.weeks, program: subject.program)
 
       create(:event, program: subject.program, created_at: Date.today)
       unconfirmed = create(:event, program: subject.program)
@@ -186,7 +186,7 @@ describe Conference do
       subject.events_per_week = db_data
 
       subject.save
-      subject.program.cfp = create(:cfp, start_date: Date.today - 2.weeks)
+      create(:cfp, start_date: Date.today - 2.weeks, program: subject.program)
 
       create(:event, program: subject.program, created_at: Date.today - 2.weeks)
 
@@ -203,7 +203,7 @@ describe Conference do
       subject.start_date = Date.today + 6.weeks
       subject.end_date = Date.today + 7.weeks
       subject.save
-      subject.program.cfp = create(:cfp, start_date: Date.today)
+      create(:cfp, start_date: Date.today, program: subject.program)
       create(:event, program: subject.program)
 
       result = {
@@ -220,7 +220,7 @@ describe Conference do
       subject.start_date = Date.today + 6.weeks
       subject.end_date = Date.today + 7.weeks
       subject.save
-      subject.program.cfp = create(:cfp, start_date: Date.today - 3.weeks)
+      create(:cfp, start_date: Date.today - 3.weeks, program: subject.program)
 
       create(:event, program: subject.program, created_at: Date.today)
       unconfirmed = create(:event, program: subject.program)
@@ -258,7 +258,7 @@ describe Conference do
       subject.events_per_week = db_data
 
       subject.save
-      subject.program.cfp = create(:cfp, start_date: Date.today - 3.weeks)
+      create(:cfp, start_date: Date.today - 3.weeks, program: subject.program)
 
       create(:event, program: subject.program, created_at: Date.today - 3.weeks)
 
@@ -992,7 +992,6 @@ describe Conference do
     end
 
     it 'calculates correct for new conference' do
-      subject.program.cfp = nil
       subject.venue = nil
       subject.program.tracks = []
       subject.program.event_types = []
@@ -1006,7 +1005,6 @@ describe Conference do
       subject.registration_period = create(:registration_period,
                                            start_date: subject.end_date - 14,
                                            end_date: subject.end_date, conference: subject)
-      subject.program.cfp = nil
       subject.venue = nil
       subject.program.event_types = []
       subject.program.tracks = []
@@ -1024,7 +1022,7 @@ describe Conference do
       subject.registration_period = create(:registration_period,
                                            start_date: subject.end_date - 14,
                                            end_date: subject.end_date, conference: subject)
-      subject.program.cfp = create(:cfp)
+      create(:cfp, program: subject.program)
       subject.venue = nil
       subject.program.tracks = []
       subject.program.event_types = []
@@ -1043,7 +1041,7 @@ describe Conference do
       subject.registration_period = create(:registration_period,
                                            start_date: subject.end_date - 14,
                                            end_date: subject.end_date, conference: subject)
-      subject.program.cfp = create(:cfp)
+      create(:cfp, program: subject.program)
       subject.venue = create(:venue, conference: subject)
       subject.venue.rooms = []
       subject.program.tracks = []
@@ -1063,7 +1061,7 @@ describe Conference do
       subject.registration_period = create(:registration_period,
                                            start_date: Date.today,
                                            end_date: Date.today + 14, conference: subject)
-      subject.program.cfp = create(:cfp)
+      create(:cfp, program: subject.program)
       subject.venue = create(:venue, conference: subject)
       subject.venue.rooms = [create(:room, venue: subject.venue)]
       subject.program.tracks = []
@@ -1087,7 +1085,7 @@ describe Conference do
       subject.registration_period = create(:registration_period,
                                            start_date: Date.today,
                                            end_date: Date.today + 14, conference: subject)
-      subject.program.cfp = create(:cfp)
+      create(:cfp, program: subject.program)
       subject.program.event_types = []
       subject.program.difficulty_levels = []
       subject.splashpage = create(:splashpage, public: false)
@@ -1109,7 +1107,7 @@ describe Conference do
       subject.registration_period = create(:registration_period,
                                            start_date: Date.today,
                                            end_date: Date.today + 14, conference: subject)
-      subject.program.cfp = create(:cfp)
+      create(:cfp, program: subject.program)
       subject.venue = create(:venue, conference: subject)
       subject.venue.rooms = [create(:room, venue: subject.venue)]
       subject.program.difficulty_levels = []
@@ -1133,7 +1131,7 @@ describe Conference do
       subject.registration_period = create(:registration_period,
                                            start_date: Date.today,
                                            end_date: Date.today + 14, conference: subject)
-      subject.program.cfp = create(:cfp)
+      create(:cfp, program: subject.program)
       subject.venue = create(:venue, conference: subject)
       subject.venue.rooms = [create(:room, venue: subject.venue)]
       subject.splashpage = create(:splashpage, public: true)
@@ -1176,34 +1174,34 @@ describe Conference do
   describe '#cfp_weeks' do
 
     it 'calculates new year' do
-      cfp = create(:cfp)
+      cfp = create(:cfp, program: subject.program)
       cfp.start_date = Date.new(2013, 12, 30)
       cfp.end_date = Date.new(2013, 12, 30) + 6
-      subject.program.cfp = cfp
+      cfp.save!
       expect(subject.cfp_weeks).to eq(1)
     end
 
     it 'is one if start and end are 6 days apart' do
-      cfp = create(:cfp)
+      cfp = create(:cfp, program: subject.program)
       cfp.start_date = Date.new(2014, 05, 26)
       cfp.end_date = Date.new(2014, 05, 26) + 6
-      subject.program.cfp = cfp
+      cfp.save!
       expect(subject.cfp_weeks).to eq(1)
     end
 
     it 'is one if start and end are the same date' do
-      cfp = create(:cfp)
+      cfp = create(:cfp, program: subject.program)
       cfp.start_date = Date.new(2014, 05, 26)
       cfp.end_date = Date.new(2014, 05, 26)
-      subject.program.cfp = cfp
+      cfp.save!
       expect(subject.cfp_weeks).to eq(1)
     end
 
     it 'is two if start and end are 10 days apart' do
-      cfp = create(:cfp)
+      cfp = create(:cfp, program: subject.program)
       cfp.start_date = Date.new(2014, 05, 26)
       cfp.end_date = Date.new(2014, 05, 26) + 10
-      subject.program.cfp = cfp
+      cfp.save!
       expect(subject.cfp_weeks).to eq(2)
     end
   end
@@ -1211,36 +1209,36 @@ describe Conference do
   describe '#get_submissions_per_week' do
 
     it 'does calculate correct if cfp start date is altered' do
-      cfp = create(:cfp)
+      cfp = create(:cfp, program: subject.program)
       cfp.start_date = Date.new(2014, 05, 26)
       cfp.end_date = Date.new(2014, 05, 26) + 21
-      subject.program.cfp = cfp
+      cfp.save!
       subject.program.events += [create(:event, created_at: Date.new(2014, 05, 26) - 7)]
       expect(subject.get_submissions_per_week).to eq([1, 1, 1, 1, 1])
     end
 
     it 'does calculate correct if cfp end date is altered' do
-      cfp = create(:cfp)
+      cfp = create(:cfp, program: subject.program)
       cfp.start_date = Date.new(2014, 05, 26)
       cfp.end_date = Date.new(2014, 05, 26) + 21
-      subject.program.cfp = cfp
+      cfp.save!
       subject.program.events += [create(:event, created_at: Date.new(2014, 05, 26) + 28)]
       expect(subject.get_submissions_per_week).to eq([0, 0, 0, 0, 1])
     end
 
     it 'pads with zeros if there are no submissions' do
-      cfp = create(:cfp)
+      cfp = create(:cfp, program: subject.program)
       cfp.start_date = Date.new(2014, 05, 26)
       cfp.end_date = Date.new(2014, 05, 26) + 21
-      subject.program.cfp = cfp
+      cfp.save!
       expect(subject.get_submissions_per_week).to eq([0, 0, 0, 0])
     end
 
     it 'summarized correct if there are no submissions in one week' do
-      cfp = create(:cfp)
+      cfp = create(:cfp, program: subject.program)
       cfp.start_date = Date.new(2014, 05, 26)
       cfp.end_date = Date.new(2014, 05, 26) + 28
-      subject.program.cfp = cfp
+      cfp.save!
       subject.program.events += [create(:event, created_at: Date.new(2014, 05, 26) + 7)]
       subject.program.events += [create(:event, created_at: Date.new(2014, 05, 26) + 14)]
       subject.program.events += [create(:event, created_at: Date.new(2014, 05, 26) + 28)]
@@ -1248,20 +1246,20 @@ describe Conference do
     end
 
     it 'summarized correct if there are submissions every week except the first' do
-      cfp = create(:cfp)
+      cfp = create(:cfp, program: subject.program)
       cfp.start_date = Date.new(2014, 05, 26)
       cfp.end_date = Date.new(2014, 05, 26) + 21
-      subject.program.cfp = cfp
+      cfp.save!
       subject.program.events += [create(:event, created_at: Date.new(2014, 05, 26) + 7)]
       subject.program.events += [create(:event, created_at: Date.new(2014, 05, 26) + 14)]
       expect(subject.get_submissions_per_week).to eq([0, 1, 2, 2])
     end
 
     it 'summarized correct if there are submissions every week' do
-      cfp = create(:cfp)
+      cfp = create(:cfp, program: subject.program)
       cfp.start_date = Date.new(2014, 05, 26)
       cfp.end_date = Date.new(2014, 05, 26) + 21
-      subject.program.cfp = cfp
+      cfp.save!
       subject.program.events += [create(:event, created_at: Date.new(2014, 05, 26))]
       subject.program.events += [create(:event, created_at: Date.new(2014, 05, 26) + 7)]
       subject.program.events += [create(:event, created_at: Date.new(2014, 05, 26) + 14)]
@@ -1269,29 +1267,29 @@ describe Conference do
     end
 
     it 'pads left' do
-      cfp = create(:cfp)
+      cfp = create(:cfp, program: subject.program)
       cfp.start_date = Date.new(2014, 05, 26)
       cfp.end_date = Date.new(2014, 05, 26) + 21
-      subject.program.cfp = cfp
+      cfp.save!
       subject.program.events += [create(:event, created_at: Date.new(2014, 05, 26) + 21)]
       expect(subject.get_submissions_per_week).to eq([0, 0, 0, 1])
     end
 
     it 'pads middle' do
-      cfp = create(:cfp)
+      cfp = create(:cfp, program: subject.program)
       cfp.start_date = Date.new(2014, 05, 26)
       cfp.end_date = Date.new(2014, 05, 26) + 21
-      subject.program.cfp = cfp
+      cfp.save!
       subject.program.events += [create(:event, created_at: Date.new(2014, 05, 26))]
       subject.program.events += [create(:event, created_at: Date.new(2014, 05, 26) + 21)]
       expect(subject.get_submissions_per_week).to eq([1, 1, 1, 2])
     end
 
     it 'pads right' do
-      cfp = create(:cfp)
+      cfp = create(:cfp, program: subject.program)
       cfp.start_date = Date.new(2014, 05, 26)
       cfp.end_date = Date.new(2014, 05, 26) + 21
-      subject.program.cfp = cfp
+      cfp.save!
       subject.program.events += [create(:event, created_at: Date.new(2014, 05, 26))]
       expect(subject.get_submissions_per_week).to eq([1, 1, 1, 1])
     end
@@ -1460,7 +1458,7 @@ describe Conference do
     context 'open cfp' do
 
       before do
-        subject.program.cfp = create(:cfp)
+        create(:cfp, program: subject.program)
       end
 
       it '#registration_open? is true' do

--- a/spec/models/email_settings_spec.rb
+++ b/spec/models/email_settings_spec.rb
@@ -46,9 +46,10 @@ describe EmailSettings do
 
     context 'conference has cfp' do
       before do
-        conference.program.update_attributes(cfp: create(:cfp,
-                                                         start_date: Date.new(2014, 04, 29),
-                                                         end_date: Date.new(2014, 05, 06)))
+        create(:cfp,
+               start_date: Date.new(2014, 04, 29),
+               end_date: Date.new(2014, 05, 06),
+               program: conference.program)
         cfp_dates_hash = { 'cfp_start_date' => Date.new(2014, 04, 29), 'cfp_end_date' => Date.new(2014, 05, 06) }
         expected_hash.merge!(cfp_dates_hash)
       end

--- a/spec/models/program_spec.rb
+++ b/spec/models/program_spec.rb
@@ -7,7 +7,7 @@ describe Program do
 
   describe 'association' do
     it { is_expected.to belong_to :conference }
-    it { is_expected.to have_one(:cfp).dependent(:destroy) }
+    it { is_expected.to have_many(:cfps).dependent(:destroy) }
     it { is_expected.to have_many(:schedules).dependent(:destroy) }
     it { is_expected.to have_many(:event_types).dependent(:destroy) }
     it { is_expected.to have_many(:tracks).dependent(:destroy) }

--- a/spec/models/program_spec.rb
+++ b/spec/models/program_spec.rb
@@ -240,4 +240,23 @@ describe Program do
     end
   end
 
+  describe '#cfp' do
+    it 'returns the cfp for events' do
+      create(:cfp, cfp_type: 'events', program: program, end_date: Date.current + 1)
+      expect(program.cfp).to be_a Cfp
+      expect(program.cfp.cfp_type).to eq('events')
+    end
+
+    it 'returns nil if the program doesn\'t have a cfp' do
+      expect(program.cfp).to eq(nil)
+    end
+  end
+
+  describe '#remaining_cfp_types' do
+    it 'returns an array with the types for which a cfp doesn\'t exist' do
+      expect(program.remaining_cfp_types).to eq(Cfp::TYPES)
+      create(:cfp, cfp_type: 'events', program: program, end_date: Date.current + 1)
+      expect(program.remaining_cfp_types).to eq([])
+    end
+  end
 end

--- a/spec/models/registration_spec.rb
+++ b/spec/models/registration_spec.rb
@@ -29,7 +29,6 @@ describe 'Registration' do
   describe 'association' do
     it { is_expected.to belong_to(:user) }
     it { is_expected.to belong_to(:conference) }
-    it { is_expected.to have_and_belong_to_many(:events) }
     it { is_expected.to have_and_belong_to_many(:qanswers) }
     it { is_expected.to have_and_belong_to_many(:vchoices) }
     it { is_expected.to have_many(:events_registrations) }


### PR DESCRIPTION
Up until now the cfp only accepts requests for events(proposals), this pr modifies it so it can be used for more things (like tracks and booths), while providing backwards compatibility.
* The column cfp_type allows as to have different kinds of cfps for the same conference
* The constant Cfp::TYPES defines the allowed values for cfp_type
* The method Cfp#open? is the equivalent of the older Program#cfp_open? for a specific cfp
* An index view has been added for the cfps
* The Cfp#show view was refactored to use partials, so each type of cfp can have it's own partial