### PR TITLE
Track request acceptance and activation

### DIFF
--- a/.haml-lint_todo.yml
+++ b/.haml-lint_todo.yml
@@ -182,6 +182,7 @@ linters:
       - "app/views/tracks/show.html.haml"
       - "app/views/conferences/_call_for_tracks.html.haml"
       - "app/views/admin/tracks/_change_state_dropdown.html.haml"
+      - "app/views/proposals/_encouragement_text.html.haml"
 
   # Offense count: 223
   InstanceVariables:

--- a/.haml-lint_todo.yml
+++ b/.haml-lint_todo.yml
@@ -180,6 +180,7 @@ linters:
       - "app/views/tracks/_form.html.haml"
       - "app/views/tracks/index.html.haml"
       - "app/views/tracks/show.html.haml"
+      - "app/views/conferences/_call_for_tracks.html.haml"
 
   # Offense count: 223
   InstanceVariables:
@@ -242,6 +243,8 @@ linters:
       - "app/views/schedules/_schedule_tabs.html.haml"
       - "app/views/admin/cfps/_events_cfp.html.haml"
       - "app/views/tracks/_form.html.haml"
+      - "app/views/admin/cfps/_tracks_cfp.html.haml"
+      - "app/views/conferences/_call_for_tracks.html.haml"
 
   # Offense count: 32
   IdNames:
@@ -261,6 +264,7 @@ linters:
       - "app/views/admin/users/show.html.haml"
       - "app/views/users/edit.html.haml"
       - "app/views/admin/cfps/_events_cfp.html.haml"
+      - "app/views/admin/cfps/_tracks_cfp.html.haml"
 
   # Offense count: 4
   UnnecessaryInterpolation:

--- a/.haml-lint_todo.yml
+++ b/.haml-lint_todo.yml
@@ -181,6 +181,7 @@ linters:
       - "app/views/tracks/index.html.haml"
       - "app/views/tracks/show.html.haml"
       - "app/views/conferences/_call_for_tracks.html.haml"
+      - "app/views/admin/tracks/_change_state_dropdown.html.haml"
 
   # Offense count: 223
   InstanceVariables:
@@ -245,6 +246,7 @@ linters:
       - "app/views/tracks/_form.html.haml"
       - "app/views/admin/cfps/_tracks_cfp.html.haml"
       - "app/views/conferences/_call_for_tracks.html.haml"
+      - "app/views/admin/tracks/_change_state_dropdown.html.haml"
 
   # Offense count: 32
   IdNames:

--- a/.rubocop_todo.yml
+++ b/.rubocop_todo.yml
@@ -317,6 +317,8 @@ Metrics/BlockLength:
 # Offense count: 23
 Metrics/CyclomaticComplexity:
   Max: 12
+  Exclude:
+    - 'app/models/track.rb'
 
 # Offense count: 2353
 # Configuration parameters: AllowHeredoc, AllowURI, URISchemes, IgnoreCopDirectives, IgnoredPatterns.
@@ -339,6 +341,8 @@ Metrics/ModuleLength:
 # Offense count: 15
 Metrics/PerceivedComplexity:
   Max: 16
+  Exclude:
+    - 'app/models/track.rb'
 
 # Offense count: 20
 Style/AccessorMethodName:

--- a/.rubocop_todo.yml
+++ b/.rubocop_todo.yml
@@ -565,6 +565,7 @@ Style/PercentLiteralDelimiters:
     - 'app/models/subscription.rb'
     - 'app/uploaders/picture_uploader.rb'
     - 'spec/models/program_spec.rb'
+    - 'app/models/track.rb'
 
 # Offense count: 2
 # Configuration parameters: NamePrefix, NamePrefixBlacklist, NameWhitelist.

--- a/app/assets/javascripts/osem-datatables.js
+++ b/app/assets/javascripts/osem-datatables.js
@@ -1,18 +1,14 @@
 $(function () {
-  $(document).ready(function() {
-    $('.datatable').DataTable({
-      // ajax: ...,
-      stateSave: true,
-      autoWidth: false,
-      pagingType: 'full_numbers',
-      "lengthMenu": [[25, 50, 100, -1], [25, 50, 100, "All"]]
-    });
+  $('.datatable').DataTable({
+    // ajax: ...,
+    stateSave: true,
+    autoWidth: false,
+    pagingType: 'full_numbers',
+    "lengthMenu": [[25, 50, 100, -1], [25, 50, 100, "All"]],
+  });
 
-    $('#versionstable').DataTable({
-      pagingType: 'full_numbers',
-      order: [[ 0, 'desc' ]]
-    });
+  $('#versionstable').DataTable({
+    pagingType: 'full_numbers',
+    order: [[ 0, 'desc' ]]
   });
 });
-
-

--- a/app/controllers/admin/events_controller.rb
+++ b/app/controllers/admin/events_controller.rb
@@ -17,7 +17,7 @@ module Admin
 
     def index
       @events = @program.events
-      @tracks = @program.tracks
+      @tracks = @program.tracks.confirmed.cfp_active
       @difficulty_levels = @program.difficulty_levels
       @event_types = @program.event_types
       @tracks_distribution_confirmed = @conference.tracks_distribution(:confirmed)
@@ -43,7 +43,7 @@ module Admin
     end
 
     def show
-      @tracks = @program.tracks
+      @tracks = @program.tracks.confirmed.cfp_active
       @event_types = @program.event_types
       @comments = @event.root_comments
       @comment_count = @event.comment_threads.count
@@ -58,7 +58,7 @@ module Admin
 
     def edit
       @event_types = @program.event_types
-      @tracks = Track.all
+      @tracks = @program.tracks.confirmed.cfp_active
       @comments = @event.root_comments
       @comment_count = @event.comment_threads.count
       @user = @event.submitter

--- a/app/controllers/admin/tracks_controller.rb
+++ b/app/controllers/admin/tracks_controller.rb
@@ -62,7 +62,7 @@ module Admin
     private
 
     def track_params
-      params.require(:track).permit(:name, :description, :color, :short_name, :cfp_active)
+      params.require(:track).permit(:name, :description, :color, :short_name, :cfp_active, :start_date, :end_date, :room_id)
     end
   end
 end

--- a/app/controllers/admin/tracks_controller.rb
+++ b/app/controllers/admin/tracks_controller.rb
@@ -19,6 +19,7 @@ module Admin
 
     def create
       @track = @program.tracks.new(track_params)
+      @track.state = 'confirmed'
       if @track.save
         redirect_to admin_conference_program_tracks_path(conference_id: @conference.short_title),
                     notice: 'Track successfully created.'

--- a/app/controllers/admin/tracks_controller.rb
+++ b/app/controllers/admin/tracks_controller.rb
@@ -20,6 +20,7 @@ module Admin
     def create
       @track = @program.tracks.new(track_params)
       @track.state = 'confirmed'
+      @track.cfp_active = true
       if @track.save
         redirect_to admin_conference_program_tracks_path(conference_id: @conference.short_title),
                     notice: 'Track successfully created.'
@@ -60,10 +61,55 @@ module Admin
       end
     end
 
+    def restart
+      update_state(:restart, "Review for #{@track.name} started!")
+    end
+
+    def to_accept
+      update_state(:to_accept, "Track #{@track.name} marked as a possible acceptance!")
+    end
+
+    def accept
+      if @track.room && @track.start_date && @track.end_date
+        update_state(:accept, "Track #{@track.name} accepted!")
+      else
+        flash[:alert] = 'Please make sure that the track has a room and start/end dates before accepting it'
+        redirect_to edit_admin_conference_program_track_path(@conference.short_title, @track)
+      end
+    end
+
+    def confirm
+      update_state(:confirm, "Track #{@track.name} confirmed!")
+    end
+
+    def to_reject
+      update_state(:to_reject, "Track #{@track.name} marked as a possible rejection!")
+    end
+
+    def reject
+      update_state(:reject, "Track #{@track.name} rejected!")
+    end
+
+    def cancel
+      update_state(:cancel, "Track #{@track.name} canceled!")
+    end
+
     private
 
     def track_params
       params.require(:track).permit(:name, :description, :color, :short_name, :cfp_active, :start_date, :end_date, :room_id)
+    end
+
+    def update_state(transition, notice)
+      errors = @track.update_state(transition)
+
+      if errors.blank?
+        flash[:notice] = notice
+      else
+        flash[:error] = errors
+      end
+
+      redirect_back_or_to(admin_conference_program_tracks_path(conference_id: @conference.short_title))
     end
   end
 end

--- a/app/controllers/admin/tracks_controller.rb
+++ b/app/controllers/admin/tracks_controller.rb
@@ -4,6 +4,9 @@ module Admin
     load_and_authorize_resource :program, through: :conference, singleton: true
     load_and_authorize_resource through: :program, find_by: :short_name
 
+    # Show flash message with ajax calls
+    after_action :prepare_unobtrusive_flash, only: :toggle_cfp_inclusion
+
     def index; end
 
     def show
@@ -55,9 +58,13 @@ module Admin
     def toggle_cfp_inclusion
       @track.cfp_active = !@track.cfp_active
       if @track.save
-        head :ok
+        flash[:notice] = "Successfully changed cfp inclusion of #{@track.name} to #{@track.cfp_active}"
       else
-        head :unprocessable_entity
+        flash[:error] = "Failed to toggle cfp inclusion of #{@track.name} to #{@track.cfp_active}"
+      end
+
+      respond_to do |format|
+        format.js
       end
     end
 

--- a/app/controllers/tracks_controller.rb
+++ b/app/controllers/tracks_controller.rb
@@ -4,7 +4,7 @@ class TracksController < ApplicationController
   load_and_authorize_resource through: :program, find_by: :short_name
 
   def index
-    @tracks = current_user.tracks.where(program: @program)
+    @tracks = @tracks.where(submitter: current_user)
   end
 
   def show; end
@@ -38,9 +38,33 @@ class TracksController < ApplicationController
     end
   end
 
+  def restart
+    update_state(:restart, "Track #{@track.name} re-submitted.")
+  end
+
+  def confirm
+    update_state(:confirm, "Track #{@track.name} confirmed.")
+  end
+
+  def withdraw
+    update_state(:withdraw, "Track #{@track.name} withdrawn.")
+  end
+
   private
 
   def track_params
-    params.require(:track).permit(:name, :description, :color, :short_name)
+    params.require(:track).permit(:name, :description, :color, :short_name, :start_date, :end_date)
+  end
+
+  def update_state(transition, notice)
+    errors = @track.update_state(transition)
+
+    if errors.blank?
+      flash[:notice] = notice
+    else
+      flash[:error] = errors
+    end
+
+    redirect_back_or_to(conference_program_tracks_path(conference_id: @conference.short_title))
   end
 end

--- a/app/controllers/tracks_controller.rb
+++ b/app/controllers/tracks_controller.rb
@@ -18,7 +18,6 @@ class TracksController < ApplicationController
   def create
     @track = @program.tracks.new(track_params)
     @track.submitter = current_user
-    @track.state = 'new'
     @track.cfp_active = false
     if @track.save
       redirect_to conference_program_tracks_path(conference_id: @conference.short_title),

--- a/app/controllers/tracks_controller.rb
+++ b/app/controllers/tracks_controller.rb
@@ -53,7 +53,7 @@ class TracksController < ApplicationController
   private
 
   def track_params
-    params.require(:track).permit(:name, :description, :color, :short_name, :start_date, :end_date)
+    params.require(:track).permit(:name, :description, :color, :short_name, :start_date, :end_date, :relevance)
   end
 
   def update_state(transition, notice)

--- a/app/helpers/application_helper.rb
+++ b/app/helpers/application_helper.rb
@@ -56,7 +56,7 @@ module ApplicationHelper
   end
 
   def tracks(conference)
-    all = conference.program.tracks.map {|t| t.name}
+    all = conference.program.tracks.map { |t| t.name if !t.self_organized? || t.confirmed? && t.cfp_active }.compact
     first = all[0...-1]
     last = all[-1]
     ts = ''

--- a/app/helpers/application_helper.rb
+++ b/app/helpers/application_helper.rb
@@ -56,7 +56,7 @@ module ApplicationHelper
   end
 
   def tracks(conference)
-    all = conference.program.tracks.where(state: 'confirmed', cfp_active: true).pluck(:name)
+    all = conference.program.tracks.confirmed.cfp_active.pluck(:name)
     first = all[0...-1]
     last = all[-1]
     ts = ''

--- a/app/helpers/application_helper.rb
+++ b/app/helpers/application_helper.rb
@@ -56,7 +56,7 @@ module ApplicationHelper
   end
 
   def tracks(conference)
-    all = conference.program.tracks.map { |t| t.name if !t.self_organized? || t.confirmed? && t.cfp_active }.compact
+    all = conference.program.tracks.where(state: 'confirmed', cfp_active: true).pluck(:name)
     first = all[0...-1]
     last = all[-1]
     ts = ''

--- a/app/helpers/events_helper.rb
+++ b/app/helpers/events_helper.rb
@@ -39,4 +39,12 @@ module EventsHelper
       content_tag :span, 'REPLACEMENT', class: (['label', 'label-info'] + label_classes)
     end
   end
+
+  def track_selector_input(form)
+    if @program.tracks.any?
+      form.input :track_id, as: :select,
+                            collection: @program.tracks.where(state: 'confirmed', cfp_active: true).pluck(:name, :id),
+                            include_blank: true
+    end
+  end
 end

--- a/app/models/ability.rb
+++ b/app/models/ability.rb
@@ -95,6 +95,14 @@ class Ability
     can :manage, Commercial, commercialable_type: 'Event', commercialable_id: user.events.pluck(:id)
 
     can [:destroy], Openid
+
+    can [:new, :create], Track do |track|
+      track.new_record? && track.program.cfps.for_tracks.try(:open?)
+    end
+
+    can [:index, :show, :edit, :update], Track do |track|
+      user == track.submitter
+    end
   end
 
   # Abilities for users with roles wandering around in non-admin views.

--- a/app/models/ability.rb
+++ b/app/models/ability.rb
@@ -100,8 +100,10 @@ class Ability
       track.new_record? && track.program.cfps.for_tracks.try(:open?)
     end
 
-    can [:index, :show, :edit, :update], Track do |track|
-      user == track.submitter
+    can [:index, :show, :restart, :confirm, :withdraw], Track, submitter_id: user.id
+
+    can [:edit, :update], Track do |track|
+      user == track.submitter && !(track.accepted? || track.confirmed?)
     end
   end
 

--- a/app/models/admin_ability.rb
+++ b/app/models/admin_ability.rb
@@ -275,6 +275,10 @@ class AdminAbility
 
     can :manage, Track, id: track_ids_for_track_organizer
 
+    cannot [:edit, :update], Track do |track|
+      track.self_organized_and_accepted_or_confirmed?
+    end
+
     # Show Roles in the admin sidebar and allow authorization of the index action
     can [:index, :show], Role do |role|
       role.resource_type == 'Conference' || role.resource_type == 'Track'

--- a/app/models/cfp.rb
+++ b/app/models/cfp.rb
@@ -1,9 +1,10 @@
 # cannot delete program if there are events submitted
 
 class Cfp < ActiveRecord::Base
-  TYPES = %w(events booths).freeze
+  TYPES = %w(events booths tracks).freeze
 
   scope :for_events, (-> { find_by(cfp_type: 'events') })
+  scope :for_tracks, (-> { find_by(cfp_type: 'tracks') })
 
   has_paper_trail ignore: [:updated_at], meta: { conference_id: :conference_id }
   belongs_to :program

--- a/app/models/cfp.rb
+++ b/app/models/cfp.rb
@@ -3,9 +3,6 @@
 class Cfp < ActiveRecord::Base
   TYPES = %w(events booths tracks).freeze
 
-  scope :for_events, (-> { find_by(cfp_type: 'events') })
-  scope :for_tracks, (-> { find_by(cfp_type: 'tracks') })
-
   has_paper_trail ignore: [:updated_at], meta: { conference_id: :conference_id }
   belongs_to :program
 
@@ -77,6 +74,24 @@ class Cfp < ActiveRecord::Base
   # * +true+ -> If today is in the CFP period.
   def open?
     (start_date..end_date).cover?(Date.current)
+  end
+
+  ##
+  # Finds the cfp for events if it exists
+  #
+  # ====Returns
+  # * +Cfp+ -> The cfp with type 'events'
+  def self.for_events
+    find_by(cfp_type: 'events')
+  end
+
+  ##
+  # Finds the cfp for tracks if it exists
+  #
+  # ====Returns
+  # * +Cfp+ -> The cfp with type 'tracks'
+  def self.for_tracks
+    find_by(cfp_type: 'tracks')
   end
 
   private

--- a/app/models/event.rb
+++ b/app/models/event.rb
@@ -45,6 +45,7 @@ class Event < ActiveRecord::Base
   validates :max_attendees, numericality: { only_integer: true, greater_than_or_equal_to: 1, allow_nil: true }
 
   validate :max_attendees_no_more_than_room_size
+  validate :acceptable_track
 
   scope :confirmed, -> { where(state: 'confirmed') }
   scope :canceled, -> { where(state: 'canceled') }
@@ -302,5 +303,12 @@ class Event < ActiveRecord::Base
 
   def conference_id
     program.conference_id
+  end
+
+  ##
+  # Allow only confirmed tracks that belong to the same program and are included in the cfp
+  def acceptable_track
+    return unless track && track.program && program
+    errors.add(:track, 'is invalid') unless track.confirmed? && track.cfp_active && track.program == program
   end
 end

--- a/app/models/room.rb
+++ b/app/models/room.rb
@@ -2,6 +2,7 @@ class Room < ActiveRecord::Base
   include RevisionCount
   belongs_to :venue
   has_many :event_schedules, dependent: :destroy
+  has_many :tracks
 
   has_paper_trail ignore: [:guid], meta: { conference_id: :conference_id }
 

--- a/app/models/track.rb
+++ b/app/models/track.rb
@@ -25,10 +25,10 @@ class Track < ActiveRecord::Base
             inclusion: { in: %w(new to_accept accepted confirmed to_reject rejected canceled withdrawn) },
             if: :self_organized?
   validates :cfp_active, inclusion: { in: [true, false] }, if: :self_organized?
-  validates :start_date, presence: true, if: :accepted_or_confirmed?
-  validates :end_date, presence: true, if: :accepted_or_confirmed?
-  validates :room, presence: true, if: :accepted_or_confirmed?
-  validate :valid_dates, if: :accepted_or_confirmed?
+  validates :start_date, presence: true, if: :self_organized_and_accepted_or_confirmed?
+  validates :end_date, presence: true, if: :self_organized_and_accepted_or_confirmed?
+  validates :room, presence: true, if: :self_organized_and_accepted_or_confirmed?
+  validate :valid_dates, if: :self_organized_and_accepted_or_confirmed?
 
   before_validation :capitalize_color
 
@@ -129,12 +129,12 @@ class Track < ActiveRecord::Base
   end
 
   ##
-  # Checks if the track is accepted or confirmed
+  # Checks if a self-organized track is accepted or confirmed
   # ====Returns
   # * +true+ -> If the track's state is 'accepted' or 'confirmed'
   # * +false+ -> If the track's state is neither 'accepted' nor 'confirmed'
-  def accepted_or_confirmed?
-    accepted? || confirmed?
+  def self_organized_and_accepted_or_confirmed?
+    self_organized? && (accepted? || confirmed?)
   end
 
   private

--- a/app/models/track.rb
+++ b/app/models/track.rb
@@ -27,6 +27,7 @@ class Track < ActiveRecord::Base
   validates :start_date, presence: true, if: :self_organized_and_accepted_or_confirmed?
   validates :end_date, presence: true, if: :self_organized_and_accepted_or_confirmed?
   validates :room, presence: true, if: :self_organized_and_accepted_or_confirmed?
+  validates :relevance, presence: true, if: :self_organized?
   validate :valid_dates
   validate :valid_room, if: :self_organized_and_accepted_or_confirmed?
 

--- a/app/models/track.rb
+++ b/app/models/track.rb
@@ -32,6 +32,9 @@ class Track < ActiveRecord::Base
 
   before_validation :capitalize_color
 
+  scope :confirmed, -> { where(state: 'confirmed') }
+  scope :cfp_active, -> { where(cfp_active: true) }
+
   state_machine initial: :pending do
     state :new
     state :to_accept

--- a/app/models/track.rb
+++ b/app/models/track.rb
@@ -9,7 +9,7 @@ class Track < ActiveRecord::Base
   belongs_to :room
   has_many :events, dependent: :nullify
 
-  has_paper_trail only: [:name, :description, :color], meta: { conference_id: :conference_id }
+  has_paper_trail ignore: [:updated_at], meta: { conference_id: :conference_id }
 
   before_create :generate_guid
   validates :name, presence: true
@@ -28,6 +28,7 @@ class Track < ActiveRecord::Base
   validates :end_date, presence: true, if: :self_organized_and_accepted_or_confirmed?
   validates :room, presence: true, if: :self_organized_and_accepted_or_confirmed?
   validates :relevance, presence: true, if: :self_organized?
+  validates :description, presence: true, if: :self_organized?
   validate :valid_dates
   validate :valid_room, if: :self_organized_and_accepted_or_confirmed?
 

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -165,7 +165,11 @@ class User < ActiveRecord::Base
   def get_roles
     result = {}
     roles.each do |role|
-      resource = Conference.find(role.resource_id).short_title
+      resource = if role.resource_type == 'Conference'
+                   Conference.find(role.resource_id).short_title
+                 elsif role.resource_type == 'Track'
+                   Track.find(role.resource_id).name
+                 end
       if result[role.name].nil?
         result[role.name] = [resource]
       else

--- a/app/views/admin/cfps/_tracks_cfp.html.haml
+++ b/app/views/admin/cfps/_tracks_cfp.html.haml
@@ -1,0 +1,12 @@
+%dt
+  Start Date:
+%dd#start_date
+  = @cfp.start_date.strftime('%A, %B %-d. %Y')
+%dt
+  End Date:
+%dd#end_date
+  = @cfp.end_date.strftime('%A, %B %-d. %Y')
+%dt
+  Days Left:
+%dd
+  = pluralize(@cfp.remaining_days, 'day')

--- a/app/views/admin/tracks/_change_state_dropdown.html.haml
+++ b/app/views/admin/tracks/_change_state_dropdown.html.haml
@@ -1,0 +1,34 @@
+- if track.transition_possible? :restart
+  %li= link_to 'Start review',
+  restart_admin_conference_program_track_path(@conference.short_title, track),
+  method: :patch, id: "restart_track_#{track.id}"
+
+- if track.transition_possible? :to_accept
+  %li= link_to 'Mark as possible acceptance',
+  to_accept_admin_conference_program_track_path(@conference.short_title, track),
+  method: :patch, id: "to_accept_track_#{track.id}"
+
+- if track.transition_possible? :accept
+  %li= link_to 'Accept track request',
+  accept_admin_conference_program_track_path(@conference.short_title, track),
+  method: :patch, id: "accept_track_#{track.id}"
+
+- if track.transition_possible? :confirm
+  %li= link_to 'Confirm track',
+  confirm_admin_conference_program_track_path(@conference.short_title, track),
+  method: :patch, id: "confirm_track_#{track.id}"
+
+- if track.transition_possible? :to_reject
+  %li= link_to 'Mark as possible rejection',
+  to_reject_admin_conference_program_track_path(@conference.short_title, track),
+  method: :patch, id: "to_reject_track_#{track.id}"
+
+- if track.transition_possible? :reject
+  %li= link_to 'Reject track request',
+  reject_admin_conference_program_track_path(@conference.short_title, track),
+  method: :patch, confirm: 'Are you sure?', id: "reject_track_#{track.id}"
+
+- if track.transition_possible? :cancel
+  %li= link_to 'Cancel track request',
+  cancel_admin_conference_program_track_path(@conference.short_title, track),
+  method: :patch, id: "cancel_track_#{track.id}"

--- a/app/views/admin/tracks/_form.html.haml
+++ b/app/views/admin/tracks/_form.html.haml
@@ -8,10 +8,16 @@
         Track
 .row
   .col-md-12
-    = semantic_form_for(@track, url: (@track.new_record? ? admin_conference_program_tracks_path : admin_conference_program_track_path(@conference.short_title, @track))) do |f|
+    = semantic_form_for(@track, url: (@track.new_record? ? admin_conference_program_tracks_path(@conference.short_title) : admin_conference_program_track_path(@conference.short_title, @track))) do |f|
       = f.input :name
       = f.input :short_name, hint: "A short and unique handle for the track, using only letters, numbers, underscores, and dashes. This will be used to identify the track in URLs etc. Example: 'my_awesome_track'", input_html: { required: 'required', pattern: '[a-zA-Z0-9_-]+', title: 'Only letters, numbers, underscores, and dashes.' }
       = f.input :color, input_html: {size: 6, type: 'color'}, required: true
+      = f.input :start_date, as: :string, input_html: { id: 'registration-period-start-datepicker', start_date: @conference.start_date, end_date: @conference.end_date, readonly: 'readonly', required: @track.self_organized_and_accepted_or_confirmed? }
+      = f.input :end_date, as: :string, input_html: { id: 'registration-period-end-datepicker', readonly: 'readonly', required: @track.self_organized_and_accepted_or_confirmed? }
+      - if @conference.venue
+        = f.input :room, as: :select, collection: (@conference.venue.rooms).map {|room| ["#{room.name}", room.id]}, include_blank: true, label: 'Room', input_html: { class: 'select-help-toggle', required: @track.self_organized_and_accepted_or_confirmed? }
+      - else
+        Please add a venue with rooms, if you want to select a room for the track.
       = f.input :description, input_html: {rows: 2, data: { provide: 'markdown-editable' } }, hint: markdown_hint
       - if @track.self_organized?
         = f.input :cfp_active, label: 'Allow event submitters to select this track for their proposal'

--- a/app/views/admin/tracks/_form.html.haml
+++ b/app/views/admin/tracks/_form.html.haml
@@ -19,6 +19,5 @@
       - else
         Please add a venue with rooms, if you want to select a room for the track.
       = f.input :description, input_html: {rows: 2, data: { provide: 'markdown-editable' } }, hint: markdown_hint
-      - if @track.self_organized?
-        = f.input :cfp_active, label: 'Allow event submitters to select this track for their proposal'
+      = f.input :cfp_active, label: 'Allow event submitters to select this track for their proposal'
       = f.action :submit, as: :button, button_html: { class: 'btn btn-primary' }

--- a/app/views/admin/tracks/_form.html.haml
+++ b/app/views/admin/tracks/_form.html.haml
@@ -14,10 +14,15 @@
       = f.input :color, input_html: {size: 6, type: 'color'}, required: true
       = f.input :start_date, as: :string, input_html: { id: 'registration-period-start-datepicker', start_date: @conference.start_date, end_date: @conference.end_date, readonly: 'readonly', required: @track.self_organized_and_accepted_or_confirmed? }
       = f.input :end_date, as: :string, input_html: { id: 'registration-period-end-datepicker', readonly: 'readonly', required: @track.self_organized_and_accepted_or_confirmed? }
-      - if @conference.venue
+      - if @conference.venue.try(:rooms)
         = f.input :room, as: :select, collection: (@conference.venue.rooms).map {|room| ["#{room.name}", room.id]}, include_blank: true, label: 'Room', input_html: { class: 'select-help-toggle', required: @track.self_organized_and_accepted_or_confirmed? }
       - else
-        Please add a venue with rooms, if you want to select a room for the track.
+        %b
+          Please add a
+          = link_to 'venue', admin_conference_venue_path(@conference.short_title)
+          with
+          = link_to 'rooms', admin_conference_venue_rooms_path(@conference.short_title)
+          , if you want to select a room for the track.
       = f.input :description, input_html: {rows: 2, data: { provide: 'markdown-editable' } }, hint: markdown_hint
       = f.input :cfp_active, label: 'Allow event submitters to select this track for their proposal'
       = f.action :submit, as: :button, button_html: { class: 'btn btn-primary' }

--- a/app/views/admin/tracks/index.html.haml
+++ b/app/views/admin/tracks/index.html.haml
@@ -42,7 +42,7 @@
               - if track.self_organized?
                 = track.state
               - else
-                N/A
+                = track.state.humanize
             %td
               - if track.self_organized?
                 = check_box_tag "#{@conference.short_title}_#{track.short_name}", track.id, track.cfp_active,

--- a/app/views/admin/tracks/index.html.haml
+++ b/app/views/admin/tracks/index.html.haml
@@ -15,6 +15,9 @@
         %th Color
         %th State
         %th Included in the Cfp
+        %th Room
+        %th Start Date
+        %th End Date
         %th Actions
       %tbody
         - @tracks.each do |track|
@@ -52,6 +55,21 @@
                           off_text: 'No' }
               - else
                 %i.fa.fa-check
+            %td
+              - if track.room
+                = link_to track.room.name, admin_conference_venue_room_path(@conference.short_title, track.room.id)
+              - else
+                N/A
+            %td
+              - if track.start_date
+                = track.start_date.strftime('%A, %B %-d. %Y')
+              - else
+                N/A
+            %td
+              - if track.end_date
+                = track.end_date.strftime('%A, %B %-d. %Y')
+              - else
+                N/A
             %td
               .btn-group{role: "group"}
                 = link_to 'Edit', edit_admin_conference_program_track_path(@conference.short_title, track),

--- a/app/views/admin/tracks/index.html.haml
+++ b/app/views/admin/tracks/index.html.haml
@@ -40,21 +40,24 @@
                 = track.color
             %td
               - if track.self_organized?
-                = track.state
+                .btn-group
+                  %button{ type: 'button', class: 'btn btn-link dropdown-toggle', 'data-toggle' => 'dropdown' }
+                    = track.state.humanize
+                    %span.caret
+                  %ul.dropdown-menu{ role: 'menu' }
+                    = render 'change_state_dropdown', track: track
               - else
                 = track.state.humanize
             %td
-              - if track.self_organized?
-                = check_box_tag "#{@conference.short_title}_#{track.short_name}", track.id, track.cfp_active,
-                  class: 'switch-checkbox', method: :patch,
-                  url: toggle_cfp_inclusion_admin_conference_program_track_path(@conference.short_title, id: track.short_name)+"?included=",
-                  data: { size: 'small',
-                          on_color: 'success',
-                          off_color: 'warning',
-                          on_text: 'Yes',
-                          off_text: 'No' }
-              - else
-                %i.fa.fa-check
+              = check_box_tag "#{@conference.short_title}_#{track.short_name}", track.id, track.cfp_active,
+                class: 'switch-checkbox', method: :patch,
+                url: toggle_cfp_inclusion_admin_conference_program_track_path(@conference.short_title, id: track.short_name)+"?included=",
+                data: { size: 'small',
+                        on_color: 'success',
+                        off_color: 'warning',
+                        on_text: 'Yes',
+                        off_text: 'No' }
+
             %td
               - if track.room
                 = link_to track.room.name, admin_conference_venue_room_path(@conference.short_title, track.room.id)
@@ -72,8 +75,9 @@
                 N/A
             %td
               .btn-group{role: "group"}
-                = link_to 'Edit', edit_admin_conference_program_track_path(@conference.short_title, track),
-                method: :get, class: 'btn btn-primary'
+                - if can? :edit, track
+                  = link_to 'Edit', edit_admin_conference_program_track_path(@conference.short_title, track),
+                  method: :get, class: 'btn btn-primary'
                 - if can? :destroy, track
                   = link_to 'Delete', admin_conference_program_track_path(@conference.short_title, track),
                   method: :delete, class: 'btn btn-danger',

--- a/app/views/admin/tracks/index.html.haml
+++ b/app/views/admin/tracks/index.html.haml
@@ -6,39 +6,46 @@
         Categorize events in your conference
 .row
   .col-md-12
-    %table.table.table-hover#tracks
+    %table.table.table-hover.table-striped.table-bordered.datatable#tracks
       %thead
         %th Name
-        %th Short name
         %th Description
-        %th Submitter
-        %th Color
-        %th State
-        %th Included in the Cfp
         %th Room
         %th Start Date
         %th End Date
+        %th Submitter
+        %th Included in Cfp
+        %th State
         %th Actions
       %tbody
         - @tracks.each do |track|
           %tr
-            %td
-              = link_to(admin_conference_program_track_path(@conference.short_title, track)) do
-                = track.name
-            %td
-              = track.short_name
+            %td{style: "padding: 15px 0px 0px 10px;"}
+              = link_to admin_conference_program_track_path(@conference.short_title, track), class: 'btn' do
+                %span.label{style: "background-color: #{track.color}; color: #{ contrast_color(track.color) }"}
+                  = track.name
             %td
               %p
-                = truncate(track.description)
+                = markdown(truncate(track.description))
             %td
-              - if track.self_organized?
-                = link_to track.submitter.name, admin_user_path(track.submitter)
-              - else
-                N/A
+              = track.room.try(:name)
             %td
-              %span.label{style: "background-color: #{track.color}; color: #{ contrast_color(track.color) }"}
-                = track.color
+              = track.start_date.strftime('%A, %B %-d. %Y') if track.start_date
             %td
+              = track.end_date.strftime('%A, %B %-d. %Y') if track.end_date
+            %td
+              = link_to track.submitter.name, admin_user_path(track.submitter) if track.self_organized?
+            %td.text-center
+              = check_box_tag "#{@conference.short_title}_#{track.short_name}", track.id, track.cfp_active,
+                class: 'switch-checkbox', method: :patch,
+                url: toggle_cfp_inclusion_admin_conference_program_track_path(@conference.short_title, id: track.short_name)+"?included=",
+                data: { size: 'small',
+                        on_color: 'success',
+                        off_color: 'warning',
+                        on_text: 'Yes',
+                        off_text: 'No' }
+
+            %td.text-center
               - if track.self_organized?
                 .btn-group
                   %button{ type: 'button', class: 'btn btn-link dropdown-toggle', 'data-toggle' => 'dropdown' }
@@ -49,38 +56,11 @@
               - else
                 = track.state.humanize
             %td
-              = check_box_tag "#{@conference.short_title}_#{track.short_name}", track.id, track.cfp_active,
-                class: 'switch-checkbox', method: :patch,
-                url: toggle_cfp_inclusion_admin_conference_program_track_path(@conference.short_title, id: track.short_name)+"?included=",
-                data: { size: 'small',
-                        on_color: 'success',
-                        off_color: 'warning',
-                        on_text: 'Yes',
-                        off_text: 'No' }
-
-            %td
-              - if track.room
-                = link_to track.room.name, admin_conference_venue_room_path(@conference.short_title, track.room.id)
-              - else
-                N/A
-            %td
-              - if track.start_date
-                = track.start_date.strftime('%A, %B %-d. %Y')
-              - else
-                N/A
-            %td
-              - if track.end_date
-                = track.end_date.strftime('%A, %B %-d. %Y')
-              - else
-                N/A
-            %td
               .btn-group{role: "group"}
                 - if can? :edit, track
-                  = link_to 'Edit', edit_admin_conference_program_track_path(@conference.short_title, track),
-                  method: :get, class: 'btn btn-primary'
+                  = link_to 'Edit', edit_admin_conference_program_track_path(@conference.short_title, track), class: 'btn btn-primary'
                 - if can? :destroy, track
-                  = link_to 'Delete', admin_conference_program_track_path(@conference.short_title, track),
-                  method: :delete, class: 'btn btn-danger',
+                  = link_to 'Delete', admin_conference_program_track_path(@conference.short_title, track), method: :delete, class: 'btn btn-danger',
                   data: { confirm: "Do you really want to delete #{track.name}? Attention: This track will be removed from all Events that have it set" }
 .row
   .col-md-12.text-right

--- a/app/views/admin/tracks/index.html.haml
+++ b/app/views/admin/tracks/index.html.haml
@@ -1,3 +1,4 @@
+.unobtrusive-flash-container
 .row
   .col-md-12
     .page-header
@@ -8,6 +9,7 @@
   .col-md-12
     %table.table.table-hover.table-striped.table-bordered.datatable#tracks
       %thead
+        %th ID
         %th Name
         %th Description
         %th Room
@@ -20,6 +22,8 @@
       %tbody
         - @tracks.each do |track|
           %tr
+            %td
+              = track.id
             %td{style: "padding: 15px 0px 0px 10px;"}
               = link_to admin_conference_program_track_path(@conference.short_title, track), class: 'btn' do
                 %span.label{style: "background-color: #{track.color}; color: #{ contrast_color(track.color) }"}
@@ -35,7 +39,7 @@
               = track.end_date.strftime('%A, %B %-d. %Y') if track.end_date
             %td
               = link_to track.submitter.name, admin_user_path(track.submitter) if track.self_organized?
-            %td.text-center
+            %td.text-center{ 'id' => "cfp_switch_#{track.id}", 'data-order' => track.cfp_active.to_s }
               = check_box_tag "#{@conference.short_title}_#{track.short_name}", track.id, track.cfp_active,
                 class: 'switch-checkbox', method: :patch,
                 url: toggle_cfp_inclusion_admin_conference_program_track_path(@conference.short_title, id: track.short_name)+"?included=",

--- a/app/views/admin/tracks/show.html.haml
+++ b/app/views/admin/tracks/show.html.haml
@@ -92,6 +92,12 @@
                 %b Description
               %td
                 = markdown(@track.description)
+            - if @track.self_organized?
+              %tr
+                %td
+                  %b Relevance
+                %td
+                  = markdown(@track.relevance)
 
     .tab-pane#events
       .col-md-12

--- a/app/views/admin/tracks/show.html.haml
+++ b/app/views/admin/tracks/show.html.haml
@@ -1,3 +1,4 @@
+.unobtrusive-flash-container
 .row
   .col-md-12
     .page-header

--- a/app/views/admin/tracks/show.html.haml
+++ b/app/views/admin/tracks/show.html.haml
@@ -4,27 +4,114 @@
       %h1
         = @track.name
         Track
-      %p.text-muted
-        Events in this track
-.row
-  .col-md-12
-    %table.table.table-hover.datatable
-      %thead
-        %th Title
-        %th Type
-        %th Submitter
-        %th State
-        %th Time
-      %tbody
-        - @track.events.each_with_index do |event|
-          %tr
-            %td
-              =link_to event.title, admin_conference_program_event_path(@conference.short_title, event)
-            %td
-              = event.event_type.title
-            %td
-              =link_to event.submitter.name, admin_user_path(event.submitter)
-            %td
-              = event.state
-            %td
-              = event.time
+
+.tabbable
+  %ul.nav.nav-tabs
+    %li.active
+      = link_to 'Details', '#details', 'data-toggle' => 'tab'
+    %li
+      = link_to 'Events', '#events', 'data-toggle' => 'tab'
+
+  .tab-content
+    .tab-pane.active#details
+      .row
+        .col-md-12
+          .btn-group.pull-right
+            - if can? :edit, @track
+              = link_to 'Edit', edit_admin_conference_program_track_path(@conference.short_title, @track),
+              method: :get, class: 'btn btn-primary'
+            - if can? :destroy, @track
+              = link_to 'Delete', admin_conference_program_track_path(@conference.short_title, @track),
+              method: :delete, class: 'btn btn-danger',
+              data: { confirm: "Do you really want to delete #{@track.name}? Attention: This track will be removed from all Events that have it set" }
+      .row
+        .col-md-12
+          %table.table
+            %tr
+              %td.col-md-2
+                %b Color
+              %td
+                %span.label{ style: "background-color: #{@track.color}; color: #{ contrast_color(@track.color) }" }
+                  = @track.color
+            %tr
+              %td
+                %b Room
+              %td
+                = @track.room.try(:name)
+            %tr
+              %td
+                %b Start date
+              %td
+                = @track.start_date.strftime('%A, %B %-d. %Y') if @track.start_date
+            %tr
+              %td
+                %b End date
+              %td
+                = @track.end_date.strftime('%A, %B %-d. %Y') if @track.end_date
+            - if @track.self_organized?
+              %tr
+                %td
+                  %b Submitter
+                %td
+                  = link_to @track.submitter.name, admin_user_path(@track.submitter)
+              - if @track.confirmed?
+                %tr
+                  %td
+                    %b Organizers
+                  %td
+                    - Role.find_by(name: 'track_organizer', resource: @track).users.each do |organizer|
+                      %div
+                        = link_to organizer.name, admin_user_path(organizer)
+            %tr
+              %td
+                %b Included in the Cfp?
+              %td
+                = check_box_tag "#{@conference.short_title}_#{@track.short_name}", @track.id, @track.cfp_active,
+                  class: 'switch-checkbox', method: :patch,
+                  url: toggle_cfp_inclusion_admin_conference_program_track_path(@conference.short_title, id: @track.short_name)+"?included=",
+                  data: { size: 'small',
+                          on_color: 'success',
+                          off_color: 'warning',
+                          on_text: 'Yes',
+                          off_text: 'No' }
+            %tr
+              %td
+                %b State
+              %td
+                - if @track.self_organized?
+                  .btn-group
+                    %button{ type: 'button', class: 'btn btn-link dropdown-toggle', 'data-toggle' => 'dropdown' }
+                      = @track.state.humanize
+                      %span.caret
+                    %ul.dropdown-menu{ role: 'menu' }
+                      = render 'change_state_dropdown', track: @track
+                - else
+                  = @track.state.humanize
+            %tr
+              %td
+                %b Description
+              %td
+                = markdown(@track.description)
+
+    .tab-pane#events
+      .col-md-12
+        %table.table.table-hover.datatable
+          %thead
+            %th Title
+            %th Type
+            %th Submitter
+            %th State
+            %th Time
+          %tbody
+            - @track.events.each_with_index do |event|
+              %tr
+                %td
+                  =link_to event.title, admin_conference_program_event_path(@conference.short_title, event)
+                %td
+                  = event.event_type.title
+                %td
+                  =link_to event.submitter.name, admin_user_path(event.submitter)
+                %td
+                  = event.state
+                %td
+                  = event.time

--- a/app/views/admin/tracks/toggle_cfp_inclusion.js.erb
+++ b/app/views/admin/tracks/toggle_cfp_inclusion.js.erb
@@ -1,0 +1,8 @@
+$('.alert').remove();
+
+track_id = <%= @track.id %>;
+track_cfp_td = $('#cfp_switch_' + track_id);
+track_cfp_value = <%= @track.cfp_active %>;
+
+track_cfp_td.attr('data-order', track_cfp_value);
+$('#tracks').DataTable().cell(track_cfp_td).invalidate();

--- a/app/views/conferences/_call_for_tracks.html.haml
+++ b/app/views/conferences/_call_for_tracks.html.haml
@@ -1,0 +1,30 @@
+= content_for :splash_nav do
+  %li
+    %a.smoothscroll{ href: '#callfortracks' } Call For Tracks
+
+.container
+  .row
+    .col-md-12.text-center
+      %h2
+        Call for Tracks
+      %p.lead
+        We are ready to accept requests for tracks!
+  .row
+    .col-md-6.col-md-offset-3.col-sm-10.col-sm-offset-1
+      %p
+        The submission period for track requests has begun
+        %em.notranslate
+          = @conference.program.cfps.for_tracks.start_date.strftime('%A, %B %-d. %Y')
+        and closes
+        %em.notranslate
+          = @conference.program.cfps.for_tracks.end_date.strftime('%A, %B %-d. %Y.')
+        - if @conference.program.cfps.for_tracks.try(:open?)
+          That means you have only
+          %b.notranslate= pluralize(@conference.program.cfps.for_tracks.remaining_days, 'day')
+          left!
+        - else
+          The submission period for track requests is closed.
+  .row
+    .col-md-12.text-center
+      %p.cta-button
+        = link_to "Submit your request for track", conference_program_tracks_path(@conference.short_title), class: 'btn btn-success btn-lg text-center'

--- a/app/views/conferences/_conference_details.html.haml
+++ b/app/views/conferences/_conference_details.html.haml
@@ -30,6 +30,10 @@
                 = link_to "Register", new_conference_conference_registration_path(conference.short_title), class: "btn btn-default", disabled: cannot?(:new, Registration.new(conference_id: conference.id))
                 - if cannot?(:new, Registration.new(conference_id: conference.id)) && conference.registration_limit_exceeded?
                   Sorry, no places left
+            - if !current_user.nil? && current_user.tracks.where(program: conference.program).length > 0
+              = link_to "My Track Requests", conference_program_tracks_path(conference.short_title), class: 'btn btn-default'
+            - elsif can? :new, conference.program.tracks.new
+              = link_to "Submit Track Request", new_conference_program_track_path(conference.short_title), class: 'btn btn-default'
             - if !current_user.nil? && current_user.proposal_count(conference) > 0
               = link_to "My Proposals", conference_program_proposals_path(conference.short_title), class: 'btn btn-default'
             - elsif can? :new, conference.program.events.new

--- a/app/views/conferences/_schedule_splashpage.html.haml
+++ b/app/views/conferences/_schedule_splashpage.html.haml
@@ -10,13 +10,22 @@
         - if @conference.splashpage and @conference.program.tracks.any? and @conference.splashpage.include_tracks
           See rock-star speakers cover the topics of
       - if @conference.splashpage and @conference.splashpage.include_tracks
-        - @conference.program.tracks.each_slice(3) do |slice|
+        - @conference.program.tracks.confirmed.cfp_active.each_slice(3) do |slice|
           .row.row-centered
             - slice.each do |track|
               .col-md-4.col-sm-4.col-centered.col-top.track
                 %h4.text-center
                   = track.name
                 = markdown(track.description)
+                - if track.start_date
+                  %br
+                  From: #{track.start_date.strftime('%A, %B %-d. %Y')}
+                - if track.end_date
+                  %br
+                  To: #{track.end_date.strftime('%A, %B %-d. %Y')}
+                - if track.room
+                  %br
+                  In: #{track.room.name}
 
   - if @conference.program and @conference.program.schedule_public
     .row

--- a/app/views/conferences/show.html.haml
+++ b/app/views/conferences/show.html.haml
@@ -45,6 +45,10 @@
       %section#program
         = render 'schedule_splashpage'
 
+    - if @conference.program.cfps.for_tracks.try(:open?) && @conference.splashpage.include_cfp
+      %section#callfortracks
+        = render 'call_for_tracks'
+
     - if @conference.program.cfp_open? and @conference.splashpage.include_cfp
       %section#callforpapers
         = render 'call_for_paper'

--- a/app/views/layouts/_user_menu.html.haml
+++ b/app/views/layouts/_user_menu.html.haml
@@ -12,6 +12,10 @@
     = link_to(conference_program_proposals_path(@conference.short_title)) do
       %span.fa.fa-comment
       My Submissions
+  %li
+    = link_to(conference_program_tracks_path(@conference.short_title)) do
+      %span.fa.fa-road
+      My Tracks
 %li
   - if ENV['OSEM_ICHAIN_ENABLED'] == 'true'
     = link_to(destroy_user_ichain_session_path, method: 'delete') do

--- a/app/views/proposals/_encouragement_text.html.haml
+++ b/app/views/proposals/_encouragement_text.html.haml
@@ -4,7 +4,7 @@
     = "#{event_types(@conference)}."
   - if @program.tracks.any?
     Proposals should fit in one of the
-    = "#{pluralize(@program.tracks.count, 'track')}:"
+    = "#{pluralize(@program.tracks.confirmed.cfp_active.count, 'track')}:"
     = "#{tracks(@conference)}."
   - if @program.cfp_open?
     The submission period has begun

--- a/app/views/proposals/_proposal_form.html.haml
+++ b/app/views/proposals/_proposal_form.html.haml
@@ -6,10 +6,7 @@
 
     = speaker_selector_input f
 
-    - if @program.tracks.any?
-      = f.input :track_id, as: :select,
-                collection: @program.tracks.map {|track| ["#{track.name}", track.id] },
-                include_blank: true
+    = track_selector_input f
 
     = f.input :event_type_id, as: :select,
       collection: @conference.program.event_types.map {|type| ["#{type.title} - #{show_time(type.length)}", type.id,

--- a/app/views/tracks/_form.html.haml
+++ b/app/views/tracks/_form.html.haml
@@ -9,9 +9,11 @@
           Track
   .row
     .col-md-12
-      = semantic_form_for(@track, url: (@track.new_record? ? conference_program_tracks_path : conference_program_track_path(@conference.short_title, @track))) do |f|
+      = semantic_form_for(@track, url: (@track.new_record? ? conference_program_tracks_path(@conference.short_title) : conference_program_track_path(@conference.short_title, @track))) do |f|
         = f.input :name
         = f.input :short_name, hint: "A short and unique handle for the track, using only letters, numbers, underscores, and dashes. This will be used to identify the track in URLs etc. Example: 'my_awesome_track'", input_html: { required: 'required', pattern: '[a-zA-Z0-9_-]+', title: 'Only letters, numbers, underscores, and dashes.' }
         = f.input :color, input_html: {size: 6, type: 'color'}, required: true
+        = f.input :start_date, as: :string, input_html: { id: 'registration-period-start-datepicker', start_date: @conference.start_date, end_date: @conference.end_date, readonly: 'readonly' }
+        = f.input :end_date, as: :string, input_html: { id: 'registration-period-end-datepicker', readonly: 'readonly' }
         = f.input :description, input_html: {rows: 2, data: { provide: 'markdown-editable' } }, required: true, hint: markdown_hint
         = f.action :submit, as: :button, button_html: { class: 'btn btn-primary' }

--- a/app/views/tracks/_form.html.haml
+++ b/app/views/tracks/_form.html.haml
@@ -16,4 +16,5 @@
         = f.input :start_date, as: :string, input_html: { id: 'registration-period-start-datepicker', start_date: @conference.start_date, end_date: @conference.end_date, readonly: 'readonly' }
         = f.input :end_date, as: :string, input_html: { id: 'registration-period-end-datepicker', readonly: 'readonly' }
         = f.input :description, input_html: {rows: 2, data: { provide: 'markdown-editable' } }, required: true, hint: "This will be public #{markdown_hint}".html_safe
+        = f.input :relevance, input_html: {rows: 5, data: { provide: 'markdown-editable' } }, required: true, hint: "Please explain here how this track relates to the conference, how you are related to it's content and why we should accept it. #{markdown_hint}".html_safe
         = f.action :submit, as: :button, button_html: { class: 'btn btn-primary' }

--- a/app/views/tracks/_form.html.haml
+++ b/app/views/tracks/_form.html.haml
@@ -15,5 +15,5 @@
         = f.input :color, input_html: {size: 6, type: 'color'}, required: true
         = f.input :start_date, as: :string, input_html: { id: 'registration-period-start-datepicker', start_date: @conference.start_date, end_date: @conference.end_date, readonly: 'readonly' }
         = f.input :end_date, as: :string, input_html: { id: 'registration-period-end-datepicker', readonly: 'readonly' }
-        = f.input :description, input_html: {rows: 2, data: { provide: 'markdown-editable' } }, required: true, hint: markdown_hint
+        = f.input :description, input_html: {rows: 2, data: { provide: 'markdown-editable' } }, required: true, hint: "This will be public #{markdown_hint}".html_safe
         = f.action :submit, as: :button, button_html: { class: 'btn btn-primary' }

--- a/app/views/tracks/index.html.haml
+++ b/app/views/tracks/index.html.haml
@@ -16,6 +16,8 @@
             %th Description
             %th Color
             %th State
+            %th Start Date
+            %th End Date
             %th Actions
           %tbody
             - @tracks.each do |track|
@@ -34,10 +36,31 @@
                 %td
                   = track.state.humanize
                 %td
-                  = link_to 'Edit', edit_conference_program_track_path(@conference.short_title, track),
-                  method: :get, class: 'btn btn-primary'
+                  - if track.start_date
+                    = track.start_date.strftime('%A, %B %-d. %Y')
+                  - else
+                    N/A
+                %td
+                  - if track.end_date
+                    = track.end_date.strftime('%A, %B %-d. %Y')
+                  - else
+                    N/A
+                %td
+                  - if track.transition_possible? :confirm
+                    = link_to 'Confirm', confirm_conference_program_track_path(@conference.short_title, track),
+                      method: :patch, class: 'btn btn-mini btn-success', id: "confirm_track_#{track.id}"
+                  - if track.transition_possible? :withdraw
+                    = link_to 'Withdraw', withdraw_conference_program_track_path(@conference.short_title, track),
+                      method: :patch, data: { confirm: 'Are you sure you want to withdraw this track request?' },
+                      class: 'btn btn-mini btn-warning', id: "withdraw_track_request_#{track.id}"
+                  - if track.transition_possible? :restart
+                    = link_to 'Re-Submit', restart_conference_program_track_path(@conference.short_title, track),
+                      method: :patch, class: 'btn btn-mini btn-success', id: "resubmit_track_request_#{track.id}"
+                  - if can? :edit, track
+                    = link_to 'Edit', edit_conference_program_track_path(@conference.short_title, track),
+                    method: :get, class: 'btn btn-primary'
 
   .row
     .col-md-12
-      - if can? :create, @track
+      - if can? :new, @program.tracks.new
         = link_to "New Track request", new_conference_program_track_path(@conference.short_title), class: 'btn btn-success pull-right'

--- a/app/views/tracks/index.html.haml
+++ b/app/views/tracks/index.html.haml
@@ -32,7 +32,7 @@
                   %span.label{style: "background-color: #{track.color}; color: #{ contrast_color(track.color) }"}
                     = track.color
                 %td
-                  = track.state
+                  = track.state.humanize
                 %td
                   = link_to 'Edit', edit_conference_program_track_path(@conference.short_title, track),
                   method: :get, class: 'btn btn-primary'

--- a/app/views/tracks/index.html.haml
+++ b/app/views/tracks/index.html.haml
@@ -6,46 +6,60 @@
         %span.notranslate
           = @conference.title
 
+  .row
+    .col-md-12
+      %p.text-right
+        = link_to '#status-help', class: 'btn btn-default',  "data-toggle"=>"collapse" do
+          Help?
+      .collapse#status-help
+        %p
+          %strong
+            What happens next with my track request?
+        %p
+          If you submit a track request, the conference organizers will review it and either accept or reject it.
+          %br
+          If your track request is accepted, the conference organizers expect you to confirm that you will be able to hold it.
+          Then you will gain the Track organizer role.
+          %br
+          If your track request is rejected, you can either live with that or adapt it and resubmit it for review again.
+          %br
+          If something changes and you can't organize the track any more, you should withdraw it.
+
   - if @tracks.any?
     .row
       .col-md-12
-        %table.table.table-hover#tracks
-          %thead
-            %th Name
-            %th Short name
-            %th Description
-            %th Color
-            %th State
-            %th Start Date
-            %th End Date
-            %th Actions
-          %tbody
-            - @tracks.each do |track|
-              %tr
-                %td
-                  = link_to(conference_program_track_path(@conference.short_title, track)) do
-                    = track.name
-                %td
-                  = track.short_name
-                %td
-                  %p
-                    = truncate(track.description)
-                %td
+        %table.table.table-striped#tracks
+          - @tracks.each do |track|
+            %tr
+              %td{style: "padding:15px 0px 0px 8px;"}
+                - if %w(new to_accept to_reject).include? track.state
+                  %span{ title: 'In review', class: 'fa fa-eye' }
+                - elsif track.state == 'accepted'
+                  %span{ title: 'Accepted', class: 'fa fa-check text-muted' }
+                - elsif track.state == 'confirmed'
+                  %spam{ title: 'Confirmed', class: 'fa fa-check text-success' }
+                - elsif %w(rejected withdrawn canceled).include? track.state
+                  %span{ title: track.state.humanize, class: 'fa fa-ban'}
+              %td{style: "padding: 15px 0px 0px 0px;"}
+                = link_to conference_program_track_path(@conference.short_title, track), class: 'btn' do
                   %span.label{style: "background-color: #{track.color}; color: #{ contrast_color(track.color) }"}
-                    = track.color
-                %td
-                  = track.state.humanize
-                %td
-                  - if track.start_date
-                    = track.start_date.strftime('%A, %B %-d. %Y')
-                  - else
-                    N/A
-                %td
-                  - if track.end_date
-                    = track.end_date.strftime('%A, %B %-d. %Y')
-                  - else
-                    N/A
-                %td
+                    = track.name
+              %td
+                = markdown(truncate(track.description))
+              %td
+                - if track.start_date
+                  From:
+                  = track.start_date.strftime('%A, %B %-d. %Y')
+              %td
+                - if track.end_date
+                  To:
+                  = track.end_date.strftime('%A, %B %-d. %Y')
+              %td
+                - if track.room
+                  In:
+                  = track.room.name
+              %td
+                .pull-right
                   - if track.transition_possible? :confirm
                     = link_to 'Confirm', confirm_conference_program_track_path(@conference.short_title, track),
                       method: :patch, class: 'btn btn-mini btn-success', id: "confirm_track_#{track.id}"
@@ -57,8 +71,7 @@
                     = link_to 'Re-Submit', restart_conference_program_track_path(@conference.short_title, track),
                       method: :patch, class: 'btn btn-mini btn-success', id: "resubmit_track_request_#{track.id}"
                   - if can? :edit, track
-                    = link_to 'Edit', edit_conference_program_track_path(@conference.short_title, track),
-                    method: :get, class: 'btn btn-primary'
+                    = link_to 'Edit', edit_conference_program_track_path(@conference.short_title, track), class: 'btn btn-default'
 
   .row
     .col-md-12

--- a/app/views/tracks/show.html.haml
+++ b/app/views/tracks/show.html.haml
@@ -18,9 +18,24 @@
         %dd
           = @track.state.humanize
         %dt
+          Start date:
+        %dd
+          - if @track.start_date
+            = @track.start_date.strftime('%A, %B %-d. %Y')
+          - else
+            N/A
+        %dt
+          End date:
+        %dd
+          - if @track.end_date
+            = @track.end_date.strftime('%A, %B %-d. %Y')
+          - else
+            N/A
+        %dt
           Description
         %dd
           = @track.description
   .row
     .col-md-12.text-right
-      = link_to 'Edit Track request', edit_conference_program_track_path(@conference.short_title, @track), class: 'btn btn-primary'
+      - if can? :edit, @track
+        = link_to 'Edit Track request', edit_conference_program_track_path(@conference.short_title, @track), class: 'btn btn-primary'

--- a/app/views/tracks/show.html.haml
+++ b/app/views/tracks/show.html.haml
@@ -16,7 +16,7 @@
         %dt
           State:
         %dd
-          = @track.state
+          = @track.state.humanize
         %dt
           Description
         %dd

--- a/app/views/tracks/show.html.haml
+++ b/app/views/tracks/show.html.haml
@@ -39,3 +39,7 @@
           Description
         %dd
           = markdown(@track.description)
+        %dt
+          Relevance
+        %dd
+          = markdown(@track.relevance)

--- a/app/views/tracks/show.html.haml
+++ b/app/views/tracks/show.html.haml
@@ -2,9 +2,12 @@
   .row
     .col-md-12
       .page-header
-        %h1
+        %h2
           = @track.name
           Track
+          .btn-group.pull-right
+            - if can? :edit, @track
+              = link_to 'Edit Track request', edit_conference_program_track_path(@conference.short_title, @track), class: 'btn btn-primary'
   .row
     .col-md-8
       %dl.dl-horizontal
@@ -16,26 +19,23 @@
         %dt
           State:
         %dd
-          = @track.state.humanize
+          - if %w(new to_accept to_reject).include? @track.state
+            New
+          - else
+            = @track.state.humanize
         %dt
           Start date:
         %dd
-          - if @track.start_date
-            = @track.start_date.strftime('%A, %B %-d. %Y')
-          - else
-            N/A
+          = @track.start_date.strftime('%A, %B %-d. %Y') if @track.start_date
         %dt
           End date:
         %dd
-          - if @track.end_date
-            = @track.end_date.strftime('%A, %B %-d. %Y')
-          - else
-            N/A
+          = @track.end_date.strftime('%A, %B %-d. %Y') if @track.end_date
+        %dt
+          Room:
+        %dd
+          = @track.room.try(:name)
         %dt
           Description
         %dd
-          = @track.description
-  .row
-    .col-md-12.text-right
-      - if can? :edit, @track
-        = link_to 'Edit Track request', edit_conference_program_track_path(@conference.short_title, @track), class: 'btn btn-primary'
+          = markdown(@track.description)

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -69,6 +69,13 @@ Osem::Application.routes.draw do
         resources :tracks do
           member do
             patch :toggle_cfp_inclusion
+            patch :restart
+            patch :to_accept
+            patch :accept
+            patch :confirm
+            patch :to_reject
+            patch :reject
+            patch :cancel
           end
         end
         resources :event_types
@@ -149,7 +156,13 @@ Osem::Application.routes.draw do
           patch '/restart' => 'proposals#restart'
         end
       end
-      resources :tracks, except: :destroy
+      resources :tracks, except: :destroy do
+        member do
+          patch :restart
+          patch :confirm
+          patch :withdraw
+        end
+      end
     end
 
     # TODO: change conference_registrations to singular resource

--- a/db/migrate/20170712120556_add_room_and_dates_to_tracks.rb
+++ b/db/migrate/20170712120556_add_room_and_dates_to_tracks.rb
@@ -1,0 +1,7 @@
+class AddRoomAndDatesToTracks < ActiveRecord::Migration
+  def change
+    add_reference :tracks, :room, index: true, foreign_key: true
+    add_column :tracks, :start_date, :date
+    add_column :tracks, :end_date, :date
+  end
+end

--- a/db/migrate/20170715131706_make_track_state_not_null_and_add_default_value.rb
+++ b/db/migrate/20170715131706_make_track_state_not_null_and_add_default_value.rb
@@ -1,0 +1,14 @@
+class MakeTrackStateNotNullAndAddDefaultValue < ActiveRecord::Migration
+  class TmpTrack < ActiveRecord::Base
+    self.table_name = 'tracks'
+  end
+
+  def change
+    TmpTrack.where(state: nil).each do |track|
+      track.state = 'confirmed'
+      track.save!
+    end
+
+    change_column :tracks, :state, :string, null: false, default: 'new'
+  end
+end

--- a/db/migrate/20170720134353_make_track_cfp_active_not_null.rb
+++ b/db/migrate/20170720134353_make_track_cfp_active_not_null.rb
@@ -1,0 +1,14 @@
+class MakeTrackCfpActiveNotNull < ActiveRecord::Migration
+  class TmpTrack < ActiveRecord::Base
+    self.table_name = 'tracks'
+  end
+
+  def change
+    TmpTrack.where(cfp_active: nil).each do |track|
+      track.cfp_active = true
+      track.save!
+    end
+
+    change_column_null :tracks, :cfp_active, false
+  end
+end

--- a/db/migrate/20170726065629_add_relevance_to_tracks.rb
+++ b/db/migrate/20170726065629_add_relevance_to_tracks.rb
@@ -1,0 +1,5 @@
+class AddRelevanceToTracks < ActiveRecord::Migration
+  def change
+    add_column :tracks, :relevance, :text
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -522,8 +522,12 @@ ActiveRecord::Schema.define(version: 20170807092805) do
     t.string   "state"
     t.boolean  "cfp_active"
     t.integer  "submitter_id"
+    t.integer  "room_id"
+    t.date     "start_date"
+    t.date     "end_date"
   end
 
+  add_index "tracks", ["room_id"], name: "index_tracks_on_room_id"
   add_index "tracks", ["submitter_id"], name: "index_tracks_on_submitter_id"
 
   create_table "users", force: :cascade do |t|

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -511,15 +511,15 @@ ActiveRecord::Schema.define(version: 20170807092805) do
   end
 
   create_table "tracks", force: :cascade do |t|
-    t.string   "guid",         null: false
-    t.string   "name",         null: false
+    t.string   "guid",                         null: false
+    t.string   "name",                         null: false
     t.text     "description"
     t.string   "color"
     t.datetime "created_at"
     t.datetime "updated_at"
     t.integer  "program_id"
-    t.string   "short_name",   null: false
-    t.string   "state"
+    t.string   "short_name",                   null: false
+    t.string   "state",        default: "new", null: false
     t.boolean  "cfp_active"
     t.integer  "submitter_id"
     t.integer  "room_id"

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -520,7 +520,7 @@ ActiveRecord::Schema.define(version: 20170807092805) do
     t.integer  "program_id"
     t.string   "short_name",                   null: false
     t.string   "state",        default: "new", null: false
-    t.boolean  "cfp_active"
+    t.boolean  "cfp_active",                   null: false
     t.integer  "submitter_id"
     t.integer  "room_id"
     t.date     "start_date"

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -525,6 +525,7 @@ ActiveRecord::Schema.define(version: 20170807092805) do
     t.integer  "room_id"
     t.date     "start_date"
     t.date     "end_date"
+    t.text     "relevance"
   end
 
   add_index "tracks", ["room_id"], name: "index_tracks_on_room_id"

--- a/spec/controllers/admin/tracks_controller_spec.rb
+++ b/spec/controllers/admin/tracks_controller_spec.rb
@@ -5,7 +5,7 @@ describe Admin::TracksController do
 
   let(:conference) { create(:conference) }
   let!(:track) { create(:track, program: conference.program, color: '#800080') }
-  let!(:self_organized_track) { create(:track, :self_organized, program: conference.program) }
+  let!(:self_organized_track) { create(:track, :self_organized, program: conference.program, name: 'My awesome track') }
 
   before :each do
     sign_in(admin)
@@ -83,6 +83,7 @@ describe Admin::TracksController do
 
       it 'the new tracks has the correct attributes' do
         expect(assigns(:track).state).to eq 'confirmed'
+        expect(assigns(:track).cfp_active).to eq true
       end
     end
 
@@ -255,6 +256,206 @@ describe Admin::TracksController do
       it 'becomes false' do
         expect(self_organized_track.cfp_active).to eq false
       end
+    end
+  end
+
+  describe 'PATCH #restart' do
+    before :each do
+      self_organized_track.state = 'canceled'
+      self_organized_track.save!
+      patch :restart, conference_id: conference.short_title, id: self_organized_track.short_name
+      self_organized_track.reload
+    end
+
+    it 'assigns the correct track' do
+      expect(assigns(:track)).to eq self_organized_track
+    end
+
+    it 'shows message in flash notice' do
+      expect(flash[:notice]).to eq 'Review for My awesome track started!'
+    end
+
+    it 'changes the track\'s state to new' do
+      expect(self_organized_track.state).to eq 'new'
+    end
+  end
+
+  describe 'PATCH #to_accept' do
+    before :each do
+      patch :to_accept, conference_id: conference.short_title, id: self_organized_track.short_name
+      self_organized_track.reload
+    end
+
+    it 'assigns the correct track' do
+      expect(assigns(:track)).to eq self_organized_track
+    end
+
+    it 'shows message in flash notice' do
+      expect(flash[:notice]).to eq 'Track My awesome track marked as a possible acceptance!'
+    end
+
+    it 'changes the track\'s state to to_accept' do
+      expect(self_organized_track.state).to eq 'to_accept'
+    end
+  end
+
+  describe 'PATCH #accept' do
+    shared_examples 'fails to accept' do |start_date, end_date, room|
+      before :each do
+        self_organized_track.start_date = start_date ? Date.today : nil
+        self_organized_track.end_date = end_date ? Date.today : nil
+        if room
+          conference.venue = create(:venue)
+          self_organized_track.room = create(:room, venue: conference.venue)
+        else
+          self_organized_track.room = nil
+        end
+        self_organized_track.save!
+
+        patch :accept, conference_id: conference.short_title, id: self_organized_track.short_name
+        self_organized_track.reload
+      end
+
+      it 'redirects to Tracks#edit' do
+        expect(response).to redirect_to edit_admin_conference_program_track_path(conference.short_title, self_organized_track)
+      end
+
+      it 'shows message in flash alert' do
+        expect(flash[:alert]).to eq 'Please make sure that the track has a room and start/end dates before accepting it'
+      end
+    end
+
+    context 'has start_date, end_date and room' do
+      before :each do
+        self_organized_track.start_date = Date.today
+        self_organized_track.end_date = Date.today
+        conference.venue = create(:venue)
+        self_organized_track.room = create(:room, venue: conference.venue)
+        self_organized_track.save!
+
+        patch :accept, conference_id: conference.short_title, id: self_organized_track.short_name
+        self_organized_track.reload
+      end
+
+      it 'assigns the correct track' do
+        expect(assigns(:track)).to eq self_organized_track
+      end
+
+      it 'shows message in flash notice' do
+        expect(flash[:notice]).to eq 'Track My awesome track accepted!'
+      end
+
+      it 'changes the track\'s state to accepted' do
+        expect(self_organized_track.state).to eq 'accepted'
+      end
+    end
+
+    context 'has start_date and end_date' do
+      it_behaves_like 'fails to accept', true, true, false
+    end
+
+    context 'has start_date and room' do
+      it_behaves_like 'fails to accept', true, false, true
+    end
+
+    context 'has start_date' do
+      it_behaves_like 'fails to accept', true, false, false
+    end
+
+    context 'has end_date and room' do
+      it_behaves_like 'fails to accept', false, true, true
+    end
+
+    context 'has end_date' do
+      it_behaves_like 'fails to accept', false, true, false
+    end
+
+    context 'has room' do
+      it_behaves_like 'fails to accept', false, false, true
+    end
+
+    context 'has non of start_date, end_date, room' do
+      it_behaves_like 'fails to accept', false, false, false
+    end
+  end
+
+  describe 'PATCH #confirm' do
+    before :each do
+      self_organized_track.state = 'accepted'
+      self_organized_track.save!
+      patch :confirm, conference_id: conference.short_title, id: self_organized_track.short_name
+      self_organized_track.reload
+    end
+
+    it 'assigns the correct track' do
+      expect(assigns(:track)).to eq self_organized_track
+    end
+
+    it 'shows message in flash notice' do
+      expect(flash[:notice]).to eq 'Track My awesome track confirmed!'
+    end
+
+    it 'changes the track\'s state to confirmed' do
+      expect(self_organized_track.state).to eq 'confirmed'
+    end
+  end
+
+  describe 'PATCH #to_reject' do
+    before :each do
+      patch :to_reject, conference_id: conference.short_title, id: self_organized_track.short_name
+      self_organized_track.reload
+    end
+
+    it 'assigns the correct track' do
+      expect(assigns(:track)).to eq self_organized_track
+    end
+
+    it 'shows message in flash notice' do
+      expect(flash[:notice]).to eq 'Track My awesome track marked as a possible rejection!'
+    end
+
+    it 'changes the track\'s state to to_reject' do
+      expect(self_organized_track.state).to eq 'to_reject'
+    end
+  end
+
+  describe 'PATCH #reject' do
+    before :each do
+      patch :reject, conference_id: conference.short_title, id: self_organized_track.short_name
+      self_organized_track.reload
+    end
+
+    it 'assigns the correct track' do
+      expect(assigns(:track)).to eq self_organized_track
+    end
+
+    it 'shows message in flash notice' do
+      expect(flash[:notice]).to eq 'Track My awesome track rejected!'
+    end
+
+    it 'changes the track\'s state to rejected' do
+      expect(self_organized_track.state).to eq 'rejected'
+    end
+  end
+
+  describe 'PATCH #cancel' do
+    before :each do
+      self_organized_track.state = 'confirmed'
+      self_organized_track.save!
+      patch :cancel, conference_id: conference.short_title, id: self_organized_track.short_name
+      self_organized_track.reload
+    end
+
+    it 'assigns the correct track' do
+      expect(assigns(:track)).to eq self_organized_track
+    end
+
+    it 'shows message in flash notice' do
+      expect(flash[:notice]).to eq 'Track My awesome track canceled!'
+    end
+
+    it 'changes the track\'s state to canceled' do
+      expect(self_organized_track.state).to eq 'canceled'
     end
   end
 end

--- a/spec/controllers/admin/tracks_controller_spec.rb
+++ b/spec/controllers/admin/tracks_controller_spec.rb
@@ -80,6 +80,10 @@ describe Admin::TracksController do
       it 'creates new track' do
         expect(Track.find(assigns(:track).id)).to be_a Track
       end
+
+      it 'the new tracks has the correct attributes' do
+        expect(assigns(:track).state).to eq 'confirmed'
+      end
     end
 
     context 'save fails' do

--- a/spec/controllers/admin/tracks_controller_spec.rb
+++ b/spec/controllers/admin/tracks_controller_spec.rb
@@ -228,16 +228,45 @@ describe Admin::TracksController do
       before :each do
         self_organized_track.cfp_active = false
         self_organized_track.save!
-        patch :toggle_cfp_inclusion, conference_id: conference.short_title, id: self_organized_track.short_name
-        self_organized_track.reload
       end
 
-      it 'assigns the correct track' do
-        expect(assigns(:track)).to eq self_organized_track
+      context 'toggles successfully' do
+        before :each do
+          patch :toggle_cfp_inclusion, conference_id: conference.short_title, id: self_organized_track.short_name, format: :js
+          self_organized_track.reload
+        end
+
+        it 'assigns the correct track' do
+          expect(assigns(:track)).to eq self_organized_track
+        end
+
+        it 'shows success message in flash notice' do
+          expect(flash[:notice]).to match('Successfully changed cfp inclusion of My awesome track to true')
+        end
+
+        it 'becomes true' do
+          expect(self_organized_track.cfp_active).to eq true
+        end
       end
 
-      it 'becomes true' do
-        expect(self_organized_track.cfp_active).to eq true
+      context 'save fails' do
+        before :each do
+          allow_any_instance_of(Track).to receive(:save).and_return(false)
+          patch :toggle_cfp_inclusion, conference_id: conference.short_title, id: self_organized_track.short_name, format: :js
+          self_organized_track.reload
+        end
+
+        it 'assigns the correct track' do
+          expect(assigns(:track)).to eq self_organized_track
+        end
+
+        it 'shows error message in flash notice' do
+          expect(flash[:error]).to match('Failed to toggle cfp inclusion of My awesome track to true')
+        end
+
+        it 'stays false' do
+          expect(self_organized_track.cfp_active).to eq false
+        end
       end
     end
 
@@ -245,16 +274,45 @@ describe Admin::TracksController do
       before :each do
         self_organized_track.cfp_active = true
         self_organized_track.save!
-        patch :toggle_cfp_inclusion, conference_id: conference.short_title, id: self_organized_track.short_name
-        self_organized_track.reload
       end
 
-      it 'assigns the correct track' do
-        expect(assigns(:track)).to eq self_organized_track
+      context 'toggles successfully' do
+        before :each do
+          patch :toggle_cfp_inclusion, conference_id: conference.short_title, id: self_organized_track.short_name, format: :js
+          self_organized_track.reload
+        end
+
+        it 'assigns the correct track' do
+          expect(assigns(:track)).to eq self_organized_track
+        end
+
+        it 'shows success message in flash notice' do
+          expect(flash[:notice]).to match('Successfully changed cfp inclusion of My awesome track to false')
+        end
+
+        it 'becomes false' do
+          expect(self_organized_track.cfp_active).to eq false
+        end
       end
 
-      it 'becomes false' do
-        expect(self_organized_track.cfp_active).to eq false
+      context 'save fails' do
+        before :each do
+          allow_any_instance_of(Track).to receive(:save).and_return(false)
+          patch :toggle_cfp_inclusion, conference_id: conference.short_title, id: self_organized_track.short_name, format: :js
+          self_organized_track.reload
+        end
+
+        it 'assigns the correct track' do
+          expect(assigns(:track)).to eq self_organized_track
+        end
+
+        it 'shows error message in flash notice' do
+          expect(flash[:error]).to match('Failed to toggle cfp inclusion of My awesome track to false')
+        end
+
+        it 'stays true' do
+          expect(self_organized_track.cfp_active).to eq true
+        end
       end
     end
   end

--- a/spec/controllers/tracks_controller_spec.rb
+++ b/spec/controllers/tracks_controller_spec.rb
@@ -1,12 +1,11 @@
 require 'spec_helper'
 
 describe TracksController do
-  # A regular user should be used when the track requests have been enabled
   let(:user) { create(:admin) }
 
   let(:conference) { create(:conference) }
   let!(:regular_track) { create(:track, program: conference.program) }
-  let!(:self_organized_track) { create(:track, :self_organized, program: conference.program, submitter: user, color: '#800080') }
+  let!(:self_organized_track) { create(:track, :self_organized, program: conference.program, submitter: user, name: 'My awesome track', color: '#800080') }
 
   before :each do
     sign_in(user)
@@ -174,6 +173,69 @@ describe TracksController do
         self_organized_track.reload
         expect(self_organized_track.color).to eq '#800080'
       end
+    end
+  end
+
+  describe 'PATCH #restart' do
+    before :each do
+      self_organized_track.state = 'withdrawn'
+      self_organized_track.save!
+      patch :restart, conference_id: conference.short_title, id: self_organized_track.short_name
+      self_organized_track.reload
+    end
+
+    it 'assigns the correct track' do
+      expect(assigns(:track)).to eq self_organized_track
+    end
+
+    it 'shows message in flash notice' do
+      expect(flash[:notice]).to eq 'Track My awesome track re-submitted.'
+    end
+
+    it 'changes the track\'s state to new' do
+      expect(self_organized_track.state).to eq 'new'
+    end
+  end
+
+  describe 'PATCH #confirm' do
+    before :each do
+      self_organized_track.state = 'accepted'
+      self_organized_track.save!
+      patch :confirm, conference_id: conference.short_title, id: self_organized_track.short_name
+      self_organized_track.reload
+    end
+
+    it 'assigns the correct track' do
+      expect(assigns(:track)).to eq self_organized_track
+    end
+
+    it 'shows message in flash notice' do
+      expect(flash[:notice]).to eq 'Track My awesome track confirmed.'
+    end
+
+    it 'changes the track\'s state to confirmed' do
+      expect(self_organized_track.state).to eq 'confirmed'
+    end
+  end
+
+  describe 'PATCH #withdraw' do
+    before :each do
+      self_organized_track.state = 'confirmed'
+      self_organized_track.save!
+      patch :withdraw, conference_id: conference.short_title, id: self_organized_track.short_name
+      self_organized_track.reload
+    end
+
+    it 'assigns the correct track' do
+      expect(assigns(:track)).to eq self_organized_track
+    end
+
+    it 'shows message in flash notice' do
+      expect(flash[:notice]).to eq 'Track My awesome track withdrawn.'
+    end
+
+    it 'changes the track\'s state to withdrawn' do
+      expect(self_organized_track.state).to eq 'withdrawn'
     end
   end
 end

--- a/spec/controllers/tracks_controller_spec.rb
+++ b/spec/controllers/tracks_controller_spec.rb
@@ -60,7 +60,7 @@ describe TracksController do
   describe 'POST #create' do
     context 'saves successfuly' do
       before :each do
-        post :create, track: attributes_for(:track, short_name: 'my_track'), conference_id: conference.short_title
+        post :create, track: attributes_for(:track, :self_organized, short_name: 'my_track'), conference_id: conference.short_title
       end
 
       it 'redirects to tracks index path' do
@@ -86,7 +86,7 @@ describe TracksController do
     context 'save fails' do
       before :each do
         allow_any_instance_of(Track).to receive(:save).and_return(false)
-        post :create, track: attributes_for(:track, short_name: 'my_track'), conference_id: conference.short_title
+        post :create, track: attributes_for(:track, :self_organized, short_name: 'my_track'), conference_id: conference.short_title
       end
 
       it 'assigns a new track with the correct conference' do
@@ -126,7 +126,7 @@ describe TracksController do
   describe 'PATCH #update' do
     context 'updates successfully' do
       before :each do
-        patch :update, track: attributes_for(:track, color: '#FF0000'),
+        patch :update, track: attributes_for(:track, :self_organized, color: '#FF0000'),
                        conference_id: conference.short_title,
                        id: self_organized_track.short_name
       end
@@ -152,7 +152,7 @@ describe TracksController do
     context 'update fails' do
       before :each do
         allow_any_instance_of(Track).to receive(:save).and_return(false)
-        patch :update, track: attributes_for(:track, color: '#FF0000'),
+        patch :update, track: attributes_for(:track, :self_organized, color: '#FF0000'),
                        conference_id: conference.short_title,
                        id: self_organized_track.short_name
       end

--- a/spec/factories/tracks.rb
+++ b/spec/factories/tracks.rb
@@ -15,6 +15,7 @@ FactoryGirl.define do
       start_date { Date.today }
       end_date { Date.today }
       room
+      relevance { Faker::Hipster.paragraph(2) }
     end
   end
 end

--- a/spec/factories/tracks.rb
+++ b/spec/factories/tracks.rb
@@ -4,6 +4,7 @@ FactoryGirl.define do
     description { Faker::Lorem.sentence }
     color { Faker::Color.hex_color }
     short_name { SecureRandom.urlsafe_base64(5) }
+    state 'confirmed'
     program
 
     trait :self_organized do

--- a/spec/factories/tracks.rb
+++ b/spec/factories/tracks.rb
@@ -5,12 +5,16 @@ FactoryGirl.define do
     color { Faker::Color.hex_color }
     short_name { SecureRandom.urlsafe_base64(5) }
     state 'confirmed'
+    cfp_active true
     program
 
     trait :self_organized do
       association :submitter, factory: :user
       state 'new'
       cfp_active false
+      start_date { Date.today }
+      end_date { Date.today }
+      room
     end
   end
 end

--- a/spec/features/cfp_ability_spec.rb
+++ b/spec/features/cfp_ability_spec.rb
@@ -64,29 +64,51 @@ feature 'Has correct abilities' do
       visit new_admin_conference_program_cfp_path(conference.short_title)
       expect(current_path).to eq(new_admin_conference_program_cfp_path(conference.short_title))
 
-      # Both event and booth exists
+      # Event and booth cfps exist
       cfb = create(:cfp, cfp_type: 'booths', program: conference.program)
       visit new_admin_conference_program_cfp_path(conference.short_title)
-      expect(current_path).to eq root_path
+      expect(current_path).to eq new_admin_conference_program_cfp_path(conference.short_title)
 
       visit edit_admin_conference_program_cfp_path(conference.short_title, conference.program.cfp)
       expect(current_path).to eq(edit_admin_conference_program_cfp_path(conference.short_title, conference.program.cfp))
 
+      # Event, booth, track cfps exist
+      cft = create(:cfp, cfp_type: 'tracks', program: conference.program)
+      visit new_admin_conference_program_cfp_path(conference.short_title)
+      expect(current_path).to eq root_path
+
+      # Booth and track cfps exist
       conference.program.cfp.destroy!
       visit new_admin_conference_program_cfp_path(conference.short_title)
       expect(current_path).to eq new_admin_conference_program_cfp_path(conference.short_title)
 
       # Only booth exists
+      cft.destroy!
       visit new_admin_conference_program_cfp_path(conference.short_title)
       expect(current_path).to eq(new_admin_conference_program_cfp_path(conference.short_title))
 
       visit edit_admin_conference_program_cfp_path(conference.short_title, cfb)
       expect(current_path). to eq(edit_admin_conference_program_cfp_path(conference.short_title, cfb))
 
+      # No cfp exists
       cfb.destroy
       visit new_admin_conference_program_cfp_path(conference.short_title)
       expect(current_path).to eq(new_admin_conference_program_cfp_path(conference.short_title))
 
+      # Only Tracks cfp exists
+      cft = create(:cfp, cfp_type: 'tracks', program: conference.program)
+      visit new_admin_conference_program_cfp_path(conference.short_title)
+      expect(current_path).to eq new_admin_conference_program_cfp_path(conference.short_title)
+
+      visit edit_admin_conference_program_cfp_path(conference.short_title, cft)
+      expect(current_path).to eq edit_admin_conference_program_cfp_path(conference.short_title, cft)
+
+      # Event and track cfps exist
+      create(:cfp, cfp_type: 'events', program: conference.program)
+      visit new_admin_conference_program_cfp_path(conference.short_title)
+      expect(current_path).to eq new_admin_conference_program_cfp_path(conference.short_title)
+
+      cft.destroy!
       create(:event, program: conference.program)
       visit edit_admin_conference_program_event_path(conference.short_title, conference.program.events.first)
       expect(current_path).to eq(edit_admin_conference_program_event_path(conference.short_title, conference.program.events.first))

--- a/spec/features/cfp_ability_spec.rb
+++ b/spec/features/cfp_ability_spec.rb
@@ -73,7 +73,7 @@ feature 'Has correct abilities' do
       expect(current_path).to eq(edit_admin_conference_program_cfp_path(conference.short_title, conference.program.cfp))
 
       # Event, booth, track cfps exist
-      cft = create(:cfp, cfp_type: 'tracks', program: conference.program)
+      call_for_tracks = create(:cfp, cfp_type: 'tracks', program: conference.program)
       visit new_admin_conference_program_cfp_path(conference.short_title)
       expect(current_path).to eq root_path
 
@@ -83,7 +83,7 @@ feature 'Has correct abilities' do
       expect(current_path).to eq new_admin_conference_program_cfp_path(conference.short_title)
 
       # Only booth exists
-      cft.destroy!
+      call_for_tracks.destroy!
       visit new_admin_conference_program_cfp_path(conference.short_title)
       expect(current_path).to eq(new_admin_conference_program_cfp_path(conference.short_title))
 
@@ -96,19 +96,19 @@ feature 'Has correct abilities' do
       expect(current_path).to eq(new_admin_conference_program_cfp_path(conference.short_title))
 
       # Only Tracks cfp exists
-      cft = create(:cfp, cfp_type: 'tracks', program: conference.program)
+      call_for_tracks = create(:cfp, cfp_type: 'tracks', program: conference.program)
       visit new_admin_conference_program_cfp_path(conference.short_title)
       expect(current_path).to eq new_admin_conference_program_cfp_path(conference.short_title)
 
-      visit edit_admin_conference_program_cfp_path(conference.short_title, cft)
-      expect(current_path).to eq edit_admin_conference_program_cfp_path(conference.short_title, cft)
+      visit edit_admin_conference_program_cfp_path(conference.short_title, call_for_tracks)
+      expect(current_path).to eq edit_admin_conference_program_cfp_path(conference.short_title, call_for_tracks)
 
       # Event and track cfps exist
       create(:cfp, cfp_type: 'events', program: conference.program)
       visit new_admin_conference_program_cfp_path(conference.short_title)
       expect(current_path).to eq new_admin_conference_program_cfp_path(conference.short_title)
 
-      cft.destroy!
+      call_for_tracks.destroy!
       create(:event, program: conference.program)
       visit edit_admin_conference_program_event_path(conference.short_title, conference.program.events.first)
       expect(current_path).to eq(edit_admin_conference_program_event_path(conference.short_title, conference.program.events.first))

--- a/spec/features/organization_admin_ability_spec.rb
+++ b/spec/features/organization_admin_ability_spec.rb
@@ -115,7 +115,7 @@ feature 'Has correct abilities' do
       expect(current_path).to eq(edit_admin_conference_program_cfp_path(conference.short_title, conference.program.cfp))
 
       # Event, booth, track cfps exist
-      cft = create(:cfp, cfp_type: 'tracks', program: conference.program)
+      call_for_tracks = create(:cfp, cfp_type: 'tracks', program: conference.program)
       visit new_admin_conference_program_cfp_path(conference.short_title)
       expect(current_path).to eq root_path
 
@@ -125,7 +125,7 @@ feature 'Has correct abilities' do
       expect(current_path).to eq new_admin_conference_program_cfp_path(conference.short_title)
 
       # Only booth exists
-      cft.destroy!
+      call_for_tracks.destroy!
       visit new_admin_conference_program_cfp_path(conference.short_title)
       expect(current_path).to eq(new_admin_conference_program_cfp_path(conference.short_title))
 
@@ -138,19 +138,19 @@ feature 'Has correct abilities' do
       expect(current_path).to eq(new_admin_conference_program_cfp_path(conference.short_title))
 
       # Only Tracks cfp exists
-      cft = create(:cfp, cfp_type: 'tracks', program: conference.program)
+      call_for_tracks = create(:cfp, cfp_type: 'tracks', program: conference.program)
       visit new_admin_conference_program_cfp_path(conference.short_title)
       expect(current_path).to eq new_admin_conference_program_cfp_path(conference.short_title)
 
-      visit edit_admin_conference_program_cfp_path(conference.short_title, cft)
-      expect(current_path).to eq edit_admin_conference_program_cfp_path(conference.short_title, cft)
+      visit edit_admin_conference_program_cfp_path(conference.short_title, call_for_tracks)
+      expect(current_path).to eq edit_admin_conference_program_cfp_path(conference.short_title, call_for_tracks)
 
       # Event and track cfps exist
       create(:cfp, cfp_type: 'events', program: conference.program)
       visit new_admin_conference_program_cfp_path(conference.short_title)
       expect(current_path).to eq new_admin_conference_program_cfp_path(conference.short_title)
 
-      cft.destroy!
+      call_for_tracks.destroy!
       visit admin_conference_program_events_path(conference.short_title)
       expect(current_path).to eq(admin_conference_program_events_path(conference.short_title))
 

--- a/spec/features/organization_admin_ability_spec.rb
+++ b/spec/features/organization_admin_ability_spec.rb
@@ -106,29 +106,51 @@ feature 'Has correct abilities' do
       visit new_admin_conference_program_cfp_path(conference.short_title)
       expect(current_path).to eq(new_admin_conference_program_cfp_path(conference.short_title))
 
-      # Both event and booth exists
+      # Event and booth cfps exist
       cfb = create(:cfp, cfp_type: 'booths', program: conference.program)
       visit new_admin_conference_program_cfp_path(conference.short_title)
-      expect(current_path).to eq root_path
+      expect(current_path).to eq new_admin_conference_program_cfp_path(conference.short_title)
 
       visit edit_admin_conference_program_cfp_path(conference.short_title, conference.program.cfp)
       expect(current_path).to eq(edit_admin_conference_program_cfp_path(conference.short_title, conference.program.cfp))
 
+      # Event, booth, track cfps exist
+      cft = create(:cfp, cfp_type: 'tracks', program: conference.program)
+      visit new_admin_conference_program_cfp_path(conference.short_title)
+      expect(current_path).to eq root_path
+
+      # Booth and track cfps exist
       conference.program.cfp.destroy!
       visit new_admin_conference_program_cfp_path(conference.short_title)
       expect(current_path).to eq new_admin_conference_program_cfp_path(conference.short_title)
 
       # Only booth exists
+      cft.destroy!
       visit new_admin_conference_program_cfp_path(conference.short_title)
       expect(current_path).to eq(new_admin_conference_program_cfp_path(conference.short_title))
 
       visit edit_admin_conference_program_cfp_path(conference.short_title, cfb)
       expect(current_path). to eq(edit_admin_conference_program_cfp_path(conference.short_title, cfb))
 
+      # No cfp exists
       cfb.destroy
       visit new_admin_conference_program_cfp_path(conference.short_title)
       expect(current_path).to eq(new_admin_conference_program_cfp_path(conference.short_title))
 
+      # Only Tracks cfp exists
+      cft = create(:cfp, cfp_type: 'tracks', program: conference.program)
+      visit new_admin_conference_program_cfp_path(conference.short_title)
+      expect(current_path).to eq new_admin_conference_program_cfp_path(conference.short_title)
+
+      visit edit_admin_conference_program_cfp_path(conference.short_title, cft)
+      expect(current_path).to eq edit_admin_conference_program_cfp_path(conference.short_title, cft)
+
+      # Event and track cfps exist
+      create(:cfp, cfp_type: 'events', program: conference.program)
+      visit new_admin_conference_program_cfp_path(conference.short_title)
+      expect(current_path).to eq new_admin_conference_program_cfp_path(conference.short_title)
+
+      cft.destroy!
       visit admin_conference_program_events_path(conference.short_title)
       expect(current_path).to eq(admin_conference_program_events_path(conference.short_title))
 

--- a/spec/features/organizer_ability_spec.rb
+++ b/spec/features/organizer_ability_spec.rb
@@ -112,29 +112,51 @@ feature 'Has correct abilities' do
       visit new_admin_conference_program_cfp_path(conference.short_title)
       expect(current_path).to eq(new_admin_conference_program_cfp_path(conference.short_title))
 
-      # Both event and booth exists
+      # Event and booth cfps exist
       cfb = create(:cfp, cfp_type: 'booths', program: conference.program)
       visit new_admin_conference_program_cfp_path(conference.short_title)
-      expect(current_path).to eq root_path
+      expect(current_path).to eq new_admin_conference_program_cfp_path(conference.short_title)
 
       visit edit_admin_conference_program_cfp_path(conference.short_title, conference.program.cfp)
       expect(current_path).to eq(edit_admin_conference_program_cfp_path(conference.short_title, conference.program.cfp))
 
+      # Event, booth, track cfps exist
+      cft = create(:cfp, cfp_type: 'tracks', program: conference.program)
+      visit new_admin_conference_program_cfp_path(conference.short_title)
+      expect(current_path).to eq root_path
+
+      # Booth and track cfps exist
       conference.program.cfp.destroy!
       visit new_admin_conference_program_cfp_path(conference.short_title)
       expect(current_path).to eq new_admin_conference_program_cfp_path(conference.short_title)
 
       # Only booth exists
+      cft.destroy!
       visit new_admin_conference_program_cfp_path(conference.short_title)
       expect(current_path).to eq(new_admin_conference_program_cfp_path(conference.short_title))
 
       visit edit_admin_conference_program_cfp_path(conference.short_title, cfb)
       expect(current_path). to eq(edit_admin_conference_program_cfp_path(conference.short_title, cfb))
 
+      # No cfp exists
       cfb.destroy
       visit new_admin_conference_program_cfp_path(conference.short_title)
       expect(current_path).to eq(new_admin_conference_program_cfp_path(conference.short_title))
 
+      # Only Tracks cfp exists
+      cft = create(:cfp, cfp_type: 'tracks', program: conference.program)
+      visit new_admin_conference_program_cfp_path(conference.short_title)
+      expect(current_path).to eq new_admin_conference_program_cfp_path(conference.short_title)
+
+      visit edit_admin_conference_program_cfp_path(conference.short_title, cft)
+      expect(current_path).to eq edit_admin_conference_program_cfp_path(conference.short_title, cft)
+
+      # Event and track cfps exist
+      create(:cfp, cfp_type: 'events', program: conference.program)
+      visit new_admin_conference_program_cfp_path(conference.short_title)
+      expect(current_path).to eq new_admin_conference_program_cfp_path(conference.short_title)
+
+      cft.destroy!
       visit admin_conference_program_events_path(conference.short_title)
       expect(current_path).to eq(admin_conference_program_events_path(conference.short_title))
 

--- a/spec/features/organizer_ability_spec.rb
+++ b/spec/features/organizer_ability_spec.rb
@@ -121,7 +121,7 @@ feature 'Has correct abilities' do
       expect(current_path).to eq(edit_admin_conference_program_cfp_path(conference.short_title, conference.program.cfp))
 
       # Event, booth, track cfps exist
-      cft = create(:cfp, cfp_type: 'tracks', program: conference.program)
+      call_for_tracks = create(:cfp, cfp_type: 'tracks', program: conference.program)
       visit new_admin_conference_program_cfp_path(conference.short_title)
       expect(current_path).to eq root_path
 
@@ -131,7 +131,7 @@ feature 'Has correct abilities' do
       expect(current_path).to eq new_admin_conference_program_cfp_path(conference.short_title)
 
       # Only booth exists
-      cft.destroy!
+      call_for_tracks.destroy!
       visit new_admin_conference_program_cfp_path(conference.short_title)
       expect(current_path).to eq(new_admin_conference_program_cfp_path(conference.short_title))
 
@@ -144,19 +144,19 @@ feature 'Has correct abilities' do
       expect(current_path).to eq(new_admin_conference_program_cfp_path(conference.short_title))
 
       # Only Tracks cfp exists
-      cft = create(:cfp, cfp_type: 'tracks', program: conference.program)
+      call_for_tracks = create(:cfp, cfp_type: 'tracks', program: conference.program)
       visit new_admin_conference_program_cfp_path(conference.short_title)
       expect(current_path).to eq new_admin_conference_program_cfp_path(conference.short_title)
 
-      visit edit_admin_conference_program_cfp_path(conference.short_title, cft)
-      expect(current_path).to eq edit_admin_conference_program_cfp_path(conference.short_title, cft)
+      visit edit_admin_conference_program_cfp_path(conference.short_title, call_for_tracks)
+      expect(current_path).to eq edit_admin_conference_program_cfp_path(conference.short_title, call_for_tracks)
 
       # Event and track cfps exist
       create(:cfp, cfp_type: 'events', program: conference.program)
       visit new_admin_conference_program_cfp_path(conference.short_title)
       expect(current_path).to eq new_admin_conference_program_cfp_path(conference.short_title)
 
-      cft.destroy!
+      call_for_tracks.destroy!
       visit admin_conference_program_events_path(conference.short_title)
       expect(current_path).to eq(admin_conference_program_events_path(conference.short_title))
 

--- a/spec/features/track_organizer_ability_spec.rb
+++ b/spec/features/track_organizer_ability_spec.rb
@@ -5,10 +5,10 @@ feature 'Has correct abilities' do
   let(:organization) { create(:organization) }
   let(:conference) { create(:full_conference, organization: organization) }
   let(:self_organized_track) { create(:track, :self_organized, program: conference.program) }
-  let(:role_track_organizer) { Role.find_by(name: 'track_organizer', resource: self_organized_track) }
+  let(:role_track_organizer) { Role.where(name: 'track_organizer', resource: self_organized_track).first_or_create }
   let(:user_track_organizer) { create(:user, role_ids: [role_track_organizer.id]) }
 
-  context 'when user is info desk' do
+  context 'when user is track organizer' do
     before do
       sign_in user_track_organizer
     end

--- a/spec/features/tracks_spec.rb
+++ b/spec/features/tracks_spec.rb
@@ -39,7 +39,7 @@ feature Track do
       within('table#tracks') do
         expect(page.has_content?(track.name)).to be false
         expect(page.has_content?(track.description)).to be false
-        expect(page.assert_selector('tr', count: 1)).to be true
+        expect(page.has_content?('No data available in table')).to eq true
       end
     end
 

--- a/spec/models/ability_spec.rb
+++ b/spec/models/ability_spec.rb
@@ -26,6 +26,7 @@ describe 'User' do
 
     let(:program_with_cfp) { create(:program, :with_cfp) }
     let(:program_without_cfp) { create(:program) }
+    let(:program_with_call_for_tracks) { create(:cfp, cfp_type: 'tracks').program }
     let(:conference_with_open_registration) { create(:conference) }
     let!(:open_registration_period) { create(:registration_period, conference: conference_with_open_registration, start_date: Date.current - 6.days) }
     let(:conference_with_closed_registration) { create(:conference) }
@@ -82,6 +83,10 @@ describe 'User' do
 
       let(:user_event_with_cfp) { create(:event, users: [user], program: program_with_cfp) }
       let(:user_commercial) { create(:commercial, commercialable: user_event_with_cfp) }
+      let(:user_self_organized_track) { create(:track, :self_organized, submitter: user) }
+      let(:accepted_user_self_organized_track) { create(:track, :self_organized, submitter: user, state: 'accepted') }
+      let(:confirmed_user_self_organized_track) { create(:track, :self_organized, submitter: user, state: 'confirmed') }
+      let(:other_self_organized_track) { create(:track, :self_organized) }
 
       it{ should be_able_to(:manage, user) }
 
@@ -114,6 +119,31 @@ describe 'User' do
       it{ should be_able_to(:create, user_event_with_cfp.commercials.new) }
       it{ should be_able_to(:manage, user_commercial) }
       it{ should_not be_able_to(:manage, commercial_event_unconfirmed) }
+
+      it{ should be_able_to(:new, Track.new(program: program_with_call_for_tracks)) }
+      it{ should be_able_to(:create, Track.new(program: program_with_call_for_tracks)) }
+      it{ should_not be_able_to(:new, Track.new(program: program_without_cfp)) }
+      it{ should_not be_able_to(:create, Track.new(program: program_without_cfp)) }
+
+      it{ should be_able_to(:index, user_self_organized_track) }
+      it{ should be_able_to(:show, user_self_organized_track) }
+      it{ should be_able_to(:restart, user_self_organized_track) }
+      it{ should be_able_to(:confirm, user_self_organized_track) }
+      it{ should be_able_to(:withdraw, user_self_organized_track) }
+      it{ should_not be_able_to(:index, other_self_organized_track) }
+      it{ should_not be_able_to(:show, other_self_organized_track) }
+      it{ should_not be_able_to(:restart, other_self_organized_track) }
+      it{ should_not be_able_to(:confirm, other_self_organized_track) }
+      it{ should_not be_able_to(:withdraw, other_self_organized_track) }
+
+      it{ should be_able_to(:edit, user_self_organized_track) }
+      it{ should be_able_to(:update, user_self_organized_track) }
+      it{ should_not be_able_to(:edit, accepted_user_self_organized_track) }
+      it{ should_not be_able_to(:update, accepted_user_self_organized_track) }
+      it{ should_not be_able_to(:edit, confirmed_user_self_organized_track) }
+      it{ should_not be_able_to(:update, confirmed_user_self_organized_track) }
+      it{ should_not be_able_to(:edit, other_self_organized_track) }
+      it{ should_not be_able_to(:update, other_self_organized_track) }
     end
   end
 end

--- a/spec/models/admin_ability_spec.rb
+++ b/spec/models/admin_ability_spec.rb
@@ -79,7 +79,7 @@ describe 'User with admin role' do
       context 'accesses track organizers' do
         before :each do
           other_self_organized_track = create(:track, :self_organized)
-          @other_track_organizer_role = Role.find_by(name: 'track_organizer', resource: other_self_organized_track)
+          @other_track_organizer_role = Role.where(name: 'track_organizer', resource: other_self_organized_track).first_or_create
         end
 
         it{ should_not be_able_to(:toggle_user, @other_track_organizer_role) }
@@ -105,7 +105,7 @@ describe 'User with admin role' do
 
       context 'accesses track organizers' do
         before :each do
-          @track_organizer_role = Role.find_by(name: 'track_organizer', resource: my_self_organized_track)
+          @track_organizer_role = Role.where(name: 'track_organizer', resource: my_self_organized_track).first_or_create
         end
 
         if role_name == 'track_organizer'
@@ -223,7 +223,7 @@ describe 'User with admin role' do
 
       context 'can manage track organizers' do
         before :each do
-          @track_organizer_role = Role.find_by(name: 'track_organizer', resource: my_self_organized_track)
+          @track_organizer_role = Role.where(name: 'track_organizer', resource: my_self_organized_track).first_or_create
         end
 
         it{ should be_able_to(:toggle_user, @track_organizer_role) }
@@ -441,7 +441,8 @@ describe 'User with admin role' do
     end
 
     context 'when user has the role track_organizer' do
-      let(:role) { Role.find_by(name: 'track_organizer', resource: my_self_organized_track) }
+
+      let(:role) { Role.where(name: 'track_organizer', resource: my_self_organized_track).first_or_create }
       let(:user) { create(:user, role_ids: [role.id]) }
       let(:new_track) { build(:track, program: my_conference.program) }
 

--- a/spec/models/admin_ability_spec.rb
+++ b/spec/models/admin_ability_spec.rb
@@ -44,7 +44,7 @@ describe 'User with admin role' do
     let!(:my_event_schedule) { create(:event_schedule, schedule: my_schedule) }
     let!(:other_event_schedule) { create(:event_schedule, schedule: other_schedule) }
 
-    let!(:my_self_organized_track) { create(:track, :self_organized, program: my_conference.program) }
+    let!(:my_self_organized_track) { create(:track, :self_organized, program: my_conference.program, state: 'confirmed') }
 
     context 'user #is_admin?' do
       let(:venue) { my_conference.venue }
@@ -505,6 +505,8 @@ describe 'User with admin role' do
       it{ should be_able_to(:show, my_conference.program) }
       it{ should be_able_to(:update, new_track) }
       it{ should be_able_to(:manage, my_self_organized_track) }
+      it{ should_not be_able_to(:edit, my_self_organized_track) }
+      it{ should_not be_able_to(:update, my_self_organized_track) }
 
       it_behaves_like 'user with any role'
       it_behaves_like 'user with non-organizer role', 'track_organizer'

--- a/spec/models/cfp_spec.rb
+++ b/spec/models/cfp_spec.rb
@@ -5,19 +5,33 @@ describe Cfp do
   let!(:conference) { create(:conference, end_date: Date.today) }
   let!(:cfp) { create(:cfp, start_date: Date.today - 2, end_date: Date.today - 1, program_id: conference.program.id) }
 
-  describe 'scope' do
-    describe '#for_events' do
-      it 'returns the cfp for events' do
-        expect(conference.program.cfps.for_events).to be_a Cfp
-        expect(conference.program.cfps.for_events.cfp_type).to eq('events')
-      end
-    end
-  end
-
   describe 'validations' do
     it { is_expected.to validate_presence_of(:cfp_type) }
     it { is_expected.to validate_inclusion_of(:cfp_type).in_array(Cfp::TYPES) }
     it { is_expected.to validate_uniqueness_of(:cfp_type).scoped_to(:program_id).case_insensitive }
+  end
+
+  describe '.for_events' do
+    it 'returns the cfp for events when it exists' do
+      expect(conference.program.cfps.for_events).to be_a Cfp
+      expect(conference.program.cfps.for_events.cfp_type).to eq('events')
+    end
+
+    it 'returns nil when the cfp for events doesn\'t exist' do
+      conference.program.cfp.destroy
+      expect(conference.program.cfps.for_events).to eq nil
+    end
+  end
+
+  describe '.for_tracks' do
+    it 'returns the cfp for tracks when it exists' do
+      call_for_tracks = create(:cfp, cfp_type: 'tracks', program: conference.program, end_date: Date.today)
+      expect(conference.program.cfps.for_tracks).to eq call_for_tracks
+    end
+
+    it 'returns nil when the cfp for tracks doesn\'t exist' do
+      expect(conference.program.cfps.for_tracks).to eq nil
+    end
   end
 
   describe '#before_end_of_conference' do

--- a/spec/models/conference_spec.rb
+++ b/spec/models/conference_spec.rb
@@ -606,8 +606,8 @@ describe Conference do
   describe 'tracks_distribution' do
     before do
       subject.email_settings = create(:email_settings)
-      @track_one = create(:track, name: 'Track One', color: '#000000')
-      @track_two = create(:track, name: 'Track Two', color: '#ffffff')
+      @track_one = create(:track, name: 'Track One', color: '#000000', program: subject.program)
+      @track_two = create(:track, name: 'Track Two', color: '#ffffff', program: subject.program)
     end
 
     describe '#tracks_distribution' do

--- a/spec/models/event_spec.rb
+++ b/spec/models/event_spec.rb
@@ -96,6 +96,40 @@ describe Event do
         end
       end
     end
+
+    describe '#acceptable_track' do
+      context 'is valid' do
+        it 'when the track belong to the same program, is confirmed and is included in the cfp' do
+          track = create(:track, state: 'confirmed', cfp_active: true, program: conference.program)
+          event = build(:event, program: conference.program, track: track)
+          expect(event.valid?).to eq true
+        end
+      end
+
+      context 'is invalid' do
+        it 'when the track doesn\'t have the same program' do
+          track = create(:track, state: 'confirmed', cfp_active: true)
+          event = build(:event, program: conference.program, track: track)
+          expect(event.valid?).to eq false
+          expect(event.errors[:track]).to eq ['is invalid']
+        end
+
+        it 'when the track is unconfirmed' do
+          track = create(:track, cfp_active: true, program: conference.program)
+          allow(track).to receive(:confirmed?).and_return(false)
+          event = build(:event, program: conference.program, track: track)
+          expect(event.valid?).to eq false
+          expect(event.errors[:track]).to eq ['is invalid']
+        end
+
+        it 'when the track isn\'t included in the cfp' do
+          track = create(:track, state: 'confirmed', cfp_active: false, program: conference.program)
+          event = build(:event, program: conference.program, track: track)
+          expect(event.valid?).to eq false
+          expect(event.errors[:track]).to eq ['is invalid']
+        end
+      end
+    end
   end
 
   describe '#comments_count' do

--- a/spec/models/program_spec.rb
+++ b/spec/models/program_spec.rb
@@ -253,28 +253,34 @@ describe Program do
   end
 
   describe '#remaining_cfp_types' do
-    it 'returns an array with the types for which a cfp doesn\'t exist, when only the Event type does' do
-      expect(program.remaining_cfp_types).to eq(Cfp::TYPES)
+    it 'returns an array without the \'events\' type, when the cfp for events exists' do
       create(:cfp, cfp_type: 'events', program: program)
-      expect(program.remaining_cfp_types).to eq(['booths'])
+      expect(program.remaining_cfp_types).to be_a Array
+      expect(program.remaining_cfp_types.include?('events')).to eq false
     end
 
-    it 'returns an array with the types for which a cfp doesn\'t exist, when only the Booth type does' do
-      expect(program.remaining_cfp_types).to eq(Cfp::TYPES)
+    it 'returns an array without the \'booths\' type, when the cfp for booths exists' do
       create(:cfp, cfp_type: 'booths', program: program)
-      expect(program.remaining_cfp_types).to eq(['events'])
+      expect(program.remaining_cfp_types).to be_a Array
+      expect(program.remaining_cfp_types.include?('booths')).to eq false
     end
 
-    it 'returns an empty array when all the cfp types exist' do
-      expect(program.remaining_cfp_types).to eq(Cfp::TYPES)
+    it 'returns an array without the \'tracks\' type, when the cfp for tracks exists' do
+      create(:cfp, cfp_type: 'tracks', program: program)
+      expect(program.remaining_cfp_types).to be_a Array
+      expect(program.remaining_cfp_types.include?('tracks')).to eq false
+    end
+
+    it 'returns an empty array when cfps for all the types exist' do
       create(:cfp, cfp_type: 'events', program: program)
       create(:cfp, cfp_type: 'booths', program: program)
+      create(:cfp, cfp_type: 'tracks', program: program)
       expect(program.remaining_cfp_types).to eq([])
     end
 
-    it 'returns all the possible cfp types when there is no existed cfp type' do
+    it 'returns all the possible cfp types when there is no cfp' do
       expect(program.remaining_cfp_types).to eq(Cfp::TYPES)
-      expect(program.remaining_cfp_types). to eq(%w[events booths])
+      expect(program.remaining_cfp_types). to eq(%w[events booths tracks])
     end
   end
 end

--- a/spec/models/room_spec.rb
+++ b/spec/models/room_spec.rb
@@ -12,6 +12,7 @@ describe Room do
   describe 'association' do
     it { should belong_to(:venue) }
     it { should have_many(:event_schedules).dependent(:destroy) }
+    it { should have_many(:tracks) }
   end
 
   describe 'callback' do

--- a/spec/models/track_spec.rb
+++ b/spec/models/track_spec.rb
@@ -48,6 +48,22 @@ describe Track do
       it { is_expected.to_not validate_presence_of(:room) }
     end
 
+    context 'when self_organized? returns true' do
+      before :each do
+        allow(subject).to receive(:self_organized?).and_return(true)
+      end
+
+      it { is_expected.to validate_presence_of(:relevance) }
+    end
+
+    context 'when self_organized? returns false' do
+      before :each do
+        allow(subject).to receive(:self_organized?).and_return(false)
+      end
+
+      it { is_expected.to_not validate_presence_of(:relevance) }
+    end
+
     describe '#valid_dates' do
       before :each do
         @conference = create(:conference, start_date: 1.day.ago, end_date: 2.days.from_now)

--- a/spec/models/track_spec.rb
+++ b/spec/models/track_spec.rb
@@ -54,6 +54,7 @@ describe Track do
       end
 
       it { is_expected.to validate_presence_of(:relevance) }
+      it { is_expected.to validate_presence_of(:description) }
     end
 
     context 'when self_organized? returns false' do
@@ -62,6 +63,7 @@ describe Track do
       end
 
       it { is_expected.to_not validate_presence_of(:relevance) }
+      it { is_expected.to_not validate_presence_of(:description) }
     end
 
     describe '#valid_dates' do

--- a/spec/models/track_spec.rb
+++ b/spec/models/track_spec.rb
@@ -120,6 +120,46 @@ describe Track do
     end
   end
 
+  describe 'scope' do
+    describe '#confirmed' do
+      before :each do
+        @program = create(:program)
+      end
+
+      context 'includes' do
+        it 'when track is confirmed' do
+          confirmed_track = create(:track, state: 'confirmed', program: @program)
+          expect(@program.tracks.confirmed.include?(confirmed_track)).to eq true
+        end
+      end
+
+      context 'excludes' do
+        %w[new to_accept accepted to_reject rejected canceled withdrawn].each do |state|
+          it "when track is #{state.humanize}" do
+            unconfirmed_track = create(:track, state: state, program: @program)
+            expect(@program.tracks.confirmed.include?(unconfirmed_track)).to eq false
+          end
+        end
+      end
+    end
+
+    describe '#cfp_active' do
+      before :each do
+        @program = create(:program)
+        @cfp_active_track = create(:track, cfp_active: true, program: @program)
+        @non_cfp_active_track = create(:track, cfp_active: false, program: @program)
+      end
+
+      it 'include tracks with the cfp_active flag enabled' do
+        expect(@program.tracks.cfp_active.include?(@cfp_active_track)).to eq true
+      end
+
+      it 'excludes tracks with the cfp_active flag disabled' do
+        expect(@program.tracks.cfp_active.include?(@non_cfp_active_track)).to eq false
+      end
+    end
+  end
+
   describe '#self_organized?' do
     it 'returns true when it has a submitter' do
       expect(self_organized_track.submitter).to be_a User

--- a/spec/models/track_spec.rb
+++ b/spec/models/track_spec.rb
@@ -8,6 +8,7 @@ describe Track do
   describe 'association' do
     it { is_expected.to belong_to(:program) }
     it { is_expected.to belong_to(:submitter).class_name('User') }
+    it { is_expected.to belong_to(:room) }
     it { is_expected.to have_many(:events) }
   end
 
@@ -23,23 +24,99 @@ describe Track do
     it { is_expected.to allow_value('My_track_name').for(:short_name) }
     it { is_expected.to_not allow_value('My track name').for(:short_name) }
     it { is_expected.to validate_uniqueness_of(:short_name).scoped_to(:program_id) }
+    it { is_expected.to validate_presence_of(:state) }
+    it { is_expected.to validate_inclusion_of(:state).in_array(%w[new to_accept accepted confirmed to_reject rejected canceled withdrawn]) }
+    it { is_expected.to validate_inclusion_of(:cfp_active).in_array([true, false]) }
 
-    context 'when self-organized' do
+    context 'when self_organized_and_accepted_or_confirmed? returns true' do
       before :each do
-        allow(subject).to receive(:self_organized?).and_return(true)
+        allow(subject).to receive(:self_organized_and_accepted_or_confirmed?).and_return(true)
       end
 
-      it { is_expected.to validate_presence_of(:state) }
-      it { is_expected.to validate_inclusion_of(:cfp_active).in_array([true, false]) }
+      it { is_expected.to validate_presence_of(:start_date) }
+      it { is_expected.to validate_presence_of(:end_date) }
+      it { is_expected.to validate_presence_of(:room) }
     end
 
-    context 'when regular' do
+    context 'when self_organized_and_accepted_or_confirmed? returns false' do
       before :each do
-        allow(subject).to receive(:self_organized?).and_return(false)
+        allow(subject).to receive(:self_organized_and_accepted_or_confirmed?).and_return(false)
       end
 
-      it { is_expected.to_not validate_presence_of(:state) }
-      it { is_expected.to_not validate_inclusion_of(:cfp_active) }
+      it { is_expected.to_not validate_presence_of(:start_date) }
+      it { is_expected.to_not validate_presence_of(:end_date) }
+      it { is_expected.to_not validate_presence_of(:room) }
+    end
+
+    describe '#valid_dates' do
+      before :each do
+        @conference = create(:conference, start_date: 1.day.ago, end_date: 2.days.from_now)
+      end
+
+      context 'is valid' do
+        it 'when the track\'s start date is before it\'s end date and between the conference start/end dates' do
+          track = build(:track, start_date: Date.today, end_date: Date.tomorrow, program: @conference.program)
+          expect(track.valid?).to eq true
+        end
+      end
+
+      context 'is invalid' do
+        it 'when the track\'s start date is before the conference\'s start date' do
+          track = build(:track, start_date: 2.days.ago, end_date: Date.tomorrow, program: @conference.program)
+          expect(track.valid?).to eq false
+          expect(track.errors[:start_date]).to eq ["can't be before the conference start date (#{1.day.ago.to_date})"]
+        end
+
+        it 'when the track\'s end date is before the conference\'s start date' do
+          track = build(:track, start_date: 3.days.ago, end_date: 2.days.ago, program: @conference.program)
+          expect(track.valid?).to eq false
+          expect(track.errors[:end_date]).to eq ["can't be before the conference start date (#{1.day.ago.to_date})"]
+        end
+
+        it 'when the track\'s start date is after the conference\'s end date' do
+          track = build(:track, start_date: 3.days.from_now, end_date: 4.days.from_now, program: @conference.program)
+          expect(track.valid?).to eq false
+          expect(track.errors[:start_date]).to eq ["can't be after the conference end date (#{2.days.from_now.to_date})"]
+        end
+
+        it 'when the track\'s end date is after the conference\'s end date' do
+          track = build(:track, start_date: Date.today, end_date: 3.days.from_now, program: @conference.program)
+          expect(track.valid?).to eq false
+          expect(track.errors[:end_date]).to eq ["can't be after the conference end date (#{2.days.from_now.to_date})"]
+        end
+
+        it 'when the track\'s start date is after it\'s end date' do
+          track = build(:track, start_date: 1.day.from_now, end_date: 1.day.ago)
+          expect(track.valid?).to eq false
+          expect(track.errors[:start_date]).to eq ['can\'t be after the end date']
+        end
+      end
+    end
+
+    describe '#valid_room' do
+      before :each do
+        @conference = create(:conference)
+        @conference.venue = create(:venue, name: 'The venue')
+      end
+
+      context 'is valid' do
+        it 'when the track\'s room belongs to the venue of the conference' do
+          room = create(:room, venue: @conference.venue)
+          track = build(:track, :self_organized, state: 'accepted', program: @conference.program, room: room)
+          expect(track.valid?).to eq true
+        end
+      end
+
+      context 'is invalid' do
+        it 'when the track\'s room doesn\'t belong to the venue of the track\'s conference' do
+          other_conference = create(:conference)
+          other_conference.venue = create(:venue)
+          room = create(:room, venue: other_conference.venue)
+          track = build(:track, :self_organized, state: 'accepted', program: @conference.program, room: room)
+          expect(track.valid?).to eq false
+          expect(track.errors[:room]).to eq ['must be a room of The venue']
+        end
+      end
     end
   end
 
@@ -52,6 +129,228 @@ describe Track do
     it 'returns false when it doesn\'t have a submitter' do
       expect(track.submitter).to eq nil
       expect(track.self_organized?).to eq false
+    end
+  end
+
+  describe '#transition_possible?' do
+    shared_examples 'transition_possible?' do |state, transition, expected|
+      it "returns #{expected} for #{transition} event, when the track's state is #{state}}" do
+        my_self_organized_track = create(:track, :self_organized, state: state)
+        expect(my_self_organized_track.transition_possible?(transition.to_sym)).to eq expected
+      end
+    end
+
+    states = [:new, :to_accept, :accepted, :confirmed, :to_reject, :rejected, :canceled, :withdrawn]
+    transitions = [:restart, :to_accept, :accept, :confirm, :to_reject, :reject, :cancel, :withdraw]
+
+    states_transitions = { new: { restart: false, to_accept: true, accept: true, confirm: false, to_reject: true, reject: true, cancel: false, withdraw: true },
+                           to_accept: { restart: false, to_accept: false, accept: true, confirm: false, to_reject: false, reject: false, cancel: true, withdraw: true },
+                           accepted: { restart: false, to_accept: false, accept: false, confirm: true, to_reject: false, reject: false, cancel: true, withdraw: true },
+                           confirmed: { restart: false, to_accept: false, accept: false, confirm: false, to_reject: false, reject: false, cancel: true, withdraw: true },
+                           to_reject: { restart: false, to_accept: false, accept: false, confirm: false, to_reject: false, reject: true, cancel: true, withdraw: true },
+                           rejected: { restart: true, to_accept: false, accept: false, confirm: false, to_reject: false, reject: false, cancel: false, withdraw: false },
+                           canceled: { restart: true, to_accept: false, accept: false, confirm: false, to_reject: false, reject: false, cancel: false, withdraw: false },
+                           withdrawn: { restart: true, to_accept: false, accept: false, confirm: false, to_reject: false, reject: false, cancel: false, withdraw: false } }
+
+    states.each do |state|
+      transitions.each do |transition|
+        it_behaves_like 'transition_possible?', state, transition, states_transitions[state.to_sym][transition.to_sym]
+      end
+    end
+  end
+
+  describe '#assign_role_to_submitter' do
+    before :each do
+      Role.where(name: 'track_organizer', resource: self_organized_track).first_or_create
+      @submitter = self_organized_track.submitter
+    end
+
+    it 'gives the role of the track organizer to the submitter of the track' do
+      expect(@submitter.has_role?(:track_organizer, self_organized_track)).to eq false
+      self_organized_track.assign_role_to_submitter
+      expect(@submitter.has_role?(:track_organizer, self_organized_track)).to eq true
+    end
+
+    it 'is executed when the track is confirmed' do
+      self_organized_track.state = 'accepted'
+      self_organized_track.save!
+      expect(@submitter.has_role?(:track_organizer, self_organized_track)).to eq false
+      self_organized_track.confirm
+      expect(@submitter.has_role?(:track_organizer, self_organized_track)).to eq true
+    end
+  end
+
+  describe '#revoke_role_and_cleanup' do
+    before :each do
+      Role.where(name: 'track_organizer', resource: self_organized_track).first_or_create
+      @a_track_organizer = create(:user)
+      self_organized_track.state = 'confirmed'
+      self_organized_track.cfp_active = true
+      self_organized_track.save!
+      @a_track_organizer.add_role 'track_organizer', self_organized_track
+      @an_event_of_the_track = create(:event, program: self_organized_track.program, track: self_organized_track)
+    end
+
+    it 'revokes the role of the track organizer' do
+      expect(@a_track_organizer.has_role?(:track_organizer, self_organized_track)).to eq true
+      self_organized_track.revoke_role_and_cleanup
+      expect(@a_track_organizer.has_role?(:track_organizer, self_organized_track)).to eq false
+    end
+
+    it 'removes the track from the events that have it set' do
+      expect(@an_event_of_the_track.track).to eq self_organized_track
+      self_organized_track.revoke_role_and_cleanup
+      @an_event_of_the_track.reload
+      expect(@an_event_of_the_track.track).to eq nil
+    end
+
+    it 'is executed when the track is canceled' do
+      self_organized_track.state = 'confirmed'
+      self_organized_track.save!
+      self_organized_track.cancel
+      expect(@a_track_organizer.has_role?(:track_organizer, self_organized_track)).to eq false
+      @an_event_of_the_track.reload
+      expect(@an_event_of_the_track.track).to eq nil
+    end
+
+    it 'is executed when the track is withdrawn' do
+      self_organized_track.withdraw
+      expect(@a_track_organizer.has_role?(:track_organizer, self_organized_track)).to eq false
+      @an_event_of_the_track.reload
+      expect(@an_event_of_the_track.track).to eq nil
+    end
+  end
+
+  describe '#accepted?' do
+    context 'returns true' do
+      it 'when the state is "accepted"' do
+        self_organized_track.state = 'accepted'
+        self_organized_track.save!
+        expect(self_organized_track.accepted?).to eq true
+      end
+    end
+
+    context 'returns false' do
+      %w[new to_accept confirmed to_reject rejected canceled withdrawn].each do |state|
+        it "when the state is \"#{state}\"" do
+          self_organized_track.state = state
+          self_organized_track.save!
+          expect(self_organized_track.accepted?).to eq false
+        end
+      end
+    end
+  end
+
+  describe '#confirmed?' do
+    context 'returns true' do
+      it 'when the state is "confirmed"' do
+        self_organized_track.state = 'confirmed'
+        self_organized_track.save!
+        expect(self_organized_track.confirmed?).to eq true
+      end
+    end
+
+    context 'returns false' do
+      %w[new to_accept accepted to_reject rejected canceled withdrawn].each do |state|
+        it "when the state is \"#{state}\"" do
+          self_organized_track.state = state
+          self_organized_track.save!
+          expect(self_organized_track.confirmed?).to eq false
+        end
+      end
+    end
+  end
+
+  # accepted? and confirmed? are mutually exclusive (they can't be both true)
+  describe '#self_organized_and_accepted_or_confirmed?' do
+    context 'returns true' do
+      context 'when self_organized? returns true' do
+        before :each do
+          allow(track).to receive(:self_organized?).and_return(true)
+        end
+
+        context 'accepted? returns true and confirmed? returns false' do
+          before :each do
+            allow(track).to receive(:accepted?).and_return(true)
+            allow(track).to receive(:confirmed?).and_return(false)
+          end
+
+          it { expect(track.self_organized_and_accepted_or_confirmed?).to eq true }
+        end
+
+        context 'accepted? returns false and confirmed? returns true' do
+          before :each do
+            allow(track).to receive(:accepted?).and_return(false)
+            allow(track).to receive(:confirmed?).and_return(true)
+          end
+
+          it { expect(track.self_organized_and_accepted_or_confirmed?).to eq true }
+        end
+      end
+    end
+
+    context 'returns false' do
+      context 'when self_organized? returns true' do
+        before :each do
+          allow(track).to receive(:self_organized?).and_return(true)
+        end
+
+        context 'accepted? returns false and confirmed? returns false' do
+          before :each do
+            allow(track).to receive(:accepted?).and_return(false)
+            allow(track).to receive(:confirmed?).and_return(false)
+          end
+
+          it { expect(track.self_organized_and_accepted_or_confirmed?).to eq false }
+        end
+      end
+
+      context 'when self_organized? returns false' do
+        before :each do
+          allow(track).to receive(:self_organized?).and_return(false)
+        end
+
+        context 'accepted? returns false and confirmed? returns false' do
+          before :each do
+            allow(track).to receive(:accepted?).and_return(false)
+            allow(track).to receive(:confirmed?).and_return(false)
+          end
+
+          it { expect(track.self_organized_and_accepted_or_confirmed?).to eq false }
+        end
+
+        context 'accepted? returns true and confirmed? returns false' do
+          before :each do
+            allow(track).to receive(:accepted?).and_return(true)
+            allow(track).to receive(:confirmed?).and_return(false)
+          end
+
+          it { expect(track.self_organized_and_accepted_or_confirmed?).to eq false }
+        end
+
+        context 'accepted? returns false and confirmed? returns true' do
+          before :each do
+            allow(track).to receive(:accepted?).and_return(false)
+            allow(track).to receive(:confirmed?).and_return(true)
+          end
+
+          it { expect(track.self_organized_and_accepted_or_confirmed?).to eq false }
+        end
+      end
+    end
+  end
+
+  describe '#create_organizer_role' do
+    it 'creates the role of the track organizer' do
+      expect(Role.find_by(name: 'track_organizer', resource: self_organized_track)).to eq nil
+      self_organized_track.send(:create_organizer_role)
+      expect(Role.find_by(name: 'track_organizer', resource: self_organized_track).description).to eq 'For the organizers of the Track'
+    end
+
+    it 'is executed when the track is accepted' do
+      expect(Role.find_by(name: 'track_organizer', resource: self_organized_track)).to eq nil
+      self_organized_track.accept
+      expect(Role.find_by(name: 'track_organizer', resource: self_organized_track).description).to eq 'For the organizers of the Track'
     end
   end
 end


### PR DESCRIPTION
* Add finite state machine to the track model and allow the state to be changed
* Make the state column not null and add the default value 'new' to it. Also, the regular tracks are marked as confirmed by default
* Create cfp for tracks and give to signed_in users the ability to create requests for tracks
* Turn the cfp scopes into class methods, because, if the answer is nil then a scope will return all records.
* Require a room and dates for accepted/confirmed self-organized tracks (This will be used for the scheduling later)
* Allow the track submitter to request specific dates for his tracks
* Don't allow the requests for tracks to be deleted
* Don't allow the submitter and the track organizers to edit a request after it has been accepted
* Make the cfp_active column not null and set the value to true if it is nill (the track is an old regular track)
* Restrict track selection in proposals to only the confirmed tracks with the cfp_active flag
* Make the tracks views similar to the proposals views
* Add a new field to the tracks (relevance) so the submitter of a request can explain how it relates to the conference

Important workflow notes:
* When a track request is accepted then the role of the track organizer for that track is created
* When a track is confirmed then the submitter is assigned that role
* When a track is cancelled/withdrawn then that role is revoked from all the users that have it and the track's association with events is removed