### PR TITLE
Improved test performance.

### DIFF
--- a/spec/support/database_cleaner.rb
+++ b/spec/support/database_cleaner.rb
@@ -1,6 +1,16 @@
 RSpec.configure do |config|
-  config.before(:each) do
+  config.before(:suite) do
     DatabaseCleaner.clean_with(:truncation)
     Rails.application.load_seed
+  end
+
+  config.before(:each) do |example|
+    DatabaseCleaner.strategy = example.metadata[:js] == true ? :truncation : :transaction
+    DatabaseCleaner.start
+  end
+
+  config.after(:each) do |example|
+    DatabaseCleaner.clean
+    Rails.application.load_seed if example.metadata[:js] == true
   end
 end

--- a/spec/support/factory_girl.rb
+++ b/spec/support/factory_girl.rb
@@ -4,9 +4,15 @@ RSpec.configure do |config|
 
   config.before(:suite) do
     if ENV['OSEM_FACTORY_LINT'] != 'false'
-      mock_commercial_request
-      FactoryGirl.lint
+      DatabaseCleaner.strategy = :transaction
+      DatabaseCleaner.clean_with(:truncation)
+      begin
+        DatabaseCleaner.start
+        mock_commercial_request
+        FactoryGirl.lint
+      ensure
+        DatabaseCleaner.clean
+      end
     end
   end
-
 end


### PR DESCRIPTION
Closes #1286.
Both cleaning of database and loading of seeds should be done before each feature, instead of each test.