### PR TITLE
Replace .today with .current in program spec

### DIFF
--- a/spec/models/program_spec.rb
+++ b/spec/models/program_spec.rb
@@ -141,7 +141,7 @@ describe Program do
   describe '#cfp_open?' do
     describe 'returns true' do
       it 'when there is an open Call for Papers for the conference' do
-        create(:cfp, start_date: Date.today - 2, end_date: Date.today, program_id: program.id)
+        create(:cfp, start_date: Date.current - 2, end_date: Date.current, program_id: program.id)
         expect(program.cfp_open?).to be true
       end
     end
@@ -152,7 +152,7 @@ describe Program do
       end
 
       it 'when the Call for Papers period is over' do
-        build(:cfp, start_date: Date.today - 2, end_date: Date.today - 1, program_id: program.id)
+        create(:cfp, start_date: Date.current - 2, end_date: Date.current - 1, program_id: program.id)
         expect(program.cfp_open?).to be false
       end
     end


### PR DESCRIPTION
The cfp_open? method uses Date.current, so it should also be tested with
Date.current and not Date.today
Also, build was replaced with create to fix a false negative

This is a partial fix for #1522