### PR TITLE
Make ticket layout configurable

### DIFF
--- a/app/controllers/admin/conferences_controller.rb
+++ b/app/controllers/admin/conferences_controller.rb
@@ -211,7 +211,7 @@ module Admin
                                          :vpositions_attributes, :use_volunteers, :color,
                                          :sponsorship_levels_attributes, :sponsors_attributes,
                                          :targets, :targets_attributes,
-                                         :campaigns, :campaigns_attributes, :registration_limit, :organization_id)
+                                         :campaigns, :campaigns_attributes, :registration_limit, :organization_id, :ticket_layout)
     end
   end
 end

--- a/app/models/conference.rb
+++ b/app/models/conference.rb
@@ -57,6 +57,7 @@ class Conference < ActiveRecord::Base
             :end_date,
             :start_hour,
             :end_hour,
+            :ticket_layout,
             :organization, presence: true
 
   validates :short_title, uniqueness: true
@@ -72,6 +73,11 @@ class Conference < ActiveRecord::Base
 
   after_create :create_free_ticket
   after_update :delete_event_schedules
+
+  enum ticket_layout: {
+    vertical: 0,
+    horizontal: 1
+  }
 
   ##
   # Checks if the user is registered to the conference

--- a/app/views/admin/conferences/edit.html.haml
+++ b/app/views/admin/conferences/edit.html.haml
@@ -11,6 +11,7 @@
       = f.input :short_title, hint: "A short title, e.g. 'oSC14', to be used in URLs"
       = f.input :description, hint: markdown_hint('A description of the conference.'), input_html: { rows: 5, data: { provide: 'markdown-editable' } }
       = f.input :color, hint: 'The color will be used eg for the dashboard.', input_html: {size: 6, type: 'color'}
+      = f.input :ticket_layout, as: :select, collection: Conference.ticket_layouts.keys, hint: "Layout type for tickets of the conference."
       = f.label 'Conference Logo'
       %br
       - if @conference.picture?

--- a/db/migrate/20170629232817_add_ticket_layout_to_conferences.rb
+++ b/db/migrate/20170629232817_add_ticket_layout_to_conferences.rb
@@ -1,0 +1,5 @@
+class AddTicketLayoutToConferences < ActiveRecord::Migration
+  def change
+    add_column :conferences, :ticket_layout, :integer, default: 0
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -105,6 +105,7 @@ ActiveRecord::Schema.define(version: 20170603095900) do
     t.integer  "start_hour",         default: 9
     t.integer  "end_hour",           default: 20
     t.integer  "organization_id"
+    t.integer  "ticket_layout",      default: 0
   end
 
   add_index "conferences", ["organization_id"], name: "index_conferences_on_organization_id"

--- a/spec/factories/conferences.rb
+++ b/spec/factories/conferences.rb
@@ -10,6 +10,7 @@ FactoryGirl.define do
     start_hour 9
     end_hour 20
     registration_limit 0
+    ticket_layout 0
     description { Faker::Hipster.paragraph }
     organization
     after(:create) do |conference|

--- a/spec/models/conference_spec.rb
+++ b/spec/models/conference_spec.rb
@@ -1573,6 +1573,10 @@ describe Conference do
       should validate_presence_of(:end_hour)
     end
 
+    it 'is not valid without a ticket_layout' do
+      should validate_presence_of(:ticket_layout)
+    end
+
     it 'is not valid with a duplicate short title' do
       should validate_uniqueness_of(:short_title)
     end


### PR DESCRIPTION
Admin can set the layout type for the tickets of the conference.

![screen shot 2017-06-30 at 6 12 00 am](https://user-images.githubusercontent.com/17237680/27716306-199b50fe-5d5b-11e7-8c3a-c581c2d1ee3e.png)
