### PR TITLE
Fix broken test in Admin::EventsController

### DIFF
--- a/spec/controllers/admin/events_controller_spec.rb
+++ b/spec/controllers/admin/events_controller_spec.rb
@@ -4,9 +4,13 @@ describe Admin::EventsController do
   let(:conference) { create(:conference) }
   let(:organizer_role) { Role.find_by(name: 'organizer', resource: conference) }
   let(:organizer) { create(:user, role_ids: organizer_role.id) }
-  let!(:event_without_commercial) { create(:event, program: conference.program) }
-  let!(:event_with_commercial) { create(:event, program: conference.program) }
-  let!(:event_commercial) { create(:event_commercial, commercialable: event_with_commercial, url: 'https://www.youtube.com/watch?v=M9bq_alk-sw') }
+  # The where_object() and where_object_changes() methods of paper_trail gem are broken when having:
+  # an Event with ID 1, an Event with ID 2, and a commercial with ID 1, for event with ID 2
+  # (the numbers could be different as long as there is this matching of IDs).
+  # We implemented or own where method to solve this and those ids are for testing this case.
+  let!(:event_without_commercial) { create(:event, id: 1, program: conference.program) }
+  let!(:event_with_commercial) { create(:event, id: 2, program: conference.program) }
+  let!(:event_commercial) { create(:event_commercial, id: 1, commercialable: event_with_commercial, url: 'https://www.youtube.com/watch?v=M9bq_alk-sw') }
 
   with_versioning do
     describe 'GET #show' do
@@ -17,8 +21,6 @@ describe Admin::EventsController do
 
       it 'assigns versions' do
         versions = event_without_commercial.versions
-        expect(event_without_commercial.id).to eq event_commercial.id
-        expect(event_commercial.id).not_to eq event_commercial.commercialable_id
         expect(assigns(:versions)).to eq versions
       end
     end

--- a/spec/features/versions_spec.rb
+++ b/spec/features/versions_spec.rb
@@ -286,8 +286,6 @@ feature 'Version' do
     expect(page).to have_text('Someone (probably via the console) created new commercial')
     visit admin_conference_program_event_path(conference.short_title, event_without_commercial)
     click_link 'History'
-    expect(event_commercial.id).not_to eq event_commercial.commercialable_id
-    expect(event_without_commercial.id).to eq event_commercial.id
     expect(page).to have_no_text('Someone (probably via the console) created new commercial')
   end
 


### PR DESCRIPTION
In the assigns versions test we were checking the ids of `event_without_commercial` and `event_commercial` were the same. That was only the case because there were the only objects in the database, but this does't need to be true and it is completely useless.

We also check that the ids of `event_commercial` and `event_commercial.commercialable` were different, but that also doesn't make any sense, as they are even different object types.

This two test worked before merging https://github.com/openSUSE/osem/pull/1541 After that, only the controller test was failing, although both of them were wrong. :bowtie: 

**We should consider improving this tests, because there are not very useful.** I'll do so or create an issue. The objective of this PR is to fix the failing tests. :wink: 