### PR TITLE
Add emails for accepted and rejected booths

### DIFF
--- a/app/controllers/admin/emails_controller.rb
+++ b/app/controllers/admin/emails_controller.rb
@@ -30,7 +30,9 @@ module Admin
                                              :send_on_conference_registration_dates_updated, :conference_registration_dates_updated_subject, :conference_registration_dates_updated_body,
                                              :send_on_venue_updated, :venue_updated_subject, :venue_updated_body,
                                              :send_on_cfp_dates_updated, :cfp_dates_updated_subject, :cfp_dates_updated_body,
-                                             :send_on_program_schedule_public, :program_schedule_public_subject, :program_schedule_public_body)
+                                             :send_on_program_schedule_public, :program_schedule_public_subject, :program_schedule_public_body,
+                                             :send_on_booths_acceptance, :booths_acceptance_subject, :booths_acceptance_body,
+                                             :send_on_booths_rejection, :booths_rejection_subject, :booths_rejection_body)
     end
   end
 end

--- a/app/mailers/mailbot.rb
+++ b/app/mailers/mailbot.rb
@@ -97,6 +97,24 @@ class Mailbot < ActionMailer::Base
                                                                         conference.email_settings.cfp_dates_updated_body))
   end
 
+  def conference_booths_acceptance_mail(conference, user)
+    mail(to: user.email,
+         from: conference.contact.email,
+         subject: conference.email_settings.booths_acceptance_subject,
+         body: conference.email_settings.generate_email_on_conf_updates(conference,
+                                                                        user,
+                                                                        conference.email_settings.conference_acceptance_body))
+  end
+
+  def conference_booths_rejection_mail(conference, user)
+    mail(to: user.email,
+         from: conference.contact.email,
+         subject: conference.email_settings.booths_rejection_subject,
+         body: conference.email_settings.generate_email_on_conf_updates(conference,
+                                                                        user,
+                                                                        conference.email_settings.conference_rejection_body))
+  end
+
   def event_comment_mail(comment, user)
     @comment = comment
     @event = @comment.commentable

--- a/app/views/admin/emails/_help.html.haml
+++ b/app/views/admin/emails/_help.html.haml
@@ -55,4 +55,7 @@
       %tr
         %td {conference_splash_link}
         %td The link to conference splash page
-
+    - if @conference.booths
+      %tr
+        %td {booth_title}
+        %td Booth's title

--- a/app/views/admin/emails/index.html.haml
+++ b/app/views/admin/emails/index.html.haml
@@ -14,6 +14,8 @@
                 %a{ 'aria-controls' => 'notifications', 'data-toggle' => 'tab', href: '#notifications', role: 'tab' } Update Notifications
               %li{ role: 'presentation' }
                 %a{ 'aria-controls' => 'cfp', 'data-toggle' => 'tab', href: '#cfp', role: 'tab' } Call for Papers
+              %li{ role: 'presentation' }
+                %a{ 'aria-controles' => 'booths', 'data-toggle' => 'tab', href: '#booth', role: 'tab' } Booth
             / Tab panes
             .tab-content
               #onboarding.tab-pane.active{ role: 'tabpanel' }
@@ -100,6 +102,26 @@
                 'data-body-text' => "Dear {name},\n\nThe Conference Call for Papers Details of {conference} has changed.\nNew Dates : {cfp_start_date} - {cfp_end_date}.\n Link to Schedule {schedule_link} \n\nBest wishes\n\n{conference} Team" } Load Template
                 %a.btn.btn-link.control_label.template_help_link{ 'data-name' => 'updated_cfp_help' } Show Help
                 = render partial: 'help', locals: {id: 'updated_cfp_help', show_event_variables: false}
+              #booth.tab-pane{ role: 'tabpanel' }
+                = f.input :send_on_booths_acceptance
+                = f.input :booths_acceptance_subject
+                = f.input :booths_acceptance_body, input_html: { rows:10, cols: 20 }
+                %a.btn.btn-link.control_label.load_template{ 'data-subject-input-id' => 'email_settings_booths_acceptance_subject',
+                'data-subject-text' => 'Your booth request has been accepted!',
+                'data-body-input-id' => 'email_settings_booths_acceptance_body',
+                'data-body-text' => "Dear {name},\n\nWe are really pleased to inform you that your booth request {booth_title} has been accepted for the conference {conference}.\nPlease confirm your booth's state as soon as possible!\n\nFeel free to contact us with any questions or concerns.\n\nWe look forward to seeing you there.\n\nBest wishes\n\n{conference} Team"} Load Template
+                %a.btn.btn-link.control_label.template_help_link{ 'data-name' => 'booth_acceptance_help' } Show help
+                =  render partial: 'help', locals: {id: 'booth_acceptance_help', show_event_variables: false}
+                = f.input :send_on_booths_rejection
+                = f.input :booths_rejection_subject
+                = f.input :booths_rejection_body, input_html: { rows:10, cols:20 }
+                %a.btn.btn-link.control_label.load_template{ 'data-subject-input-id' => 'email_settings_booths_rejection_subject',
+                'data-subject-text' => 'Your booth request has been rejected',
+                'data-body-input-id' => 'email_settings_booths_rejection_body',
+                'data-body-text' => "Dear {name},\n\nThank you for your booth request {booth_title} for the conference {conference}.\n\nUnfortunately, we are sorry to inform you that your request has been rejected.\n\n\nBest wishes\n\n{conference} Team" } Load Template
+                %a.btn.btn-link.control_label.template_help_link{ 'data-name' => 'booth_rejection_help' } Show help
+                =  render partial: 'help', locals: {id: 'booth_rejection_help', show_event_variables: false}
+
       .row
         .col-md-12
           = f.action :submit, as: :button, button_html: { class: 'btn btn-primary' }

--- a/db/migrate/20170731161207_add_booths_to_email_settings.rb
+++ b/db/migrate/20170731161207_add_booths_to_email_settings.rb
@@ -1,0 +1,10 @@
+class AddBoothsToEmailSettings < ActiveRecord::Migration
+  def change
+    add_column :email_settings, :send_on_booths_acceptance, :boolean, default: false
+    add_column :email_settings, :booths_acceptance_subject, :string
+    add_column :email_settings, :booths_acceptance_body, :text
+    add_column :email_settings, :send_on_booths_rejection, :boolean, default: false
+    add_column :email_settings, :booths_rejection_subject, :string
+    add_column :email_settings, :booths_rejection_body, :text
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -11,7 +11,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 20170721001700) do
+ActiveRecord::Schema.define(version: 20170731161207) do
 
   create_table "ahoy_events", force: :cascade do |t|
     t.integer  "visit_id"
@@ -205,6 +205,15 @@ ActiveRecord::Schema.define(version: 20170721001700) do
     t.string   "cfp_dates_updated_subject"
     t.text     "program_schedule_public_body"
     t.text     "cfp_dates_updated_body"
+    t.text     "booths_acceptance_template"
+    t.text     "booths_rejection_template"
+    t.string   "booths_acceptance_subject"
+    t.boolean  "send_on_booths_acceptance",                     default: false
+    t.string   "booths_acceptance_subject"
+    t.text     "booths_acceptance_body"
+    t.boolean  "send_on_booths_rejection",                      default: false
+    t.string   "booths_rejection_subject"
+    t.text     "booths_rejection_body"
   end
 
   create_table "event_schedules", force: :cascade do |t|


### PR DESCRIPTION
Add the option for admin to send emails that will inform submitters about the acceptance or rejection of their booth requests. It extends admin/emails.