### PR TITLE
Route to conference#show for custom domain

### DIFF
--- a/app/controllers/conferences_controller.rb
+++ b/app/controllers/conferences_controller.rb
@@ -2,7 +2,6 @@ class ConferencesController < ApplicationController
   protect_from_forgery with: :null_session
   before_action :respond_to_options
   load_and_authorize_resource find_by: :short_title
-  load_resource :program, through: :conference, singleton: true, except: :index
 
   def index
     @current = Conference.where('end_date >= ?', Date.current).reorder(start_date: :asc)
@@ -10,14 +9,15 @@ class ConferencesController < ApplicationController
   end
 
   def show
-    # have to change "localhost" to ENV['OSEM_HOSTNAME'] in production 
+    # have to change "localhost" to ENV['OSEM_HOSTNAME'] in production
     check_custom_domain if request.host != 'localhost'
+    @program = @conference.program
   end
 
   private
 
   def check_custom_domain
-    @conference = @conference.custom_domain.present? ? Conference.find_by(custom_domain: request.domain) : @conference
+    @conference = @conference.nil? ? Conference.find_by(custom_domain: request.domain) : @conference
   end
 
   def respond_to_options

--- a/app/controllers/conferences_controller.rb
+++ b/app/controllers/conferences_controller.rb
@@ -9,9 +9,16 @@ class ConferencesController < ApplicationController
     @antiquated = @conferences - @current
   end
 
-  def show; end
+  def show
+    # have to change "localhost" to ENV['OSEM_HOSTNAME'] in production 
+    check_custom_domain if request.host != 'localhost'
+  end
 
   private
+
+  def check_custom_domain
+    @conference = @conference.custom_domain.present? ? Conference.find_by(custom_domain: request.domain) : @conference
+  end
 
   def respond_to_options
     respond_to do |format|

--- a/app/controllers/conferences_controller.rb
+++ b/app/controllers/conferences_controller.rb
@@ -1,7 +1,7 @@
 class ConferencesController < ApplicationController
   protect_from_forgery with: :null_session
   before_action :respond_to_options
-  load_and_authorize_resource find_by: :short_title
+  load_and_authorize_resource find_by: :short_title, except: :show
 
   def index
     @current = Conference.where('end_date >= ?', Date.current).reorder(start_date: :asc)
@@ -9,15 +9,19 @@ class ConferencesController < ApplicationController
   end
 
   def show
-    # have to change "localhost" to ENV['OSEM_HOSTNAME'] in production
-    check_custom_domain if request.host != 'localhost'
+    @conference = if params[:id]
+                    Conference.find_by_short_title(params[:id])
+                  else
+                    load_conference_by_domain
+                  end
+    authorize! :show, @conference
     @program = @conference.program
   end
 
   private
 
-  def check_custom_domain
-    @conference = @conference.nil? ? Conference.find_by(custom_domain: request.domain) : @conference
+  def load_conference_by_domain
+    Conference.find_by(custom_domain: request.domain)
   end
 
   def respond_to_options

--- a/config/initializers/domain_constraint.rb
+++ b/config/initializers/domain_constraint.rb
@@ -1,6 +1,6 @@
 class DomainConstraint
   def self.matches?(request)
-  	@domains = Conference.pluck(:custom_domain).compact
-    @domains.include?(request.domain)
+    domains = Conference.where.not(custom_domain: nil).pluck(:custom_domain)
+    domains.include?(request.domain)
   end
 end

--- a/config/initializers/domain_constraint.rb
+++ b/config/initializers/domain_constraint.rb
@@ -1,0 +1,6 @@
+class DomainConstraint
+  def self.matches?(request)
+  	@domains = Conference.pluck(:custom_domain).compact
+    @domains.include?(request.domain)
+  end
+end

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -1,5 +1,9 @@
 Osem::Application.routes.draw do
 
+  constraints DomainConstraint do
+    get '/', to: 'conferences#show'
+  end
+
   if ENV['OSEM_ICHAIN_ENABLED'] == 'true'
     devise_for :users, controllers: { registrations: :registrations }
   else

--- a/db/migrate/20170721184810_add_custom_domain_to_conferences.rb
+++ b/db/migrate/20170721184810_add_custom_domain_to_conferences.rb
@@ -1,0 +1,5 @@
+class AddCustomDomainToConferences < ActiveRecord::Migration
+  def change
+    add_column :conferences, :custom_domain, :string
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -11,10 +11,10 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 20170807092805) do
+ActiveRecord::Schema.define(version: 20170816203325) do
 
   create_table "ahoy_events", force: :cascade do |t|
-    t.integer  "visit_id"
+    t.uuid     "visit_id",   limit: 16
     t.integer  "user_id"
     t.string   "name"
     t.text     "properties"
@@ -127,6 +127,7 @@ ActiveRecord::Schema.define(version: 20170807092805) do
     t.integer  "end_hour",           default: 20
     t.integer  "organization_id"
     t.integer  "ticket_layout",      default: 0
+    t.string   "custom_domain"
     t.integer  "booth_limit",        default: 0
   end
 
@@ -511,10 +512,10 @@ ActiveRecord::Schema.define(version: 20170807092805) do
 
   create_table "tickets", force: :cascade do |t|
     t.integer "conference_id"
-    t.string  "title",                          null: false
+    t.string  "title",                               null: false
     t.text    "description"
-    t.integer "price_cents",    default: 0,     null: false
-    t.string  "price_currency", default: "USD", null: false
+    t.integer "price_cents",         default: 0,     null: false
+    t.string  "price_currency",      default: "USD", null: false
     t.boolean "registration_ticket", default: false
   end
 
@@ -572,6 +573,7 @@ ActiveRecord::Schema.define(version: 20170807092805) do
     t.boolean  "is_admin",               default: false
     t.string   "username"
     t.boolean  "is_disabled",            default: false
+    t.string   "token"
   end
 
   add_index "users", ["confirmation_token"], name: "index_users_on_confirmation_token", unique: true

--- a/spec/controllers/conferences_controller_spec.rb
+++ b/spec/controllers/conferences_controller_spec.rb
@@ -23,6 +23,15 @@ describe ConferencesController do
         get :show, id: conference.short_title
         expect(response).to render_template :show
       end
+
+      it 'assigns correct conference from a custom domain' do
+        conference.update_attribute(:custom_domain, 'lvh.me')
+        @request.host = 'lvh.me'
+
+        get :show
+        expect(response).to render_template :show
+        expect(assigns(:conference)).to eq conference
+      end
     end
   end
 

--- a/spec/controllers/conferences_controller_spec.rb
+++ b/spec/controllers/conferences_controller_spec.rb
@@ -23,12 +23,17 @@ describe ConferencesController do
         get :show, id: conference.short_title
         expect(response).to render_template :show
       end
+    end
 
-      it 'assigns correct conference from a custom domain' do
+    context 'accessing conference via custom domain' do
+      before do
         conference.update_attribute(:custom_domain, 'lvh.me')
         @request.host = 'lvh.me'
+      end
 
+      it 'assigns correct conference' do
         get :show
+
         expect(response).to render_template :show
         expect(assigns(:conference)).to eq conference
       end


### PR DESCRIPTION
This PR consists of the following changes:
- a new column _custom_domain_ in _conferences_ table.
- route to point to the correct _splashpage_ of a conference by finding conference by its _custom_domain_. 