### PR TITLE
Add valid email regex to user.rb

### DIFF
--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -64,7 +64,8 @@ class User < ActiveRecord::Base
   scope :admin, -> { where(is_admin: true) }
   scope :active, -> { where(is_disabled: false) }
 
-  validates :email, presence: true
+  VALID_EMAIL_REGEX = /\A([\w+\-].?)+@[a-z\d\-]+(\.[a-z]+)*\.[a-z]+\z/i
+  validates :email, presence: true, format: {with: VALID_EMAIL_REGEX }
 
   validates :username,
             uniqueness: {


### PR DESCRIPTION
Validation on the email is added in user.rb so that invalid emails (example - a@a) will not be accepted.
Fixes issue #1614 