### PR TITLE
Correct past and upcoming conferences count in admin/organizations#index

### DIFF
--- a/app/models/conference.rb
+++ b/app/models/conference.rb
@@ -7,6 +7,8 @@ class Conference < ActiveRecord::Base
   resourcify :roles, dependent: :delete_all
 
   default_scope { order('start_date DESC') }
+  scope :upcoming, (-> { where('end_date >= ?', Date.current) })
+  scope :past, (-> { where('end_date < ?', Date.current) })
 
   belongs_to :organization
 

--- a/app/views/admin/organizations/index.html.haml
+++ b/app/views/admin/organizations/index.html.haml
@@ -20,9 +20,9 @@
             %td
               = organization.name
             %td
-              = organization.conferences.count
+              = organization.conferences.upcoming.count
             %td
-              = organization.conferences.count
+              = organization.conferences.past.count
             %td
               .btn-group
                 = link_to 'Edit', edit_admin_organization_path(organization),

--- a/spec/models/conference_spec.rb
+++ b/spec/models/conference_spec.rb
@@ -1687,4 +1687,21 @@ describe Conference do
       expect{ room.save }.to change { subject.revision }.by(1)
     end
   end
+
+  describe '.upcoming' do
+    let!(:upcoming_conference) { create(:conference) }
+    let!(:past_conference) { create(:conference, start_date: Date.current - 1.days, end_date: Date.current - 1.days) }
+    subject { Conference.upcoming }
+
+    it { is_expected.to eq [upcoming_conference] }
+  end
+
+  describe '.past' do
+    let!(:upcoming_conference) { create(:conference) }
+    let!(:past_conference1) { create(:conference, start_date: Date.current - 1.days, end_date: Date.current - 1.days) }
+    let!(:past_conference2) { create(:conference, start_date: Date.current - 2.days, end_date: Date.current - 1.days) }
+    subject { Conference.past }
+
+    it { is_expected.to eq [past_conference1, past_conference2] }
+  end
 end


### PR DESCRIPTION
Display correct past and upcoming conferences count in `organizations@index` : 

![screenshot_20170608_043224](https://user-images.githubusercontent.com/14155445/28044658-4c376aea-65f6-11e7-8c2f-20f00f95e508.png)
