### PR TITLE
Add Style/SelfAssignment Rubocop Cop

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -92,6 +92,10 @@ Style/SpaceAroundOperators:
 Style/SpaceInsideBrackets:
   Enabled: true
 
+# This cop enforces the use the shorthand for self-assignment.
+Style/SelfAssignment:
+  Enabled: true
+  
 # Use single quotes unless there's string interpolation
 Style/StringLiterals:
   Enabled: true

--- a/.rubocop_todo.yml
+++ b/.rubocop_todo.yml
@@ -723,14 +723,6 @@ Style/RegexpLiteral:
 
 # Offense count: 3
 # Cop supports --auto-correct.
-Style/SelfAssignment:
-  Exclude:
-    - 'app/models/event.rb'
-    - 'db/migrate/20141104131625_generate_username.rb'
-    - 'spec/support/save_feature_failures.rb'
-
-# Offense count: 3
-# Cop supports --auto-correct.
 # Configuration parameters: EnforcedStyle, SupportedStyles.
 # SupportedStyles: only_raise, only_fail, semantic
 Style/SignalException:

--- a/app/models/event.rb
+++ b/app/models/event.rb
@@ -115,7 +115,7 @@ class Event < ActiveRecord::Base
   def average_rating
     @total_rating = 0
     votes.each do |vote|
-      @total_rating = @total_rating + vote.rating
+      @total_rating += vote.rating
     end
     @total = votes.size
     @total_rating > 0 ? number_with_precision(@total_rating / @total.to_f, precision: 2, strip_insignificant_zeros: true) : 0

--- a/db/migrate/20141104131625_generate_username.rb
+++ b/db/migrate/20141104131625_generate_username.rb
@@ -7,9 +7,7 @@ class GenerateUsername < ActiveRecord::Migration
     TempUser.all.each do |user|
       if user.username.blank?
         username = user.email.split('@')[0]
-        if TempUser.find_by(username: username)
-          username = username + user.id.to_s
-        end
+        username += user.id.to_s if TempUser.find_by(username: username)
         user.update_attributes(username: username)
       end
     end

--- a/spec/support/save_feature_failures.rb
+++ b/spec/support/save_feature_failures.rb
@@ -5,7 +5,7 @@ RSpec.configure do |config|
   config.after(:each, type: :feature) do
     example_filename = RSpec.current_example.full_description
     example_filename = example_filename.tr(' ', '_')
-    example_filename = example_filename + '.html'
+    example_filename += '.html'
     example_filename = File.expand_path(example_filename, Capybara.save_and_open_page_path)
     if RSpec.current_example.exception.present?
       save_page(example_filename)


### PR DESCRIPTION
Enabled Style/SelfAssignment Cop in the Rubocop linter. This cop enforces the use the shorthand for self-assignment. That is force the use of `a+=1` over `a=a+1`. Also all the offenses have been auto corrected with `vagrant exec rubocop --auto-correct` .Fixes #1531 .