### PR TITLE
Add tests for booth controller

### DIFF
--- a/app/models/booth.rb
+++ b/app/models/booth.rb
@@ -55,7 +55,7 @@ class Booth < ActiveRecord::Base
       transitions to: :rejected, from: [:new, :to_reject]
     end
     event :cancel do
-      transitions to: :canceled, from: [:accepted, :rejected]
+      transitions to: :canceled, from: [:accepted, :rejected, :to_accept, :to_reject]
     end
   end
 

--- a/app/views/admin/booths/_form.html.haml
+++ b/app/views/admin/booths/_form.html.haml
@@ -5,7 +5,7 @@
 .row
   .col-md-8
     = semantic_form_for(@booth,  url: @booth.new_record? ?  admin_conference_booths_path(@conference.short_title) : admin_conference_booth_path(@conference.short_title, @booth.id), html: { multipart: true }) do |f|
-      = f.input :title, as: :string, required: true
+      = f.input :title, as: :string, autofocus: true, required: true
       = f.input :description, input_html: { rows: 5, data: { provide: 'markdown-editable' } }, required: true,
         hint: 'This field becomes public upon request acceptance'
       = f.input :reasoning, input_html: { rows: 5, data: { provide: 'markdown-editable' } }, required: true,

--- a/spec/controllers/admin/booths_controller_spec.rb
+++ b/spec/controllers/admin/booths_controller_spec.rb
@@ -1,0 +1,148 @@
+require 'spec_helper'
+
+describe Admin::BoothsController do
+
+  let(:admin) { create(:admin) }
+  let(:conference) { create(:conference) }
+  let(:booth) { create(:booth, title: 'Title', conference: conference) }
+  let(:admin) { create(:admin) }
+
+  context 'not logged in user' do
+
+    describe 'GET index' do
+      it 'does not render admin/booths#index' do
+        get :index, conference_id: conference.short_title
+        expect(response).to redirect_to(user_session_path)
+      end
+    end
+
+    describe 'GET show' do
+      it 'does not render admin/booths#show' do
+        get :show, id: booth.id, conference_id: conference.short_title
+        expect(response).to redirect_to(user_session_path)
+      end
+    end
+  end
+
+  context 'user is admin' do
+    before :each do
+      sign_in admin
+    end
+
+    describe 'GET index' do
+      before { get :index, conference_id: conference.short_title }
+
+      it 'assigns attributes for booths' do
+        expect(assigns(:booths)).to eq([booth])
+      end
+
+      it 'renders index template' do
+        expect(response).to render_template('index')
+      end
+    end
+
+    describe 'GET new' do
+      before { get :new, conference_id: conference.short_title }
+
+      it 'assigns attributes for booths' do
+        expect(assigns(:booth)).to be_a_new(Booth)
+      end
+
+      it 'renders new template' do
+        expect(response).to render_template('new')
+      end
+    end
+
+    describe 'POST #create' do
+      context 'successfully created' do
+        before { post :create, booth: attributes_for(:booth), conference_id: conference.short_title }
+
+        it 'creates a new booth' do
+          expected = expect do
+            post :create, booth: attributes_for(:booth), conference_id: conference.short_title
+          end
+          expected.to change { Booth.count }.by(1)
+        end
+
+        it 'redirects to admin booth index' do
+          expect(response).to redirect_to(admin_conference_booths_path)
+        end
+
+        it 'has responsibles' do
+          expect(booth.responsibles.count).to_not eq(0)
+        end
+
+        it 'shows success message' do
+          expect(flash[:notice]).to match('Booth successfully created.')
+        end
+      end
+
+      context 'create action fails' do
+        before { post :create, booth: attributes_for(:booth, title: ''), conference_id: conference.short_title }
+
+        it 'does not create any record' do
+          expected = expect do
+            post :create, booth: attributes_for(:booth, title: ''), conference_id: conference.short_title
+          end
+          expected.to_not change(Booth, :count)
+        end
+
+        it 'redirects to new' do
+          expect(response).to render_template('new')
+        end
+
+        it 'shows flash message' do
+          expect(flash[:error]).to eq("Creating booth failed. Title can't be blank.")
+        end
+      end
+    end
+
+    describe 'GET #edit' do
+      before { get :edit, id: booth.id, conference_id: conference.short_title }
+
+      it 'renders edit template' do
+        expect(response).to render_template('edit')
+      end
+
+      it 'assigns booth variable' do
+        expect(assigns(:booth)).to eq booth
+      end
+    end
+
+    describe 'PATCH #update' do
+      context 'updates suchessfully' do
+        before { patch :update, id: booth.id, booth: attributes_for(:booth, title: 'different'), conference_id: conference.short_title }
+        it 'redirects to admin booth index path' do
+          expect(response).to redirect_to admin_conference_booths_path
+        end
+
+        it 'shows success message' do
+          expect(flash[:notice]).to match 'Successfully updated booth.'
+        end
+
+        it 'updates booth' do
+          booth.reload
+          expect(booth.title).to eq('different')
+        end
+      end
+    end
+
+    describe 'DELETE #destroy' do
+      context 'deletes successfully' do
+        before { delete :destroy, id: booth.id, conference_id: conference.short_title }
+
+        it 'booth deleted' do
+          expect(Booth.count).to eq(0)
+        end
+
+        it 'redirects to admin booth index path' do
+          expect(response).to redirect_to(admin_conference_booths_path)
+        end
+
+        it 'show success message' do
+          expect(flash[:notice]).to match('Booth successfully destroyed.')
+        end
+      end
+    end
+  end
+end

--- a/spec/factories/booth_request.rb
+++ b/spec/factories/booth_request.rb
@@ -1,0 +1,8 @@
+FactoryGirl.define do
+  factory :booth_request do
+    booth
+    user
+    role 'responsible'
+
+  end
+end

--- a/spec/factories/booths.rb
+++ b/spec/factories/booths.rb
@@ -8,8 +8,6 @@ FactoryGirl.define do
 
     conference
 
-    after(:build) do |booth|
-      booth.responsibles << create(:user)
-    end
+    responsible_ids { [create(:user).id] }
   end
 end

--- a/spec/models/booth_spec.rb
+++ b/spec/models/booth_spec.rb
@@ -38,8 +38,8 @@ describe 'Booth' do
 
     states_transitions = { new: { restart: false, withdraw: true, accept: true, to_accept: true, to_reject: true, reject: true, cancel: false },
                            withdrawn: { restart: true, withdraw: false, accept: false, to_accept: false, to_reject: false, reject: false, cancel: false },
-                           to_accept: { restart: true, withdraw: true, accept: true, to_accept: false, to_reject: true, reject: false, cancel: false },
-                           to_reject: { restart: true, withdraw: true, accept: false, to_accept: true, to_reject: false, reject: true, cancel: false },
+                           to_accept: { restart: true, withdraw: true, accept: true, to_accept: false, to_reject: true, reject: false, cancel: true },
+                           to_reject: { restart: true, withdraw: true, accept: false, to_accept: true, to_reject: false, reject: true, cancel: true },
                            accepted: { restart: false, withdraw: true, accept: false, to_accept: false, to_reject: false, reject: false, cancel: true },
                            rejected: { restart: false, withdraw: true, accept: false, to_accept: false, to_reject: false, reject: false, cancel: true },
                            canceled: { restart: true, withdraw: false, accept: false, to_accept: false, to_reject: false, reject: false, cancel: false } }


### PR DESCRIPTION
Tests for the Admin::BoothsController. 
It tests the behavior of  #index, #new, #create, #edit, #update and #destroy actions when the user is admin.