### PR TITLE
Add booth limit 

### DIFF
--- a/.haml-lint_todo.yml
+++ b/.haml-lint_todo.yml
@@ -11,6 +11,8 @@ linters:
   # Offense count: 945
   LineLength:
     exclude:
+      - "app/views/admin/booths/_change_state_dropdown.html.haml"
+      - "app/views/admin/booths/_form.html.haml"
       - "app/views/admin/booths/index.html.haml"
       - "app/views/admin/booths/show.html.haml"
       - "app/views/admin/campaigns/_form.html.haml"

--- a/.rubocop_todo.yml
+++ b/.rubocop_todo.yml
@@ -330,6 +330,8 @@ Metrics/LineLength:
 # Configuration parameters: CountComments.
 Metrics/MethodLength:
   Max: 56
+  Exclude:
+    - 'app/models/admin_ability.rb'
 
 # Offense count: 3
 # Configuration parameters: CountComments.
@@ -443,6 +445,7 @@ Style/HashSyntax:
 # Configuration parameters: MaxLineLength.
 Style/IfUnlessModifier:
   Exclude:
+    - 'app/controllers/admin/booths_controller.rb'
     - 'app/controllers/admin/events_controller.rb'
     - 'app/controllers/api/v1/events_controller.rb'
     - 'app/controllers/conference_registrations_controller.rb'

--- a/app/controllers/admin/booths_controller.rb
+++ b/app/controllers/admin/booths_controller.rb
@@ -47,18 +47,21 @@ module Admin
     end
 
     def accept
-      @booth.accept!
 
-      if @booth.save
-        if @conference.email_settings.send_on_booths_acceptance
-          Mailbot.conference_booths_acceptance_mail(@booth).deliver
+      if can? :accept, @booth
+        @booth.accept!
+
+        if @booth.save
+          if @conference.email_settings.send_on_booths_acceptance
+            Mailbot.conference_booths_acceptance_mail(@booth).deliver
+          end
+          redirect_to admin_conference_booths_path(conference_id: @conference.short_title),
+                      notice: 'Booth successfully accepted!'
+        else
+          redirect_to admin_conference_booths_path(conference_id: @conference.short_title)
+          flash[:error] = "Booth could not be accepted. #{@booth.errors.full_messages.to_sentence}."
         end
-        redirect_to admin_conference_booths_path(conference_id: @conference.short_title),
-                    notice: 'Booth successfully accepted!'
-      else
-        redirect_to admin_conference_booths_path(conference_id: @conference.short_title)
-        flash[:error] = "Booth could not be accepted. #{@booth.errors.full_messages.to_sentence}."
-      end
+      end  
     end
 
     def to_accept

--- a/app/controllers/admin/booths_controller.rb
+++ b/app/controllers/admin/booths_controller.rb
@@ -47,21 +47,18 @@ module Admin
     end
 
     def accept
+      @booth.accept!
 
-      if can? :accept, @booth
-        @booth.accept!
-
-        if @booth.save
-          if @conference.email_settings.send_on_booths_acceptance
-            Mailbot.conference_booths_acceptance_mail(@booth).deliver
-          end
-          redirect_to admin_conference_booths_path(conference_id: @conference.short_title),
-                      notice: 'Booth successfully accepted!'
-        else
-          redirect_to admin_conference_booths_path(conference_id: @conference.short_title)
-          flash[:error] = "Booth could not be accepted. #{@booth.errors.full_messages.to_sentence}."
+      if @booth.save
+        if @conference.email_settings.send_on_booths_acceptance
+          Mailbot.conference_booths_acceptance_mail(@booth).deliver
         end
-      end  
+        redirect_to admin_conference_booths_path(conference_id: @conference.short_title),
+                    notice: 'Booth successfully accepted!'
+      else
+        redirect_to admin_conference_booths_path(conference_id: @conference.short_title)
+        flash[:error] = "Booth could not be accepted. #{@booth.errors.full_messages.to_sentence}."
+      end
     end
 
     def to_accept

--- a/app/controllers/admin/conferences_controller.rb
+++ b/app/controllers/admin/conferences_controller.rb
@@ -211,7 +211,7 @@ module Admin
                                          :vpositions_attributes, :use_volunteers, :color,
                                          :sponsorship_levels_attributes, :sponsors_attributes,
                                          :targets, :targets_attributes,
-                                         :campaigns, :campaigns_attributes, :registration_limit, :organization_id, :ticket_layout)
+                                         :campaigns, :campaigns_attributes, :registration_limit, :organization_id, :ticket_layout, :booth_limit)
     end
   end
 end

--- a/app/models/admin_ability.rb
+++ b/app/models/admin_ability.rb
@@ -74,6 +74,11 @@ class AdminAbility
     cannot :destroy, Track do |track|
       track.self_organized?
     end
+    # Can't accept a booth when booth_limit is reached
+    cannot :accept, Booth do |booth|
+      conference = booth.conference
+      conference.maximum_accepted_booths?
+    end
   end
 
   # Abilities for signed in users with roles

--- a/app/models/booth.rb
+++ b/app/models/booth.rb
@@ -25,6 +25,7 @@ class Booth < ActiveRecord::Base
             :submitter_relationship,
             presence: true
 
+  scope :accepted, -> { where(state: 'accepted') }
   scope :confirmed, -> { where(state: 'confirmed') }
 
   mount_uploader :picture, PictureUploader, mount_on: :logo_link

--- a/app/models/conference.rb
+++ b/app/models/conference.rb
@@ -739,6 +739,15 @@ class Conference < ActiveRecord::Base
   end
 
   ##
+  #
+  # ====Returns
+  # * +True+ -> if accepted booths are equal to the booth limit
+  # * +False+ -> Accepted booths have not reached the booth limit
+  def maximum_accepted_booths?
+    booth_limit > 0 && booths.accepted.count + booths.confirmed.count >= booth_limit
+  end
+
+  ##
   # Return the current conference object to be used in RevisionCount
   #
   # ====Returns

--- a/app/views/admin/booths/_change_state_dropdown.html.haml
+++ b/app/views/admin/booths/_change_state_dropdown.html.haml
@@ -1,13 +1,17 @@
+
 - if booth.transition_possible? :accept
-  - if can? :accept, @booth
+  - if can? :accept, booth
+    - if @conference.booth_limit > 0
+      - confirm_message = ' You are able to accept '+ pluralize(@conference.booth_limit - (@conference.booths.accepted.count + @conference.booths.confirmed.count), 'more booth') + " (booth limit set to #{@conference.booth_limit}). Are you sure you want to accept this one?"
     - if @conference.email_settings.send_on_booths_acceptance
       - link = 'Accept with email'
+      - confirm_message = "By accepting this booth, an email will be sent informing the submitter for the acceptance. You may change the state to \'To accept\' until you are completely sure." + confirm_message
     - else
       - link = 'Accept booth'
     %li= link_to link,
     accept_admin_conference_booth_path(@conference.short_title, booth),
     method: :patch ,id: "accept_booth_#{booth.id}",
-    data: (@conference.booth_limit > 0 ? { confirm: 'You are able to accept '+ pluralize(@conference.booth_limit - @conference.booths.accepted.count, 'more booth') + " (booth limit set to #{@conference.booth_limit}). Are you sure you want to accept this one?" } : nil )
+    data: (confirm_message ? { confirm: confirm_message } : nil)
 
 - if booth.transition_possible? :reject
   - if @conference.email_settings.send_on_booths_rejection
@@ -16,7 +20,8 @@
     - link = 'Reject'
   %li= link_to link,
   reject_admin_conference_booth_path(@conference.short_title, booth),
-  method: :patch, id: "reject_booth_#{booth.id}"
+  method: :patch, id: "reject_booth_#{booth.id}",
+  data: (@conference.email_settings.send_on_booths_rejection ? { confirm: 'By rejecting this booth, an email will be sent informing the submitter about the rejection. You may change the state to \'To reject\' until you are completely sure.'} : nil)
 
 - if booth.transition_possible? :to_reject
   %li= link_to 'To reject booth',

--- a/app/views/admin/booths/_change_state_dropdown.html.haml
+++ b/app/views/admin/booths/_change_state_dropdown.html.haml
@@ -1,11 +1,13 @@
 - if booth.transition_possible? :accept
-  - if @conference.email_settings.send_on_booths_acceptance
-    - link = 'Accept with email'
-  - else
-    - link = 'Accept booth'
-  %li= link_to link,
-  accept_admin_conference_booth_path(@conference.short_title, booth),
-  method: :patch ,id: "accept_booth_#{booth.id}"
+  - if can? :accept, @booth
+    - if @conference.email_settings.send_on_booths_acceptance
+      - link = 'Accept with email'
+    - else
+      - link = 'Accept booth'
+    %li= link_to link,
+    accept_admin_conference_booth_path(@conference.short_title, booth),
+    method: :patch ,id: "accept_booth_#{booth.id}",
+    data: (@conference.booth_limit > 0 ? { confirm: 'You are able to accept '+ pluralize(@conference.booth_limit - @conference.booths.accepted.count, 'more booth') + " (booth limit set to #{@conference.booth_limit}). Are you sure you want to accept this one?" } : nil )
 
 - if booth.transition_possible? :reject
   - if @conference.email_settings.send_on_booths_rejection

--- a/app/views/admin/booths/index.html.haml
+++ b/app/views/admin/booths/index.html.haml
@@ -10,7 +10,6 @@
       %p.text-muted
         All the booth requests
 
-
 .row
   .col-md-12
     %h4
@@ -33,46 +32,45 @@
           (
           = link_to "#{@conference.booth_limit} booths", edit_admin_conference_path(@conference.short_title)
           )
-    .margin-booth-table
-      %table.table.table-striped.table-bordered.table-hover.datatable
-        %thead
-          %th
-            %b ID
-          %th
-            %b Logo
-          %th
-            %b Title
-          %th
-            %b Submitter
-          %th
-            %b Responsibles
-          %th
-            %b State
-          %th
-            %b Actions
-        - @booths.each do |booth|
-          %tr
+    %table.table.table-striped.table-bordered.table-hover.datatable
+      %thead
+        %th
+          %b ID
+        %th
+          %b Logo
+        %th
+          %b Title
+        %th
+          %b Submitter
+        %th
+          %b Responsibles
+        %th
+          %b State
+        %th
+          %b Actions
+      - @booths.each do |booth|
+        %tr
+          %td
+            = booth.id
+          %td
+            - if booth.logo_link
+              = image_tag(booth.picture.thumb.url, width: '20%')
+          %td
+            = link_to booth.title, admin_conference_booth_path(@conference.short_title, booth)
+          %td
+            = link_to booth.submitter.name, admin_user_path(booth.submitter) if booth.submitter
+          %td
+            .responsibles
+              - booth.responsibles.each_with_index do |responsible, i|
+                = link_to responsible.name, admin_user_path(responsible)
+                = ", " unless i == booth.responsibles.length - 1
+          %td
+            .btn-group
+              %button{ type: 'button', class: 'btn btn-link dropdown-toggle', 'data-toggle' => 'dropdown' }
+                = booth.state.humanize
+                %span.caret
+              %ul.dropdown-menu{ role: 'menu' }
+                = render 'change_state_dropdown', booth: booth
             %td
-              = booth.id
-            %td
-              - if booth.logo_link
-                = image_tag(booth.picture.thumb.url, width: '20%')
-            %td
-              = link_to booth.title, admin_conference_booth_path(@conference.short_title, booth)
-            %td
-              = link_to booth.submitter.name, admin_user_path(booth.submitter) if booth.submitter
-            %td
-              .responsibles
-                - booth.responsibles.each_with_index do |responsible, i|
-                  = link_to responsible.name, admin_user_path(responsible)
-                  = ", " unless i == booth.responsibles.length - 1
-            %td
-              .btn-group
-                %button{ type: 'button', class: 'btn btn-link dropdown-toggle', 'data-toggle' => 'dropdown' }
-                  = booth.state.humanize
-                  %span.caret
-                %ul.dropdown-menu{ role: 'menu' }
-                  = render 'change_state_dropdown', booth: booth
-              %td
-                = link_to 'Edit', edit_admin_conference_booth_path(@conference.short_title, booth.id),
-                class: 'btn btn-primary'
+              = link_to 'Edit', edit_admin_conference_booth_path(@conference.short_title, booth.id),
+              class: 'btn btn-primary'

--- a/app/views/admin/booths/index.html.haml
+++ b/app/views/admin/booths/index.html.haml
@@ -9,8 +9,30 @@
             = link_to 'Add Booth', new_admin_conference_booth_path(@conference.short_title), class: 'button btn btn-primary'
       %p.text-muted
         All the booth requests
+
+
 .row
   .col-md-12
+    %h4
+      - if @conference.booth_limit == 0
+        %p
+          Set the
+          = link_to 'Booth limit', edit_admin_conference_path(@conference.short_title)
+          to make sure you are not accepting more booths than you can accommodate.
+      - elsif !@conference.maximum_accepted_booths?
+        %p
+          You cannot accept more than
+          %b
+            = pluralize(@conference.booth_limit, 'booth')
+          (
+          = pluralize(@conference.booths.accepted.count + @conference.booths.confirmed.count, 'accepted booth')
+          so far)
+      - else
+        %p
+          You have reached the maximum number of accepted booths.
+          (
+          = link_to "#{@conference.booth_limit} booths", edit_admin_conference_path(@conference.short_title)
+          )
     .margin-booth-table
       %table.table.table-striped.table-bordered.table-hover.datatable
         %thead

--- a/app/views/admin/conferences/edit.html.haml
+++ b/app/views/admin/conferences/edit.html.haml
@@ -26,4 +26,7 @@
         = f.input :end_hour, input_html: {size: 2, type: 'number', min: 1, max: 24}
       = f.inputs name: 'Registrations' do
         = f.input :registration_limit, as: :number, in: 0..9999, hint: 'Limit the number of registrations to the conference (0 no limit). Please note that the registration limit doesn\'t apply to speakers of confirmed events (they will still be able to register even if it has been reached). You currently have ' + pluralize(@conference.registrations.count, 'registration')
+      = f.inputs name: 'Booths' do
+        = f.input :booth_limit, as: :number, in: 0..9999,
+        hint: 'Booth limit is the maximum number of booths that you can accept for this conference. By setting this number (0 no limit) you can be sure that you are not going to accept more booths than the conference can accommodate. You currently have ' + pluralize(@conference.booths.accepted.count, 'accepted booth') +'.'
       = f.action :submit, as: :button, button_html: {class: 'btn btn-primary'}

--- a/app/views/admin/emails/index.html.haml
+++ b/app/views/admin/emails/index.html.haml
@@ -109,7 +109,7 @@
                 %a.btn.btn-link.control_label.load_template{ 'data-subject-input-id' => 'email_settings_booths_acceptance_subject',
                 'data-subject-text' => 'Your booth has been accepted!',
                 'data-body-input-id' => 'email_settings_booths_acceptance_body',
-                'data-body-text' => "Dear {name},\n\nWe are really pleased to inform you that your booth request {booth_title} has been accepted for the conference {conference}.\nPlease click the confirm button to let us know you can make it as soon as possible!\n\nFeel free to contact us with any questions or concerns.\n\nWe look forward to seeing you there.\n\nBest wishes\n\n{conference} Team"} Load Template
+                'data-body-text' => "Dear {name},\n\nWe are pleased to inform you that your booth request {booth_title} has been accepted for the conference {conference}.\nPlease click the confirm button to let us know you can make it as soon as possible!\n\nFeel free to contact us with any questions or concerns.\n\nWe are looking forward to seeing you there.\n\nBest wishes\n\n{conference} Team"} Load Template
                 %a.btn.btn-link.control_label.template_help_link{ 'data-name' => 'booth_acceptance_help' } Show help
                 =  render partial: 'help', locals: {id: 'booth_acceptance_help', show_event_variables: false}
                 = f.input :send_on_booths_rejection

--- a/db/migrate/20170728182033_add_booth_limit_to_conferences.rb
+++ b/db/migrate/20170728182033_add_booth_limit_to_conferences.rb
@@ -1,0 +1,5 @@
+class AddBoothLimitToConferences < ActiveRecord::Migration
+  def change
+    add_column :conferences, :booth_limit, :integer, default: 0
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -127,6 +127,7 @@ ActiveRecord::Schema.define(version: 20170807092805) do
     t.integer  "end_hour",           default: 20
     t.integer  "organization_id"
     t.integer  "ticket_layout",      default: 0
+    t.integer  "booth_limit",        default: 0
   end
 
   add_index "conferences", ["organization_id"], name: "index_conferences_on_organization_id"


### PR DESCRIPTION
Add column booth_limit to conference so admin won't be able to accept more booth requests than a conference can support. Method `maximum_accepted_booths?` tests whether the accepted booths have reached the booth limit or not.