### PR TITLE
Add booths to splashpage

### DIFF
--- a/.haml-lint_todo.yml
+++ b/.haml-lint_todo.yml
@@ -118,6 +118,7 @@ linters:
       - "app/views/conference_registrations/_registration_info.html.haml"
       - "app/views/conference_registrations/_volunteer.html.haml"
       - "app/views/conference_registrations/show.html.haml"
+      - "app/views/conferences/_booths.html.haml"
       - "app/views/conferences/_call_for_paper.html.haml"
       - "app/views/conferences/_conference_details.html.haml"
       - "app/views/conferences/_gallery.html.haml"

--- a/app/controllers/admin/splashpages_controller.rb
+++ b/app/controllers/admin/splashpages_controller.rb
@@ -47,7 +47,8 @@ module Admin
                                          :include_tracks, :include_program, :include_cfp,
                                          :include_venue, :include_registrations,
                                          :include_tickets, :include_lodgings,
-                                         :include_sponsors, :include_social_media)
+                                         :include_sponsors, :include_social_media,
+                                         :include_booths)
     end
   end
 end

--- a/app/models/ability.rb
+++ b/app/models/ability.rb
@@ -75,7 +75,9 @@ class Ability
     can [:new, :create], Payment, user_id: user.id
     can [:index, :show], PhysicalTicket, user: user
 
-    can [:new, :create], Booth
+    can [:new, :create], Booth do |booth|
+      booth.new_record? && booth.conference.program.cfps.for_booths.try(:open?)
+    end
 
     can [:edit, :update, :index, :show], Booth do |booth|
       booth.users.include?(user)

--- a/app/models/booth.rb
+++ b/app/models/booth.rb
@@ -25,6 +25,8 @@ class Booth < ActiveRecord::Base
             :submitter_relationship,
             presence: true
 
+  scope :confirmed, -> { where(state: 'confirmed') }
+
   mount_uploader :picture, PictureUploader, mount_on: :logo_link
 
   state_machine initial: :new do

--- a/app/models/cfp.rb
+++ b/app/models/cfp.rb
@@ -94,6 +94,15 @@ class Cfp < ActiveRecord::Base
     find_by(cfp_type: 'tracks')
   end
 
+  ##
+  # Finds the cfp for booths if it exists
+  #
+  # ====Returns
+  # * +Cfp+ -> The cfp with type 'booths'
+  def self.for_booths
+    find_by(cfp_type: 'booths')
+  end
+
   private
 
   def before_end_of_conference

--- a/app/views/admin/splashpages/_form.html.haml
+++ b/app/views/admin/splashpages/_form.html.haml
@@ -14,6 +14,7 @@
         = f.input :include_tickets, label: 'Display tickets', input_html: { checked: params[:action] == 'new' || @splashpage.try(:include_tickets) }
         = f.input :include_lodgings, label: 'Display the lodgings', input_html: { checked: params[:action] == 'new' || @splashpage.try(:include_lodgings) }
         = f.input :include_sponsors, label: 'Display sponsors', input_html: { checked: params[:action] == 'new' || @splashpage.try(:include_sponsors) }
+        = f.input :include_booths, label: 'Display confirmed booths', input_html: { checked: params[:action] == 'new' || @splashpage.try(:include_booths) }
         = f.input :include_social_media, label: 'Display social media', input_html: { checked: params[:action] == 'new' || @splashpage.try(:include_social_media) }
       = f.inputs name: 'Access' do
         = f.input :public, label: 'Make splash page public?'

--- a/app/views/admin/splashpages/show.html.haml
+++ b/app/views/admin/splashpages/show.html.haml
@@ -67,6 +67,13 @@
           - else
             No
         %dt
+          Include Booths
+        %dd
+          - if @splashpage.include_booths
+            Yes
+          - else
+            No
+        %dt
           Include Social Media:
         %dd
           - if @splashpage.include_social_media

--- a/app/views/conferences/_booths.html.haml
+++ b/app/views/conferences/_booths.html.haml
@@ -1,0 +1,24 @@
+= content_for :splash_nav do
+  %li
+    %a.smoothscroll{ href: '#booths' } Booths
+
+.container
+  .row
+    .col-md-12.text-center
+      %h2 Booths
+  - @conference.booths.confirmed.each_slice(3).with_index do |slice, index_for_row|
+    .row.row-centered
+      - slice.each.with_index do |booth, index_for_column|
+        .col-md-4.col-sm-4.col-xs-10.col-centered.col-top
+          .thumbnail
+            - if booth.logo_link
+              = link_to booth.website_url, class: 'thumbnail' do
+                = image_tag booth.picture.large.url
+            .caption
+              %h3.text-center
+                = booth.title
+              %p.text-center.text-muted
+                = link_to "#show_descrition_#{index_for_row}_#{index_for_column}", "data-toggle"=>"collapse" do
+                  learn more
+              .collapse{ id: "show_descrition_#{index_for_row}_#{index_for_column}" }
+                = markdown(booth.description)

--- a/app/views/conferences/_conference_details.html.haml
+++ b/app/views/conferences/_conference_details.html.haml
@@ -38,6 +38,10 @@
               = link_to "My Proposals", conference_program_proposals_path(conference.short_title), class: 'btn btn-default'
             - elsif can? :new, conference.program.events.new
               = link_to "Submit Proposal", new_conference_program_proposal_path(conference.short_title), class: 'btn btn-default'
+            - if current_user && current_user.booths.where(conference_id: conference.id).count > 0
+              = link_to 'My Booth Requests', conference_booths_path(conference.short_title), class: 'btn btn-default'
+            - elsif can? :new, conference.booths.new
+              = link_to 'Request Booth', new_conference_booth_path(conference.short_title), class: 'btn btn-default'
             - if current_user.nil? || !current_user.subscribed?(conference)
               = link_to 'Subscribe', conference_subscriptions_path(conference.short_title), method: :post, class: 'btn btn-default'
             - else

--- a/app/views/conferences/show.html.haml
+++ b/app/views/conferences/show.html.haml
@@ -65,6 +65,10 @@
       %section#tickets
         = render 'tickets'
 
+    - if @conference.booths.confirmed.any? and @conference.splashpage.include_booths
+      %section#booths
+        = render 'booths'
+
     - if @conference.sponsors.any? and @conference.splashpage.include_sponsors
       %section#sponsors
         = render 'sponsors'

--- a/db/migrate/20170727081731_add_include_booths_to_splashpages.rb
+++ b/db/migrate/20170727081731_add_include_booths_to_splashpages.rb
@@ -1,0 +1,5 @@
+class AddIncludeBoothsToSplashpages < ActiveRecord::Migration
+  def change
+    add_column :splashpages, :include_booths, :boolean
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -451,6 +451,7 @@ ActiveRecord::Schema.define(version: 20170807092805) do
     t.datetime "created_at"
     t.datetime "updated_at"
     t.boolean  "include_cfp",               default: false
+    t.boolean  "include_booths"
   end
 
   create_table "sponsors", force: :cascade do |t|

--- a/spec/controllers/booths_controller_spec.rb
+++ b/spec/controllers/booths_controller_spec.rb
@@ -8,6 +8,7 @@ describe BoothsController do
 
   context 'user is signed in with submitter role' do
     before :each do
+      create(:cfp, program: conference.program, cfp_type: 'booths')
       sign_in booth.submitter
     end
 


### PR DESCRIPTION
Displays confirmed booths at splashpage.
Clicking at the logo redirects to community's website, while clicking at the Title shows booth's description.
