### PR TITLE
Fix vagrant broken after updating to Ruby 2.4

### DIFF
--- a/bootstrap.sh
+++ b/bootstrap.sh
@@ -2,6 +2,8 @@
 pushd /vagrant
 
 echo -e "\ninstalling required software packages...\n"
+zypper -q ar -f http://download.opensuse.org/repositories/devel:/languages:/ruby/openSUSE_Leap_42.2/devel:languages:ruby.repo
+zypper -q --gpg-auto-import-keys --non-interactive ref
 zypper -q -n install update-alternatives ruby2.4-devel make gcc gcc-c++ \
              libxml2-devel libxslt-devel nodejs screen mariadb \
              libmysqld-devel sqlite3-devel ImageMagick


### PR DESCRIPTION
Ruby got updated in https://github.com/openSUSE/osem/pull/1588, but there was a repo missed, so Ruby 2.4 can be installed in our Vagrant machine. :bowtie: :tada: 

Closes https://github.com/openSUSE/osem/issues/1601