### PR TITLE
Use ruby2.3 in vagrant

### DIFF
--- a/bootstrap.sh
+++ b/bootstrap.sh
@@ -2,7 +2,7 @@
 pushd /vagrant
 
 echo -e "\ninstalling required software packages...\n"
-zypper -q -n install update-alternatives ruby2.4-devel make gcc gcc-c++ \
+zypper -q -n install update-alternatives ruby2.3-devel make gcc gcc-c++ \
              libxml2-devel libxslt-devel nodejs screen mariadb \
              libmysqld-devel sqlite3-devel ImageMagick
 
@@ -10,7 +10,7 @@ echo -e "\ndisabling versioned gem binary names...\n"
 echo 'install: --no-format-executable' >> /etc/gemrc
 
 echo -e "\ninstalling bundler...\n"
-gem.ruby2.4 install bundler
+gem.ruby2.3 install bundler
 
 echo -e "\ninstalling your bundle...\n"
 su - vagrant -c "cd /vagrant/; bundle install --quiet"


### PR DESCRIPTION
The package for ruby 2.4 doesn't exist in the repositories of openSUSE 42.2.
Related to #1601