### PR TITLE
Enable Style/CommentAnnotation Rubocop cop

### DIFF
--- a/.rubocop_todo.yml
+++ b/.rubocop_todo.yml
@@ -288,14 +288,6 @@ Style/ColonMethodCall:
     - 'app/models/commercial.rb'
     - 'app/models/contact.rb'
 
-# Offense count: 1
-# Cop supports --auto-correct.
-# Configuration parameters: Keywords.
-# Keywords: TODO, FIXME, OPTIMIZE, HACK, REVIEW
-Style/CommentAnnotation:
-  Exclude:
-    - 'app/models/event_user.rb'
-
 # Offense count: 14
 # Cop supports --auto-correct.
 Style/CommentIndentation:

--- a/app/models/event_user.rb
+++ b/app/models/event_user.rb
@@ -1,5 +1,5 @@
 class EventUser < ActiveRecord::Base
-  # TODO Do we need these roles?
+  # TODO: Do we need these roles?
   ROLES = [%w[Speaker speaker], %w[Submitter submitter], %w[Moderator moderator]]
 
   belongs_to :event


### PR DESCRIPTION
This cop checks that comment annotation keywords are written according to guidelines. The offense was automatically corrected. :bowtie: 