### PR TITLE
Show conference changelog ( rebased #1530 )

### DIFF
--- a/app/helpers/application_helper.rb
+++ b/app/helpers/application_helper.rb
@@ -98,25 +98,6 @@ module ApplicationHelper
       .reverse.sub(',', ' dna ').reverse
   end
 
-  # Recieves a model_name and id
-  # Returns nil if model_name is invalid
-  # Returns object in its current state if its alive
-  # Otherwise Returns object state just before deletion
-  def current_or_last_object_state(model_name, id)
-    return nil unless id.present? && model_name.present?
-    begin
-      object = model_name.constantize.find_by(id: id)
-    rescue NameError
-      return nil
-    end
-
-    if object.nil?
-      object_last_version = PaperTrail::Version.where(item_type: model_name, item_id: id).last
-      object = object_last_version.reify if object_last_version
-    end
-    object
-  end
-
   def normalize_array_length(hashmap, length)
     hashmap.each do |_, value|
       if value.length < length

--- a/app/helpers/paths_helper.rb
+++ b/app/helpers/paths_helper.rb
@@ -2,14 +2,6 @@ module PathsHelper
   ##
   # Includes functions related to links or redirects
   ##
-  def link_to_user(user_id)
-    user = User.find_by(id: user_id)
-    if user
-      link_to user.name, admin_user_path(id: user_id)
-    else
-      'Someone (probably via the console)'
-    end
-  end
 
   def active_nav_li(link)
     if current_page?(link)

--- a/app/models/admin_ability.rb
+++ b/app/models/admin_ability.rb
@@ -208,7 +208,7 @@ class AdminAbility
     end
 
     can [:index, :revert_object, :revert_attribute], PaperTrail::Version,
-        item_type: %w(Event EventType Track DifficultyLevel EmailSettings Room Cfp Program Comment), conference_id: conf_ids_for_cfp
+        item_type: %w[Event EventType Track DifficultyLevel EmailSettings Room Cfp Program Comment], conference_id: conf_ids_for_cfp
     can [:index, :revert_object, :revert_attribute], PaperTrail::Version,
         ["item_type = 'Commercial' AND conference_id IN (?) AND (object LIKE '%Event%' OR object_changes LIKE '%Event%')", conf_ids_for_cfp] do |version|
       version.item_type == 'Commercial' && conf_ids_for_cfp.include?(version.conference_id) &&

--- a/app/models/admin_ability.rb
+++ b/app/models/admin_ability.rb
@@ -167,9 +167,8 @@ class AdminAbility
         role.resource_type == 'Track' && (track_ids.include? role.resource_id)
     end
 
-    can [:index, :revert_object, :revert_attribute], PaperTrail::Version do |version|
-      version.item_type == 'User' || (conf_ids.include? version.conference_id)
-    end
+    can [:index, :revert_object, :revert_attribute], PaperTrail::Version, item_type: 'User'
+    can [:index, :revert_object, :revert_attribute], PaperTrail::Version, conference_id: conf_ids
   end
 
   def signed_in_with_cfp_role(user)
@@ -208,9 +207,10 @@ class AdminAbility
         (Conference.with_role(:cfp, user).pluck(:id).include? role.resource_id)
     end
 
-    can [:index, :revert_object, :revert_attribute], PaperTrail::Version, item_type: 'Event', conference_id: conf_ids_for_cfp
-    can [:index, :revert_object, :revert_attribute], PaperTrail::Version, item_type: 'Vote', conference_id: conf_ids_for_cfp
-    can [:index, :revert_object, :revert_attribute], PaperTrail::Version do |version|
+    can [:index, :revert_object, :revert_attribute], PaperTrail::Version,
+        item_type: %w(Event EventType Track DifficultyLevel EmailSettings Room Cfp Program Comment), conference_id: conf_ids_for_cfp
+    can [:index, :revert_object, :revert_attribute], PaperTrail::Version,
+        ["item_type = 'Commercial' AND conference_id IN (?) AND (object LIKE '%Event%' OR object_changes LIKE '%Event%')", conf_ids_for_cfp] do |version|
       version.item_type == 'Commercial' && conf_ids_for_cfp.include?(version.conference_id) &&
         (version.object.to_s.include?('Event') || version.object_changes.to_s.include?('Event'))
     end
@@ -244,6 +244,7 @@ class AdminAbility
       role.resource_type == 'Conference' && role.name == 'info_desk' &&
         (Conference.with_role(:info_desk, user).pluck(:id).include? role.resource_id)
     end
+    can [:index, :revert_object, :revert_attribute], PaperTrail::Version, item_type: 'Registration', conference_id: conf_ids_for_info_desk
   end
 
   def signed_in_with_volunteers_coordinator_role(user)

--- a/app/models/conference.rb
+++ b/app/models/conference.rb
@@ -760,6 +760,10 @@ class Conference < ActiveRecord::Base
     self
   end
 
+  def to_param
+    short_title
+  end
+
   private
 
   # Returns a different html colour for every i and consecutive colors are

--- a/app/models/organization.rb
+++ b/app/models/organization.rb
@@ -1,6 +1,8 @@
 class Organization < ActiveRecord::Base
   resourcify :roles, dependent: :delete_all
 
+  has_paper_trail
+
   has_many :conferences, dependent: :destroy
 
   after_create :create_roles

--- a/app/views/admin/versions/_object_desc_and_link.html.haml
+++ b/app/views/admin/versions/_object_desc_and_link.html.haml
@@ -1,84 +1,92 @@
+- conference = Conference.find_by(id: version.conference_id)
+- conference_short_title = conference.try(:short_title) || current_or_last_object_state(version.item_type, version.item_id).try(:conference).try(:short_title) || ''
+
 - case version.item_type
 - when 'UsersRole'
   - users_role = current_or_last_object_state(version.item_type, version.item_id)
-  - user = current_or_last_object_state('User', users_role.user_id)
   = 'role'
-  = link_to users_role.role.name, admin_conference_role_path(conference_id: Conference.find(version.conference_id).short_title, id: users_role.role.name)
+  = link_to users_role.role.name, admin_conference_role_path(conference.short_title, users_role.role.name)
   = version.event == 'create' ? 'to' : 'from'
   = 'user'
-
-  = link_to (user.try(:name) || 'deleted user'), admin_user_path(id: users_role.user.id)
+  = link_to_user(users_role.user_id)
 
 - when 'Subscription', 'Registration'
   = 'conference'
-  = link_to Conference.find(version.conference_id).title,
-          admin_conference_registrations_path(conference_id: Conference.find(version.conference_id).short_title)
+  = link_to_conference(version.conference_id)
 
 - when 'Commercial'
   - commercial = current_or_last_object_state(version.item_type, version.item_id)
   - commercialable = current_or_last_object_state(commercial.commercialable_type, commercial.commercialable_id)
-  - commercialable_last_version = PaperTrail::Version.where(item_type: commercial.commercialable_type, item_id: commercial.commercialable_id).last
 
   - case commercial.commercialable_type
   - when 'Event'
-    commercial in
-    - if commercialable_last_version.item
-      event
+    = 'commercial in event'
+    - if commercialable && conference
       =  link_to commercialable.title,
-             admin_conference_program_event_path(conference_id: Conference.find(version.conference_id).short_title, id: commercialable.id)
+             admin_conference_program_event_path(conference_id: conference.short_title,
+                                                 id: commercialable.id)
     - else
       = commercialable.title
+      = "with ID #{commercialable.id}"
 
   - when 'Venue'
-    commercial in venue
-    - if commercialable_last_version.item
+    = 'commercial in venue'
+    - if commercialable && conference
       = link_to commercialable.name,
-            edit_admin_conference_venue_path(conference_id: Conference.find(version.conference_id).short_title,
-                                                id: commercialable.id, anchor: 'commercials-content')
+            edit_admin_conference_venue_path(conference_id: conference_short_title,
+                                             id: commercialable.id, anchor: 'commercials-content')
     - else
       = commercialable.name
+      = "with ID #{commercialable.id}"
 
   - when 'Conference'
-    = link_to 'commercial',
-            admin_conference_commercials_path(conference_id: Conference.find(version.conference_id).short_title)
+    = 'commercial in conference'
+    - if commercialable
+      = link_to commercialable.short_title,
+              admin_conference_commercials_path(conference_id: commercialable.short_title)
+    - else
+      = commercialable.short_title
+      = "with ID #{commercialable.id}"
 
 - when 'EventsRegistration', 'Comment', 'Vote', 'Event'
   = 'event'
   - object = current_or_last_object_state(version.item_type, version.item_id)
   - event_id = object.try(:event_id) || object.try(:commentable_id) || object.id
   = link_to (current_or_last_object_state('Event', event_id).try(:title) || 'deleted event'),
-          admin_conference_program_event_path(conference_id: Conference.find(version.conference_id).short_title, id: event_id)
+          admin_conference_program_event_path(conference_id: conference_short_title, id: event_id)
 
 - when 'Target'
   = 'target'
   - target = current_or_last_object_state(version.item_type, version.item_id)
-  = link_if_alive version, target.to_s, admin_conference_targets_path(conference_id: Conference.find(version.conference_id).short_title)
+  = link_if_alive version, target.to_s, admin_conference_targets_path(conference_id: conference_short_title), conference
 
 - when 'EventSchedule'
   - event_schedule = current_or_last_object_state(version.item_type, version.item_id)
   event
-  = link_to (current_or_last_object_state('Event', event_schedule.event_id).try(:title) || 'deleted event'),
-           admin_conference_program_event_path(conference_id: Conference.find(version.conference_id).short_title, id: event_schedule.event_id)
+  = link_to (current_or_last_object_state('Event', event_schedule.event_id).try(:title) || 'deleted'),
+           admin_conference_program_event_path(conference_id: conference_short_title, id: event_schedule.event_id)
   in
   =  link_to "Schedule #{event_schedule.schedule_id}",
-            admin_conference_schedule_path(conference_id: Conference.find(version.conference_id).short_title, id: event_schedule.schedule_id)
+            admin_conference_schedule_path(conference_id: conference_short_title, id: event_schedule.schedule_id)
 
 - when 'Schedule'
   = link_if_alive version, "Schedule #{version.item_id}",
-            admin_conference_schedule_path(conference_id: Conference.find(version.conference_id).short_title, id: version.item_id)
+            admin_conference_schedule_path(conference_id: conference_short_title, id: version.item_id),
+            conference
 
 - when 'Conference'
   = 'conference'
-  = link_to Conference.find(version.conference_id).title,
-          edit_admin_conference_path(id: Conference.find(version.conference_id).short_title)
+  = link_to_conference(version.item_id)
 
 - when 'RegistrationPeriod'
   = link_if_alive version, 'registration period',
-          admin_conference_registration_period_path(conference_id: Conference.find(version.conference_id).short_title)
+          admin_conference_registration_period_path(conference_id: conference_short_title),
+          conference
 
 - when 'Contact'
   = link_if_alive version, 'contact details',
-          edit_admin_conference_contact_path(conference_id: Conference.find(version.conference_id).short_title)
+          edit_admin_conference_contact_path(conference_id: conference_short_title),
+          conference
 
 - when 'Booth'
   = 'booth'
@@ -88,94 +96,108 @@
 
 - when 'Program'
   = link_if_alive version, 'program',
-          admin_conference_program_path(conference_id: Conference.find(version.conference_id).short_title)
+          admin_conference_program_path(conference_id: conference_short_title),
+          conference
 
 - when 'Cfp'
   = 'cfp for'
   - cfp = current_or_last_object_state(version.item_type, version.item_id)
   = link_if_alive version, cfp.cfp_type,
-          admin_conference_program_cfp_path(conference_id: Conference.find(version.conference_id).short_title, id: version.item_id)
+          admin_conference_program_cfp_path(conference_id: conference_short_title, id: version.item_id),
+          conference
 
 - when 'Track'
   = 'track'
   - track = current_or_last_object_state(version.item_type, version.item_id)
   = link_if_alive version, track.name,
-          admin_conference_program_track_path(conference_id: Conference.find(version.conference_id).short_title, id: track.try(:short_name))
+          admin_conference_program_track_path(conference_id: conference_short_title, id: track.try(:short_name)),
+          conference
 
 - when 'EventType'
   = 'event type'
   - event_type = current_or_last_object_state(version.item_type, version.item_id)
   = link_if_alive version, event_type.title,
-          admin_conference_program_event_types_path(conference_id: Conference.find(version.conference_id).short_title)
+          admin_conference_program_event_types_path(conference_id: conference_short_title),
+          conference
 
 - when 'Role'
   = 'role'
   - role = current_or_last_object_state(version.item_type, version.item_id)
   = link_if_alive version, role.name,
-          admin_conference_role_path(conference_id: Conference.find(version.conference_id).short_title, id: role.name)
+          admin_conference_role_path(conference_id: conference_short_title, id: role.name),
+          conference
 
 - when 'Venue'
   = 'venue'
   - venue = current_or_last_object_state(version.item_type, version.item_id)
   = link_if_alive version, venue.name,
-          admin_conference_venue_path(conference_id: Conference.find(version.conference_id).short_title)
+          admin_conference_venue_path(conference_id: conference_short_title),
+          conference
 
 - when 'Lodging'
   = 'lodging'
   - lodging = current_or_last_object_state(version.item_type, version.item_id)
   = link_if_alive version, lodging.name,
-          admin_conference_lodgings_path(conference_id: Conference.find(version.conference_id).short_title)
+          admin_conference_lodgings_path(conference_id: conference_short_title),
+          conference
 
 - when 'Room'
   = 'room'
   - room = current_or_last_object_state(version.item_type, version.item_id)
   = link_if_alive version, room.name,
-          admin_conference_venue_rooms_path(conference_id: Conference.find(version.conference_id).short_title)
+          admin_conference_venue_rooms_path(conference_id: conference_short_title),
+          conference
 
 - when 'Sponsor'
   = 'sponsor'
   - sponsor = current_or_last_object_state(version.item_type, version.item_id)
   = link_if_alive version, sponsor.name,
-          admin_conference_sponsors_path(conference_id: Conference.find(version.conference_id).short_title)
+          admin_conference_sponsors_path(conference_id: conference_short_title),
+          conference
 
 - when 'SponsorshipLevel'
   = 'sponsorship level'
   - sponsorship_level = current_or_last_object_state(version.item_type, version.item_id)
   = link_if_alive version, sponsorship_level.title,
-          admin_conference_sponsorship_levels_path(conference_id: Conference.find(version.conference_id).short_title)
+          admin_conference_sponsorship_levels_path(conference_id: conference_short_title),
+          conference
 
 - when 'Ticket'
   = 'ticket'
   - ticket = current_or_last_object_state(version.item_type, version.item_id)
   = link_if_alive version, ticket.title,
-          admin_conference_ticket_path(conference_id: Conference.find(version.conference_id).short_title, id: version.item_id)
+          admin_conference_ticket_path(conference_id: conference_short_title, id: version.item_id),
+          conference
 
 - when 'Campaign'
   = 'campaign'
   - campaign = current_or_last_object_state(version.item_type, version.item_id)
   = link_if_alive version, campaign.name,
-          admin_conference_campaigns_path(conference_id: Conference.find(version.conference_id).short_title)
+          admin_conference_campaigns_path(conference_id: conference_short_title),
+          conference
 
 - when 'DifficultyLevel'
   = 'difficulty level'
   - difficulty_level = current_or_last_object_state(version.item_type, version.item_id)
   = link_if_alive version, difficulty_level.title,
-          admin_conference_program_difficulty_level_path(conference_id: Conference.find(version.conference_id).short_title, id: version.item_id)
+          admin_conference_program_difficulty_level_path(conference_id: conference_short_title, id: version.item_id),
+          conference
 
 - when 'Splashpage'
   = link_if_alive version, 'splashpage',
-          admin_conference_splashpage_path(conference_id: Conference.find(version.conference_id).short_title)
+          admin_conference_splashpage_path(conference_id: conference_short_title),
+          conference
 
 - when 'EmailSettings'
   = link_if_alive version, 'email settings',
-          admin_conference_emails_path(conference_id: Conference.find(version.conference_id).short_title)
+          admin_conference_emails_path(conference_id: conference_short_title),
+          conference
 
 - when 'User'
   - if version.event == 'update'
     = 'user'
-    = link_to (current_or_last_object_state('User', version.item_id).try(:name) || 'deleted user'), admin_user_path(id: version.item_id)
+    = link_to_user(version.item_id)
 
 - unless %w(Conference Subscription Registration User).include?(version.item_type)
-  = "in conference"
-  = link_to Conference.find(version.conference_id).short_title,
-          edit_admin_conference_path(id: Conference.find(version.conference_id).short_title)
+  = 'in conference'
+  = link_to_conference(version.conference_id)

--- a/app/views/admin/versions/_object_desc_and_link.html.haml
+++ b/app/views/admin/versions/_object_desc_and_link.html.haml
@@ -1,17 +1,32 @@
-- conference = Conference.find_by(id: version.conference_id)
-- conference_short_title = conference.try(:short_title) || current_or_last_object_state(version.item_type, version.item_id).try(:conference).try(:short_title) || ''
+- unless version.item_type == 'Role' || version.item_type == 'UsersRole'
+  - conference = Conference.find_by(id: version.conference_id)
+  - conference_short_title = conference.try(:short_title) || current_or_last_object_state('Conference', version.conference_id).try(:short_title) || ' '
 
 - case version.item_type
+- when 'Organization'
+  organization
+  = link_to_organization(version.item_id)
+
 - when 'UsersRole'
   - users_role = current_or_last_object_state(version.item_type, version.item_id)
-  = 'role'
-  = link_to users_role.role.name, admin_conference_role_path(conference.short_title, users_role.role.name)
+  - role = Role.find_by(id: users_role.role_id) if users_role
+  role
+  - if role.name == 'organization_admin'
+    -# organization_admin belongs to organization and not conferences
+    - organization = Organization.find(version.conference_id)
+    = link_if_alive version, role.name,
+            admins_admin_organization_path(organization), organization
+  - else
+    - conference = Conference.find_by(id: version.conference_id)
+    - conference_short_title = conference.try(:short_title) || current_or_last_object_state('Conference', version.conference_id).try(:short_title) || ' '
+    = link_if_alive version, role.try(:name), admin_conference_role_path(role.try(:name) || ' ', conference_short_title), conference
+
   = version.event == 'create' ? 'to' : 'from'
-  = 'user'
+  user
   = link_to_user(users_role.user_id)
 
 - when 'Subscription', 'Registration'
-  = 'conference'
+  conference
   = link_to_conference(version.conference_id)
 
 - when 'Commercial'
@@ -20,72 +35,71 @@
 
   - case commercial.commercialable_type
   - when 'Event'
-    = 'commercial in event'
+    commercial in event
     - if commercialable && conference
       =  link_to commercialable.title,
-             admin_conference_program_event_path(conference_id: conference.short_title,
-                                                 id: commercialable.id)
+             admin_conference_program_event_path(conference, commercialable.id)
     - else
       = commercialable.title
       = "with ID #{commercialable.id}"
 
   - when 'Venue'
-    = 'commercial in venue'
+    commercial in venue
     - if commercialable && conference
       = link_to commercialable.name,
-            edit_admin_conference_venue_path(conference_id: conference_short_title,
-                                             id: commercialable.id, anchor: 'commercials-content')
+            edit_admin_conference_venue_path(conference_short_title,
+                                             commercialable.id, anchor: 'commercials-content')
     - else
       = commercialable.name
       = "with ID #{commercialable.id}"
 
   - when 'Conference'
-    = 'commercial in conference'
+    commercial in conference
     - if commercialable
       = link_to commercialable.short_title,
-              admin_conference_commercials_path(conference_id: commercialable.short_title)
+              admin_conference_commercials_path(commercialable.short_title)
     - else
       = commercialable.short_title
       = "with ID #{commercialable.id}"
 
 - when 'EventsRegistration', 'Comment', 'Vote', 'Event'
-  = 'event'
+  event
   - object = current_or_last_object_state(version.item_type, version.item_id)
   - event_id = object.try(:event_id) || object.try(:commentable_id) || object.id
   = link_to (current_or_last_object_state('Event', event_id).try(:title) || 'deleted event'),
-          admin_conference_program_event_path(conference_id: conference_short_title, id: event_id)
+          admin_conference_program_event_path(conference_short_title, event_id)
 
 - when 'Target'
-  = 'target'
+  target
   - target = current_or_last_object_state(version.item_type, version.item_id)
-  = link_if_alive version, target.to_s, admin_conference_targets_path(conference_id: conference_short_title), conference
+  = link_if_alive version, target.to_s, admin_conference_targets_path(conference_short_title), conference
 
 - when 'EventSchedule'
   - event_schedule = current_or_last_object_state(version.item_type, version.item_id)
   event
   = link_to (current_or_last_object_state('Event', event_schedule.event_id).try(:title) || 'deleted'),
-           admin_conference_program_event_path(conference_id: conference_short_title, id: event_schedule.event_id)
+           admin_conference_program_event_path(conference_short_title, event_schedule.event_id)
   in
   =  link_to "Schedule #{event_schedule.schedule_id}",
-            admin_conference_schedule_path(conference_id: conference_short_title, id: event_schedule.schedule_id)
+            admin_conference_schedule_path(conference_short_title, event_schedule.schedule_id)
 
 - when 'Schedule'
   = link_if_alive version, "Schedule #{version.item_id}",
-            admin_conference_schedule_path(conference_id: conference_short_title, id: version.item_id),
+            admin_conference_schedule_path(conference_short_title, version.item_id),
             conference
 
 - when 'Conference'
-  = 'conference'
+  conference
   = link_to_conference(version.item_id)
 
 - when 'RegistrationPeriod'
   = link_if_alive version, 'registration period',
-          admin_conference_registration_period_path(conference_id: conference_short_title),
+          admin_conference_registration_period_path(conference_short_title),
           conference
 
 - when 'Contact'
   = link_if_alive version, 'contact details',
-          edit_admin_conference_contact_path(conference_id: conference_short_title),
+          edit_admin_conference_contact_path(conference_short_title),
           conference
 
 - when 'Booth'
@@ -96,108 +110,120 @@
 
 - when 'Program'
   = link_if_alive version, 'program',
-          admin_conference_program_path(conference_id: conference_short_title),
+          admin_conference_program_path(conference_short_title),
           conference
 
 - when 'Cfp'
-  = 'cfp for'
+  cfp for
   - cfp = current_or_last_object_state(version.item_type, version.item_id)
   = link_if_alive version, cfp.cfp_type,
-          admin_conference_program_cfp_path(conference_id: conference_short_title, id: version.item_id),
+          admin_conference_program_cfp_path(conference_short_title, version.item_id),
           conference
 
 - when 'Track'
-  = 'track'
+  track
   - track = current_or_last_object_state(version.item_type, version.item_id)
   = link_if_alive version, track.name,
-          admin_conference_program_track_path(conference_id: conference_short_title, id: track.try(:short_name)),
+          admin_conference_program_track_path(conference_short_title, track.try(:short_name)),
           conference
 
 - when 'EventType'
-  = 'event type'
+  event type
   - event_type = current_or_last_object_state(version.item_type, version.item_id)
   = link_if_alive version, event_type.title,
-          admin_conference_program_event_types_path(conference_id: conference_short_title),
+          admin_conference_program_event_types_path(conference_short_title),
           conference
 
 - when 'Role'
-  = 'role'
+  role
   - role = current_or_last_object_state(version.item_type, version.item_id)
-  = link_if_alive version, role.name,
-          admin_conference_role_path(conference_id: conference_short_title, id: role.name),
-          conference
+  - role_name = role.try(:name) || PaperTrail::Version.where(item_type: 'Role', item_id: version.item_id).last.changeset[:name].second
+  - if role_name == 'organization_admin'
+    -# organization_admin belongs to organization and not conferences
+    - organization = Organization.find(version.conference_id)
+    = link_if_alive version, role_name,
+            admins_admin_organization_path(organization), organization
+  - else
+    - conference = Conference.find_by(id: version.conference_id)
+    - conference_short_title = conference.try(:short_title) || current_or_last_object_state('Conference', version.conference_id).try(:short_title) || ' '
+    = link_if_alive version, role_name,
+            admin_conference_role_path(conference_short_title, role_name), conference
 
 - when 'Venue'
-  = 'venue'
+  venue
   - venue = current_or_last_object_state(version.item_type, version.item_id)
   = link_if_alive version, venue.name,
-          admin_conference_venue_path(conference_id: conference_short_title),
+          admin_conference_venue_path(conference_short_title),
           conference
 
 - when 'Lodging'
-  = 'lodging'
+  lodging
   - lodging = current_or_last_object_state(version.item_type, version.item_id)
   = link_if_alive version, lodging.name,
-          admin_conference_lodgings_path(conference_id: conference_short_title),
+          admin_conference_lodgings_path(conference_short_title),
           conference
 
 - when 'Room'
-  = 'room'
+  room
   - room = current_or_last_object_state(version.item_type, version.item_id)
   = link_if_alive version, room.name,
-          admin_conference_venue_rooms_path(conference_id: conference_short_title),
+          admin_conference_venue_rooms_path(conference_short_title),
           conference
 
 - when 'Sponsor'
-  = 'sponsor'
+  sponsor
   - sponsor = current_or_last_object_state(version.item_type, version.item_id)
   = link_if_alive version, sponsor.name,
-          admin_conference_sponsors_path(conference_id: conference_short_title),
+          admin_conference_sponsors_path(conference_short_title),
           conference
 
 - when 'SponsorshipLevel'
-  = 'sponsorship level'
+  sponsorship level
   - sponsorship_level = current_or_last_object_state(version.item_type, version.item_id)
   = link_if_alive version, sponsorship_level.title,
-          admin_conference_sponsorship_levels_path(conference_id: conference_short_title),
+          admin_conference_sponsorship_levels_path(conference_short_title),
           conference
 
 - when 'Ticket'
-  = 'ticket'
+  ticket
   - ticket = current_or_last_object_state(version.item_type, version.item_id)
   = link_if_alive version, ticket.title,
-          admin_conference_ticket_path(conference_id: conference_short_title, id: version.item_id),
+          admin_conference_ticket_path(conference_short_title, version.item_id),
           conference
 
 - when 'Campaign'
-  = 'campaign'
+  campaign
   - campaign = current_or_last_object_state(version.item_type, version.item_id)
   = link_if_alive version, campaign.name,
-          admin_conference_campaigns_path(conference_id: conference_short_title),
+          admin_conference_campaigns_path(conference_short_title),
           conference
 
 - when 'DifficultyLevel'
-  = 'difficulty level'
+  difficulty level
   - difficulty_level = current_or_last_object_state(version.item_type, version.item_id)
   = link_if_alive version, difficulty_level.title,
-          admin_conference_program_difficulty_level_path(conference_id: conference_short_title, id: version.item_id),
+          admin_conference_program_difficulty_level_path(conference_short_title, version.item_id),
           conference
 
 - when 'Splashpage'
   = link_if_alive version, 'splashpage',
-          admin_conference_splashpage_path(conference_id: conference_short_title),
+          admin_conference_splashpage_path(conference_short_title),
           conference
 
 - when 'EmailSettings'
   = link_if_alive version, 'email settings',
-          admin_conference_emails_path(conference_id: conference_short_title),
+          admin_conference_emails_path(conference_short_title),
           conference
 
 - when 'User'
   - if version.event == 'update'
-    = 'user'
+    user
     = link_to_user(version.item_id)
 
-- unless %w(Conference Subscription Registration User).include?(version.item_type)
-  = 'in conference'
-  = link_to_conference(version.conference_id)
+- unless %w(Conference Subscription Registration User Organization).include?(version.item_type)
+  - if (version.item_type == 'Role' && role_name == 'organization_admin') || (version.item_type == 'UsersRole' && role.name == 'organization_admin')
+    in organization
+    = link_to_organization(version.conference_id)
+  - else
+    in conference
+    = link_to_conference(version.conference_id)

--- a/app/views/admin/versions/index.html.haml
+++ b/app/views/admin/versions/index.html.haml
@@ -8,7 +8,7 @@
           %span.caret
         %ul.dropdown-menu
           %li= link_to 'All Conferences & Users',  admin_revision_history_path
-          - @conf_ids_with_role.each do |conference_short_title|
+          - @conferences_with_role.each do |conference_short_title|
             %li= link_to conference_short_title,  admin_conference_revision_history_path(conference_id: conference_short_title)
 
       %h1 Revision History

--- a/app/views/admin/versions/index.html.haml
+++ b/app/views/admin/versions/index.html.haml
@@ -1,6 +1,16 @@
 .row
   .col-md-12
     .page-header
+
+      .dropdown.pull-right
+        %button.btn.btn-success.dropdown-toggle{ 'data-toggle' => 'dropdown', type: 'button' }
+          = @conference.nil? ? 'All Conferences' : @conference.short_title
+          %span.caret
+        %ul.dropdown-menu
+          %li= link_to 'All Conferences & Users',  admin_revision_history_path
+          - @conf_ids_with_role.each do |conference_short_title|
+            %li= link_to conference_short_title,  admin_conference_revision_history_path(conference_id: conference_short_title)
+
       %h1 Revision History
       %p.text-muted
         Log of changes made to conferences and associated resources

--- a/app/views/layouts/_admin_sidebar.html.haml
+++ b/app/views/layouts/_admin_sidebar.html.haml
@@ -139,8 +139,15 @@
       = link_to(admin_conference_roles_path(@conference.short_title)) do
         %span.fa.fa-group
         Roles
+
   - if can? :index, @conference.resources.new
     %li
       = link_to admin_conference_resources_path(@conference.short_title) do
         %span.fa.fa-pencil-square
         Resources
+
+  - if can?(:index, PaperTrail::Version.new(conference_id: @conference.id, item_type: 'Event')) || can?(:index, PaperTrail::Version.new(conference_id: @conference.id, item_type: 'Registration'))
+    %li{:class=> active_nav_li(admin_conference_revision_history_path(@conference.short_title))}
+      = link_to(admin_conference_revision_history_path(@conference.short_title)) do
+        %span.fa.fa-history
+        Revision History

--- a/app/views/layouts/_admin_sidebar_index.html.haml
+++ b/app/views/layouts/_admin_sidebar_index.html.haml
@@ -27,7 +27,7 @@
       = link_to(admin_users_path) do
         %span.fa.fa-user
         Users
-  - if can? :index, PaperTrail::Version.new(item_type: 'User')
+  - if can? :index, PaperTrail::Version
     %li
       = link_to(admin_revision_history_path) do
         %span.fa.fa-history

--- a/app/views/layouts/_user_menu.html.haml
+++ b/app/views/layouts/_user_menu.html.haml
@@ -48,7 +48,7 @@
     = link_to(admin_users_path) do
       %span.fa.fa-user
       Users
-- if can? :index, PaperTrail::Version.new(item_type: 'User')
+- if can? :index, PaperTrail::Version
   %li
     = link_to(admin_revision_history_path) do
       %span.fa.fa-history

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -136,6 +136,8 @@ Osem::Application.routes.draw do
           patch :update_conference
         end
       end
+
+      get '/revision_history' => 'versions#index'
     end
 
     get '/revision_history' => 'versions#index'

--- a/lib/tasks/version.rake
+++ b/lib/tasks/version.rake
@@ -1,7 +1,7 @@
 namespace :data do
   desc 'Sets conference_id in all pre-existing PaperTrail::Version objects'
   task set_conference_in_versions: :environment do
-
+    ids_with_failure = []
     PaperTrail::Version.where(conference_id: nil, item_type: %w[Conference Event]).each do |version|
       # All pre-existing versions are either of Conference or Event
       if version.item_type == 'Conference'
@@ -9,13 +9,25 @@ namespace :data do
 
       elsif version.item_type == 'Event'
         event = (version.item || version.reify || version.next.reify)
-        if event.try(:program)
-          version.update_attributes(conference_id: event.program.conference_id)
-        else
-          puts "Setting conference_id value failed for PaperTrail::Version object with ID=#{version.id}"
-        end
+
+        conference_id = if event.try(:program)
+                          event.program.conference_id
+                        # Event had attribute conference_id before it was replaced with program_id
+                        elsif version.changeset[:conference_id]
+                          version.changeset[:conference_id].second
+                        elsif version.changeset[:program_id]
+                          version.changeset[:program_id].second
+                        elsif version.object && (object = YAML.safe_load(version.object))
+                          object['conference_id']
+                        else
+                          ids_with_failure << version.id
+                          puts "Setting conference_id value failed for PaperTrail::Version object with ID=#{version.id}"
+                          nil
+                        end
+        version.update_attributes(conference_id: conference_id)
       end
     end
     puts 'All done!'
+    puts "IDs with failures: #{ids_with_failure}" if ids_with_failure.any?
   end
 end

--- a/spec/controllers/admin/versions_controller_spec.rb
+++ b/spec/controllers/admin/versions_controller_spec.rb
@@ -4,6 +4,9 @@ describe Admin::VersionsController do
 
   let!(:conference) { create(:conference, short_title: 'exampletitle', description: 'Example Description') }
   let(:admin) { create(:admin) }
+  let(:role_organizer) { conference.roles.find_by(name: 'organizer') }
+  let(:role_cfp) { conference.roles.find_by(name: 'cfp') }
+  let(:role_info_desk) { conference.roles.find_by(name: 'info_desk') }
 
   with_versioning do
     describe 'GET #revert' do
@@ -99,11 +102,54 @@ describe Admin::VersionsController do
     end
 
     describe 'GET #index' do
-      it 'raises error if user is not an organizer of specified conference' do
+      it 'raises error if user is not of any role' do
         user = create(:user)
         sign_in user
         get :index, conference_id: conference.short_title
-        expect(flash[:alert]).to match('You are not authorized to access this area.')
+        expect(flash[:alert]).to match('You are not authorized to access this page.')
+      end
+
+      context 'with conference' do
+        before :each do
+          @user = create(:user)
+
+          conference.update_attributes(short_title: 'testtitle', description: 'Some random text')
+          @version_organizer = PaperTrail::Version.last
+          create(:cfp, program: conference.program)
+          @version_cfp = PaperTrail::Version.last
+          registration = create(:registration, conference: conference)
+          registration.update_attributes(attended: true)
+          @version_info_desk = PaperTrail::Version.last
+        end
+
+        it 'when user has role cfp' do
+          @user.roles = [role_cfp]
+          sign_in @user
+          get :index, conference_id: conference.short_title
+
+          expect(assigns(:versions).include?(@version_cfp)).to eq true
+          expect(assigns(:versions).include?(@version_organizer)).to eq false
+        end
+
+        it 'when user has role info_desk' do
+          @user.roles = [role_info_desk]
+          sign_in @user
+          get :index, conference_id: conference.short_title
+
+          expect(assigns(:versions).include?(@version_info_desk)).to eq true
+          expect(assigns(:versions).include?(@version_organizer)).to eq false
+          expect(assigns(:versions).include?(@version_cfp)).to eq false
+        end
+
+        it 'when user has role organizer' do
+          @user.roles = [role_organizer]
+          sign_in @user
+          get :index, conference_id: conference.short_title
+
+          expect(assigns(:versions).include?(@version_organizer)).to eq true
+          expect(assigns(:versions).include?(@version_cfp)).to eq true
+          expect(assigns(:versions).include?(@version_info_desk)).to eq true
+        end
       end
     end
   end

--- a/spec/controllers/admin/versions_controller_spec.rb
+++ b/spec/controllers/admin/versions_controller_spec.rb
@@ -97,5 +97,14 @@ describe Admin::VersionsController do
         expect(flash[:error]).to match('Revert failed. Attribute missing or invalid')
       end
     end
+
+    describe 'GET #index' do
+      it 'raises error if user is not an organizer of specified conference' do
+        user = create(:user)
+        sign_in user
+        get :index, conference_id: conference.short_title
+        expect(flash[:alert]).to match('You are not authorized to access this area.')
+      end
+    end
   end
 end

--- a/spec/features/cfp_ability_spec.rb
+++ b/spec/features/cfp_ability_spec.rb
@@ -298,7 +298,7 @@ feature 'Has correct abilities' do
       expect(current_path).to eq(root_path)
 
       visit admin_revision_history_path
-      expect(current_path).to eq(root_path)
+      expect(current_path).to eq(admin_revision_history_path)
     end
   end
 end

--- a/spec/features/info_desk_ability_spec.rb
+++ b/spec/features/info_desk_ability_spec.rb
@@ -160,7 +160,7 @@ feature 'Has correct abilities' do
       expect(current_path).to eq(edit_admin_conference_resource_path(conference.short_title, conference.resources.first))
 
       visit admin_revision_history_path
-      expect(current_path).to eq(root_path)
+      expect(current_path).to eq(admin_revision_history_path)
 
       visit admin_conference_path(conference.short_title)
       expect(current_path).to eq(admin_conference_path(conference.short_title))

--- a/spec/features/versions_spec.rb
+++ b/spec/features/versions_spec.rb
@@ -35,23 +35,25 @@ feature 'Version' do
   scenario 'display changes in cfp', feature: true, versioning: true, js: true do
     cfp = create(:cfp, program: conference.program)
     cfp.update_attributes(start_date: (Date.today + 1).strftime('%d/%m/%Y'), end_date: (Date.today + 3).strftime('%d/%m/%Y'))
+    cfp_id = cfp.id
     cfp.destroy
 
     visit admin_revision_history_path
-    expect(page).to have_text("Someone (probably via the console) created new cfp for events in conference #{conference.short_title}")
-    expect(page).to have_text("Someone (probably via the console) updated start date and end date of cfp for events in conference #{conference.short_title}")
-    expect(page).to have_text("Someone (probably via the console) deleted cfp for events in conference #{conference.short_title}")
+    expect(page).to have_text("Someone (probably via the console) created new cfp for events with ID #{cfp_id} in conference #{conference.short_title}")
+    expect(page).to have_text("Someone (probably via the console) updated start date and end date of cfp for events with ID #{cfp_id} in conference #{conference.short_title}")
+    expect(page).to have_text("Someone (probably via the console) deleted cfp for events with ID #{cfp_id} in conference #{conference.short_title}")
   end
 
   scenario 'display changes in registration_period', feature: true, versioning: true, js: true do
     registration_period = create(:registration_period, conference: conference)
     registration_period.update_attributes(start_date: (Date.today + 1).strftime('%d/%m/%Y'), end_date: (Date.today + 3).strftime('%d/%m/%Y'))
+    registration_period_id = registration_period.id
     registration_period.destroy
 
     visit admin_revision_history_path
-    expect(page).to have_text("Someone (probably via the console) created new registration period in conference #{conference.short_title}")
-    expect(page).to have_text("Someone (probably via the console) updated start date and end date of registration period in conference #{conference.short_title}")
-    expect(page).to have_text("Someone (probably via the console) deleted registration period in conference #{conference.short_title}")
+    expect(page).to have_text("Someone (probably via the console) created new registration period with ID #{registration_period_id} in conference #{conference.short_title}")
+    expect(page).to have_text("Someone (probably via the console) updated start date and end date of registration period with ID #{registration_period_id} in conference #{conference.short_title}")
+    expect(page).to have_text("Someone (probably via the console) deleted registration period with ID #{registration_period_id} in conference #{conference.short_title}")
   end
 
   scenario 'display changes in conference', feature: true, versioning: true, js: true do
@@ -61,32 +63,34 @@ feature 'Version' do
 
     visit admin_revision_history_path
     select '100', from: 'versionstable_length'
-    expect(page).to have_text('Someone (probably via the console) created new conference New Con')
+    expect(page).to have_text('Someone (probably via the console) created new conference NewCon')
     expect(page).to have_text('Someone (probably via the console) created new event type Talk in conference NewCon')
     expect(page).to have_text('Someone (probably via the console) created new event type Workshop in conference NewCon')
-    expect(page).to have_text('Someone (probably via the console) updated title and short title of conference New Con')
+    expect(page).to have_text('Someone (probably via the console) updated title and short title of conference NewCon')
   end
 
   scenario 'display changes in event_type', feature: true, versioning: true, js: true do
     event_type = create(:event_type, program: conference.program, name: 'Discussion')
     event_type.update_attributes(length: 90, maximum_abstract_length: 10000)
+    event_type_id = event_type.id
     event_type.destroy
 
     visit admin_revision_history_path
-    expect(page).to have_text("Someone (probably via the console) created new event type Discussion in conference #{conference.short_title}")
-    expect(page).to have_text("Someone (probably via the console) updated length and maximum abstract length of event type Discussion in conference #{conference.short_title}")
-    expect(page).to have_text("Someone (probably via the console) deleted event type Discussion in conference #{conference.short_title}")
+    expect(page).to have_text("Someone (probably via the console) created new event type Discussion with ID #{event_type_id} in conference #{conference.short_title}")
+    expect(page).to have_text("Someone (probably via the console) updated length and maximum abstract length of event type Discussion with ID #{event_type_id} in conference #{conference.short_title}")
+    expect(page).to have_text("Someone (probably via the console) deleted event type Discussion with ID #{event_type_id} in conference #{conference.short_title}")
   end
 
   scenario 'display changes in lodging', feature: true, versioning: true, js: true do
     lodging = create(:lodging, conference: conference, name: 'Hotel XYZ')
     lodging.update_attributes(description: 'Nice view,close to venue', website_link: 'http://www.example.com')
+    lodging_id = lodging.id
     lodging.destroy
 
     visit admin_revision_history_path
-    expect(page).to have_text("Someone (probably via the console) created new lodging Hotel XYZ in conference #{conference.short_title}")
-    expect(page).to have_text("Someone (probably via the console) updated description and website link of lodging Hotel XYZ in conference #{conference.short_title}")
-    expect(page).to have_text("Someone (probably via the console) deleted lodging Hotel XYZ in conference #{conference.short_title}")
+    expect(page).to have_text("Someone (probably via the console) created new lodging Hotel XYZ with ID #{lodging_id} in conference #{conference.short_title}")
+    expect(page).to have_text("Someone (probably via the console) updated description and website link of lodging Hotel XYZ with ID #{lodging_id} in conference #{conference.short_title}")
+    expect(page).to have_text("Someone (probably via the console) deleted lodging Hotel XYZ with ID #{lodging_id} in conference #{conference.short_title}")
   end
 
   scenario 'display changes in role', feature: true, versioning: true, js: true do
@@ -102,12 +106,13 @@ feature 'Version' do
     venue = create(:venue, conference: conference)
     room = create(:room, venue: venue, name: 'Auditorium')
     room.update_attributes(size: 120)
+    room_id = room.id
     room.destroy
 
     visit admin_revision_history_path
-    expect(page).to have_text("Someone (probably via the console) created new room Auditorium in conference #{conference.short_title}")
-    expect(page).to have_text("Someone (probably via the console) updated size of room Auditorium in conference #{conference.short_title}")
-    expect(page).to have_text("Someone (probably via the console) deleted room Auditorium in conference #{conference.short_title}")
+    expect(page).to have_text("Someone (probably via the console) created new room Auditorium with ID #{room_id} in conference #{conference.short_title}")
+    expect(page).to have_text("Someone (probably via the console) updated size of room Auditorium with ID #{room_id} in conference #{conference.short_title}")
+    expect(page).to have_text("Someone (probably via the console) deleted room Auditorium with ID #{room_id} in conference #{conference.short_title}")
   end
 
   scenario 'display changes in sponsor', feature: true, versioning: true, js: true do
@@ -115,55 +120,60 @@ feature 'Version' do
     sponsor = create(:sponsor, conference: conference, name: 'SUSE', sponsorship_level: conference.sponsorship_levels.first)
     sponsor.update_attributes(website_url: 'https://www.suse.com/company/history', sponsorship_level: conference.sponsorship_levels.second)
     sponsor.destroy
+    sponsor_id = sponsor.id
 
     visit admin_revision_history_path
-    expect(page).to have_text("Someone (probably via the console) created new sponsor SUSE in conference #{conference.short_title}")
-    expect(page).to have_text("Someone (probably via the console) updated website url and sponsorship level of sponsor SUSE in conference #{conference.short_title}")
-    expect(page).to have_text("Someone (probably via the console) deleted sponsor SUSE in conference #{conference.short_title}")
+    expect(page).to have_text("Someone (probably via the console) created new sponsor SUSE with ID #{sponsor_id} in conference #{conference.short_title}")
+    expect(page).to have_text("Someone (probably via the console) updated website url and sponsorship level of sponsor SUSE with ID #{sponsor_id} in conference #{conference.short_title}")
+    expect(page).to have_text("Someone (probably via the console) deleted sponsor SUSE with ID #{sponsor_id} in conference #{conference.short_title}")
   end
 
   scenario 'display changes in sponsorship_level', feature: true, versioning: true, js: true do
     sponsorship_level = create(:sponsorship_level, conference: conference)
     sponsorship_level.update_attributes(title: 'Gold')
+    sponsorship_level_id = sponsorship_level.id
     sponsorship_level.destroy
 
     visit admin_revision_history_path
-    expect(page).to have_text("Someone (probably via the console) created new sponsorship level Gold in conference #{conference.short_title}")
-    expect(page).to have_text("Someone (probably via the console) updated title of sponsorship level Gold in conference #{conference.short_title}")
-    expect(page).to have_text("Someone (probably via the console) deleted sponsorship level Gold in conference #{conference.short_title}")
+    expect(page).to have_text("Someone (probably via the console) created new sponsorship level Gold with ID #{sponsorship_level_id} in conference #{conference.short_title}")
+    expect(page).to have_text("Someone (probably via the console) updated title of sponsorship level Gold with ID #{sponsorship_level_id} in conference #{conference.short_title}")
+    expect(page).to have_text("Someone (probably via the console) deleted sponsorship level Gold with ID #{sponsorship_level_id} in conference #{conference.short_title}")
   end
 
   scenario 'display changes in ticket', feature: true, versioning: true, js: true do
     ticket = create(:ticket, conference: conference, title: 'Gold')
     ticket.update_attributes(price: 50, description: 'Premium Ticket')
+    ticket_id = ticket.id
     ticket.destroy
 
     visit admin_revision_history_path
-    expect(page).to have_text("Someone (probably via the console) created new ticket Gold in conference #{conference.short_title}")
-    expect(page).to have_text("Someone (probably via the console) updated price cents and description of ticket Gold in conference #{conference.short_title}")
-    expect(page).to have_text("Someone (probably via the console) deleted ticket Gold in conference #{conference.short_title}")
+    expect(page).to have_text("Someone (probably via the console) created new ticket Gold with ID #{ticket_id} in conference #{conference.short_title}")
+    expect(page).to have_text("Someone (probably via the console) updated price cents and description of ticket Gold with ID #{ticket_id} in conference #{conference.short_title}")
+    expect(page).to have_text("Someone (probably via the console) deleted ticket Gold with ID #{ticket_id} in conference #{conference.short_title}")
   end
 
   scenario 'display changes in track', feature: true, versioning: true, js: true do
     track = create(:track, program: conference.program, name: 'Distribution')
     track.update_attributes(description: 'Events about Linux distributions')
+    track_id = track.id
     track.destroy
 
     visit admin_revision_history_path
-    expect(page).to have_text("Someone (probably via the console) created new track Distribution in conference #{conference.short_title}")
-    expect(page).to have_text("Someone (probably via the console) updated description of track Distribution in conference #{conference.short_title}")
-    expect(page).to have_text("Someone (probably via the console) deleted track Distribution in conference #{conference.short_title}")
+    expect(page).to have_text("Someone (probably via the console) created new track Distribution with ID #{track_id} in conference #{conference.short_title}")
+    expect(page).to have_text("Someone (probably via the console) updated description of track Distribution with ID #{track_id} in conference #{conference.short_title}")
+    expect(page).to have_text("Someone (probably via the console) deleted track Distribution with ID #{track_id} in conference #{conference.short_title}")
   end
 
   scenario 'display changes in venue', feature: true, versioning: true, js: true do
     venue = create(:venue, conference: conference, name: 'Example University')
     venue.update_attributes(website: 'www.example.com new', description: 'Just another beautiful venue')
+    venue_id = venue.id
     venue.destroy
 
     visit admin_revision_history_path
-    expect(page).to have_text("Someone (probably via the console) created new venue Example University in conference #{conference.short_title}")
-    expect(page).to have_text("Someone (probably via the console) updated website and description of venue Example University in conference #{conference.short_title}")
-    expect(page).to have_text("Someone (probably via the console) deleted venue Example University in conference #{conference.short_title}")
+    expect(page).to have_text("Someone (probably via the console) created new venue Example University with ID #{venue_id} in conference #{conference.short_title}")
+    expect(page).to have_text("Someone (probably via the console) updated website and description of venue Example University with ID #{venue_id} in conference #{conference.short_title}")
+    expect(page).to have_text("Someone (probably via the console) deleted venue Example University with ID #{venue_id} in conference #{conference.short_title}")
   end
 
   scenario 'display changes in event', feature: true, versioning: true, js: true do
@@ -209,12 +219,13 @@ feature 'Version' do
   scenario 'display changes in difficulty levels', feature: true, versioning: true, js: true do
     difficulty_level = create(:difficulty_level, program: conference.program, title: 'Expert')
     difficulty_level.update_attributes(description: 'Only for Experts')
+    difficulty_level_id = difficulty_level.id
     difficulty_level.destroy
 
     visit admin_revision_history_path
-    expect(page).to have_text("Someone (probably via the console) created new difficulty level Expert in conference #{conference.short_title}")
-    expect(page).to have_text("Someone (probably via the console) updated description of difficulty level Expert in conference #{conference.short_title}")
-    expect(page).to have_text("Someone (probably via the console) deleted difficulty level Expert in conference #{conference.short_title}")
+    expect(page).to have_text("Someone (probably via the console) created new difficulty level Expert with ID #{difficulty_level_id} in conference #{conference.short_title}")
+    expect(page).to have_text("Someone (probably via the console) updated description of difficulty level Expert with ID #{difficulty_level_id} in conference #{conference.short_title}")
+    expect(page).to have_text("Someone (probably via the console) deleted difficulty level Expert with ID #{difficulty_level_id} in conference #{conference.short_title}")
   end
 
   scenario 'display changes in splashpages', feature: true, versioning: true, js: true do
@@ -232,13 +243,14 @@ feature 'Version' do
     uncheck('Display social media')
     check('Make splash page public?')
     click_button 'Save Splashpage'
+    splashpage_id = conference.splashpage.id
 
     click_link 'Delete'
     visit admin_revision_history_path
-    expect(page).to have_text("#{organizer.name} created new splashpage in conference #{conference.short_title}")
+    expect(page).to have_text("#{organizer.name} created new splashpage with ID #{splashpage_id} in conference #{conference.short_title}")
     expect(page).to have_text("#{organizer.name} updated public, include program, include cfp, include venue, include tickets, include lodgings,
-      include sponsors and include social media of splashpage in conference #{conference.short_title}")
-    expect(page).to have_text("#{organizer.name} deleted splashpage in conference #{conference.short_title}")
+      include sponsors and include social media of splashpage with ID #{splashpage_id} in conference #{conference.short_title}")
+    expect(page).to have_text("#{organizer.name} deleted splashpage with ID #{splashpage_id} in conference #{conference.short_title}")
   end
 
   scenario 'displays users subscribe/unsubscribe to conferences', feature: true, versioning: true, js: true do
@@ -249,10 +261,10 @@ feature 'Version' do
     PaperTrail::Version.last.item.destroy!
 
     visit admin_revision_history_path
-    expect(page).to have_text("#{organizer.name} subscribed to conference #{conference.title}")
-    expect(page).to have_text("#{organizer.name} unsubscribed from conference #{conference.title}")
-    expect(page).to have_text("Someone (probably via the console) subscribed #{organizer.name} to conference #{conference.title}")
-    expect(page).to have_text("Someone (probably via the console) unsubscribed #{organizer.name} from conference #{conference.title}")
+    expect(page).to have_text("#{organizer.name} subscribed to conference #{conference.short_title}")
+    expect(page).to have_text("#{organizer.name} unsubscribed from conference #{conference.short_title}")
+    expect(page).to have_text("Someone (probably via the console) subscribed #{organizer.name} to conference #{conference.short_title}")
+    expect(page).to have_text("Someone (probably via the console) unsubscribed #{organizer.name} from conference #{conference.short_title}")
   end
 
   scenario 'display changes in conference commercials', feature: true, versioning: true, js: true do
@@ -312,8 +324,8 @@ feature 'Version' do
     Registration.last.destroy
 
     visit admin_revision_history_path
-    expect(page).to have_text("Someone (probably via the console) registered #{organizer.name} to conference #{conference.title}")
-    expect(page).to have_text("Someone (probably via the console) unregistered #{organizer.name} from conference #{conference.title}")
+    expect(page).to have_text("Someone (probably via the console) registered #{organizer.name} to conference #{conference.short_title}")
+    expect(page).to have_text("Someone (probably via the console) unregistered #{organizer.name} from conference #{conference.short_title}")
   end
 
   scenario 'display changes in event registration', feature: true, versioning: true, js: true do
@@ -335,12 +347,13 @@ feature 'Version' do
   scenario 'display changes in target', feature: true, versioning: true, js: true do
     target = create(:target, conference: conference)
     target.update_attributes(due_date: Date.today, target_count: 1000)
+    target_id = target.id
     target.destroy
 
     visit admin_revision_history_path
-    expect(page).to have_text("Someone (probably via the console) created new target 1000 Submissions by #{Date.today} in conference #{conference.short_title}")
-    expect(page).to have_text("Someone (probably via the console) updated due date and target count of target 1000 Submissions by #{Date.today} in conference #{conference.short_title}")
-    expect(page).to have_text("Someone (probably via the console) deleted target 1000 Submissions by #{Date.today} in conference #{conference.short_title}")
+    expect(page).to have_text("Someone (probably via the console) created new target 1000 Submissions by #{Date.today} with ID #{target_id} in conference #{conference.short_title}")
+    expect(page).to have_text("Someone (probably via the console) updated due date and target count of target 1000 Submissions by #{Date.today} with ID #{target_id} in conference #{conference.short_title}")
+    expect(page).to have_text("Someone (probably via the console) deleted target 1000 Submissions by #{Date.today} with ID #{target_id} in conference #{conference.short_title}")
   end
 
   scenario 'display changes in comment', feature: true, versioning: true, js: true do
@@ -376,12 +389,13 @@ feature 'Version' do
   scenario 'display changes in campaign', feature: true, versioning: true, js: true do
     campaign = create(:campaign, conference: conference, name: 'Test Campaign', utm_campaign: 'campaign')
     campaign.update_attributes(utm_source: 'source', utm_medium: 'medium', utm_term: 'term', utm_content: 'content')
+    campaign_id = campaign.id
     campaign.destroy
 
     visit admin_revision_history_path
-    expect(page).to have_text("Someone (probably via the console) created new campaign Test Campaign in conference #{conference.short_title}")
-    expect(page).to have_text("Someone (probably via the console) updated utm source, utm medium, utm term and utm content of campaign Test Campaign in conference #{conference.short_title}")
-    expect(page).to have_text("Someone (probably via the console) deleted campaign Test Campaign in conference #{conference.short_title}")
+    expect(page).to have_text("Someone (probably via the console) created new campaign Test Campaign with ID #{campaign_id} in conference #{conference.short_title}")
+    expect(page).to have_text("Someone (probably via the console) updated utm source, utm medium, utm term and utm content of campaign Test Campaign with ID #{campaign_id} in conference #{conference.short_title}")
+    expect(page).to have_text("Someone (probably via the console) deleted campaign Test Campaign with ID #{campaign_id} in conference #{conference.short_title}")
   end
 
   scenario 'display password reset requests', feature: true, versioning: true, js: true do


### PR DESCRIPTION
As described in #1530 :
>This comes from #1124, it is rebased, and has some fixes.
>
>* Use load_and_authorize_resource in versions controller
>* Add conference specific route to revision history page
>* Users with role can view revision_history only for the versions they have access to
>* Handle versions where conference_id is not set (records before papertrail was introduced)

Changes covered in [`fa86267`](https://github.com/openSUSE/osem/pull/1587/commits/fa86267802eec75b1762251335517d1fcf99760d) :
* Added revision history for organizations
* Added revision history for `organization admins` role
* Added revision history for users with role organization_admin