### PR TITLE
Fix new conference links

### DIFF
--- a/app/views/layouts/_admin_sidebar.html.haml
+++ b/app/views/layouts/_admin_sidebar.html.haml
@@ -16,7 +16,7 @@
               %span.fa.fa-cog
               Manage
               = conference.short_title
-      - if (current_user.is_admin) || (current_user.has_role? :organizer, :any)
+      - if can? :new, Conference.new
         %li
           = link_to(new_admin_conference_path) do
             %span.fa.fa-plus

--- a/app/views/layouts/_admin_sidebar_index.html.haml
+++ b/app/views/layouts/_admin_sidebar_index.html.haml
@@ -16,7 +16,7 @@
               %span.fa.fa-cog
               Manage
               = conference.short_title
-      - if can? :create, Conference
+      - if can? :new, Conference.new
         %li
           = link_to(new_admin_conference_path) do
             %span.fa.fa-plus

--- a/app/views/layouts/_user_menu.html.haml
+++ b/app/views/layouts/_user_menu.html.haml
@@ -28,10 +28,10 @@
         = link_to(admin_conferences_path()) do
           %span.fa.fa-home
           Administration
-      - if can? :create, Conference
+      - if can? :new, Conference.new
         =link_to(new_admin_conference_path) do
           %span.fa.fa-plus
-          Create Conference
+          New Conference
     -if @conference and @conference.id and can? :show, @conference
       %li
         = link_to(admin_conference_path(@conference.short_title)) do

--- a/spec/features/cfp_ability_spec.rb
+++ b/spec/features/cfp_ability_spec.rb
@@ -46,6 +46,7 @@ feature 'Has correct abilities' do
       expect(page).to_not have_link('Goals', href: "/admin/conferences/#{conference.short_title}/targets")
       expect(page).to have_link('Roles', href: "/admin/conferences/#{conference.short_title}/roles")
       expect(page).to have_link('Resources', href: "/admin/conferences/#{conference.short_title}/resources")
+      expect(page).to_not have_link('New Conference', href: '/admin/conferences/new')
 
       visit admin_conference_venue_rooms_path(conference.short_title)
       expect(current_path).to eq(admin_conference_venue_rooms_path(conference.short_title))

--- a/spec/features/info_desk_ability_spec.rb
+++ b/spec/features/info_desk_ability_spec.rb
@@ -46,6 +46,7 @@ feature 'Has correct abilities' do
       expect(page).to have_link('Registrations', href: "/admin/conferences/#{conference.short_title}/registrations")
       expect(page).to have_link('Questions', href: "/admin/conferences/#{conference.short_title}/questions")
       expect(page).to_not have_link('E-Mails', href: "/admin/conferences/#{conference.short_title}/emails")
+      expect(page).to_not have_link('New Conference', href: '/admin/conferences/new')
 
       visit admin_organizations_path
       expect(current_path).to eq(admin_organizations_path)

--- a/spec/features/organization_admin_ability_spec.rb
+++ b/spec/features/organization_admin_ability_spec.rb
@@ -55,6 +55,7 @@ feature 'Has correct abilities' do
       expect(page).to have_link('E-Mails', href: "/admin/conferences/#{conference.short_title}/emails")
       expect(page).to have_link('Roles', href: "/admin/conferences/#{conference.short_title}/roles")
       expect(page).to have_link('Resources', href: "/admin/conferences/#{conference.short_title}/resources")
+      expect(page).to have_link('New Conference', href: '/admin/conferences/new')
 
       visit edit_admin_conference_path(conference.short_title)
       expect(current_path).to eq(edit_admin_conference_path(conference.short_title))

--- a/spec/features/organizer_ability_spec.rb
+++ b/spec/features/organizer_ability_spec.rb
@@ -58,6 +58,7 @@ feature 'Has correct abilities' do
       expect(page).to have_link('E-Mails', href: "/admin/conferences/#{conference.short_title}/emails")
       expect(page).to have_link('Roles', href: "/admin/conferences/#{conference.short_title}/roles")
       expect(page).to have_link('Resources', href: "/admin/conferences/#{conference.short_title}/resources")
+      expect(page).to_not have_link('New Conference', href: '/admin/conferences/new')
 
       visit admin_conference_path(other_conference.short_title)
       expect(page).to have_link('Add venue', href: "/admin/conferences/#{other_conference.short_title}/venue/new")


### PR DESCRIPTION
Only `site admins` and `organization admins` have the permission to access `conference#new` from now on. Therefore, the `New Conference` link should not be visible for others.