### PR TITLE
Fix user already subscribed exception

### DIFF
--- a/app/controllers/subscriptions_controller.rb
+++ b/app/controllers/subscriptions_controller.rb
@@ -5,17 +5,19 @@ class SubscriptionsController < ApplicationController
 
   def create
     @subscription = current_user.subscriptions.build(conference_id: @conference.id)
-    if @subscription.save!
-      redirect_to root_path, notice: "You have been subscribed to receive email notifications for #{@conference.short_title}."
+    if @subscription.save
+      redirect_to root_path, notice: "You have subscribed to receive email notifications for #{@conference.title}."
     else
-      redirect_to root_path, error: subscription.errors.full_messages.to_sentence
+      redirect_to root_path, error: @subscription.errors.full_messages.to_sentence
     end
   end
 
   def destroy
     @subscription = current_user.subscriptions.find_by(conference_id: @conference.id)
+
+    redirect_to(root_path, error: "You are not subscribed to #{@conference.title}.") && return unless @subscription
     if @subscription.destroy
-      redirect_to root_path, notice: "You have been unsubscribed and now you will not be receiving email notifications for #{@conference.short_title}."
+      redirect_to root_path, notice: "You have unsubscribed and you will not be receiving email notifications for #{@conference.title}."
     else
       redirect_to root_path, error: @subscription.errors.full_messages.to_sentence
     end

--- a/app/models/subscription.rb
+++ b/app/models/subscription.rb
@@ -1,5 +1,4 @@
 class Subscription < ActiveRecord::Base
-  validates :user_id, uniqueness: { scope: [:conference_id] }
   belongs_to :conference
   belongs_to :user
 

--- a/spec/controllers/subscriptions_controller_spec.rb
+++ b/spec/controllers/subscriptions_controller_spec.rb
@@ -24,7 +24,7 @@ describe SubscriptionsController do
 
       it 'shows success message in flash notice' do
         post :create, conference_id: conference.short_title
-        expect(flash[:notice]).to match("You have been subscribed to receive email notifications for #{conference.short_title}")
+        expect(flash[:notice]).to match("You have subscribed to receive email notifications for #{conference.title}")
       end
 
       it 'subscribes user to conference' do
@@ -47,7 +47,7 @@ describe SubscriptionsController do
 
     it 'shows success message in flash notice' do
       delete :destroy, conference_id: conference.short_title
-        expect(flash[:notice]).to match("You have been unsubscribed and now you will not be receiving email notifications for #{conference.short_title}.")
+        expect(flash[:notice]).to match("You have unsubscribed and you will not be receiving email notifications for #{conference.title}.")
     end
   end
 end


### PR DESCRIPTION
Rescue exception that is produced when user tries to subscribe in a conference that has already been subscribed to it.

Fixes #1589