### PR TITLE
Enable rails/findEach Rubocop cop

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -196,6 +196,10 @@ Lint/DuplicatedKey:
 Rails:
   Enabled: true
 
+# Use `find_each` instead of `each`.
+Rails/FindEach:
+  Enabled: true
+
 # Avoid use of old-style attribute validation
 Rails/Validation:
   Enabled: true

--- a/.rubocop_todo.yml
+++ b/.rubocop_todo.yml
@@ -154,14 +154,6 @@ Rails/FindBy:
     - 'app/models/ticket_purchase.rb'
     - 'app/models/user.rb'
 
-# Offense count: 1
-# Cop supports --auto-correct.
-# Configuration parameters: Include.
-# Include: app/models/**/*.rb
-Rails/FindEach:
-  Exclude:
-    - 'app/models/conference.rb'
-
 # Offense count: 7
 # Configuration parameters: Include.
 # Include: app/models/**/*.rb

--- a/app/models/conference.rb
+++ b/app/models/conference.rb
@@ -643,7 +643,7 @@ class Conference < ActiveRecord::Base
   def self.write_event_distribution_to_db
     week = DateTime.now.end_of_week
 
-    Conference.where('end_date > ?', Date.today).each do |conference|
+    Conference.where('end_date > ?', Date.today).find_each do |conference|
       result = {}
       Event.state_machine.states.each do |state|
         count = conference.program.events.where('state = ?', state.name).count


### PR DESCRIPTION
Enable rails/findEach Rubocop cop

This cop enforce the use of `find_each` instead of `each`.

Closes #1535