### PR TITLE
Add emails for booth's acceptance and rejection

### DIFF
--- a/.haml-lint_todo.yml
+++ b/.haml-lint_todo.yml
@@ -303,6 +303,7 @@ linters:
   SpaceInsideHashAttributes:
     exclude:
       - "app/views/admin/conferences/_todo_list.html.haml"
+      - "app/views/admin/emails/index.html.haml"
       - "app/views/admin/questions/_form.html.haml"
       - "app/views/admin/questions/index.html.haml"
       - "app/views/admin/registrations/index.html.haml"
@@ -403,6 +404,7 @@ linters:
   # Offense count: 14
   ConsecutiveSilentScripts:
     exclude:
+      - "app/views/admin/booths/_change_state_dropdown.html.haml"
       - "app/views/admin/events/index.html.haml"
       - "app/views/admin/schedules/_day_tab.html.haml"
       - "app/views/admin/schedules/_event.html.haml"

--- a/.rubocop_todo.yml
+++ b/.rubocop_todo.yml
@@ -450,6 +450,7 @@ Style/IfUnlessModifier:
     - 'app/helpers/application_helper.rb'
     - 'app/models/commercial.rb'
     - 'app/models/conference.rb'
+    - 'app/models/email_settings.rb'
     - 'app/models/ticket_purchase.rb'
     - 'app/models/user.rb'
     - 'db/migrate/20151031092713_change_conference_id_to_venue_id_in_rooms.rb'

--- a/app/controllers/admin/emails_controller.rb
+++ b/app/controllers/admin/emails_controller.rb
@@ -30,7 +30,9 @@ module Admin
                                              :send_on_conference_registration_dates_updated, :conference_registration_dates_updated_subject, :conference_registration_dates_updated_body,
                                              :send_on_venue_updated, :venue_updated_subject, :venue_updated_body,
                                              :send_on_cfp_dates_updated, :cfp_dates_updated_subject, :cfp_dates_updated_body,
-                                             :send_on_program_schedule_public, :program_schedule_public_subject, :program_schedule_public_body)
+                                             :send_on_program_schedule_public, :program_schedule_public_subject, :program_schedule_public_body,
+                                             :send_on_booths_acceptance, :booths_acceptance_subject, :booths_acceptance_body,
+                                             :send_on_booths_rejection, :booths_rejection_subject, :booths_rejection_body)
     end
   end
 end

--- a/app/mailers/mailbot.rb
+++ b/app/mailers/mailbot.rb
@@ -97,6 +97,24 @@ class Mailbot < ActionMailer::Base
                                                                         conference.email_settings.cfp_dates_updated_body))
   end
 
+  def conference_booths_acceptance_mail(booth)
+    conference = booth.conference
+
+    mail(to: booth.submitter.email,
+         from: conference.contact.email,
+         subject: conference.email_settings.booths_acceptance_subject,
+         body: conference.email_settings.generate_booth_mail(booth, conference.email_settings.booths_acceptance_body))
+  end
+
+  def conference_booths_rejection_mail(booth)
+    conference = booth.conference
+
+    mail(to: booth.submitter.email,
+         from: conference.contact.email,
+         subject: conference.email_settings.booths_rejection_subject,
+         body: conference.email_settings.generate_booth_mail(booth, conference.email_settings.booths_rejection_body))
+  end
+
   def event_comment_mail(comment, user)
     @comment = comment
     @event = @comment.commentable

--- a/app/models/email_settings.rb
+++ b/app/models/email_settings.rb
@@ -3,7 +3,7 @@ class EmailSettings < ActiveRecord::Base
 
   has_paper_trail on: [:update], ignore: [:updated_at], meta: { conference_id: :conference_id }
 
-  def get_values(conference, user, event = nil)
+  def get_values(conference, user, event = nil, booth = nil)
     h = {
       'email' => user.email,
       'name' => user.name,
@@ -45,6 +45,10 @@ class EmailSettings < ActiveRecord::Base
       h['proposalslink'] = Rails.application.routes.url_helpers.conference_program_proposals_url(
                            conference.short_title, host: (ENV['OSEM_HOSTNAME'] || 'localhost:3000'))
     end
+
+    if booth
+      h['booth_title'] = booth.title
+    end
     h
   end
 
@@ -56,6 +60,11 @@ class EmailSettings < ActiveRecord::Base
   def generate_email_on_conf_updates(conference, user, conf_update_template)
     values = get_values(conference, user)
     parse_template(conf_update_template, values)
+  end
+
+  def generate_booth_mail(booth, booth_template)
+    values = get_values(booth.conference, booth.submitter, nil, booth)
+    parse_template(booth_template, values)
   end
 
   private

--- a/app/views/admin/booths/_change_state_dropdown.html.haml
+++ b/app/views/admin/booths/_change_state_dropdown.html.haml
@@ -1,17 +1,25 @@
 - if booth.transition_possible? :accept
-  %li= link_to 'Accept booth',
+  - if @conference.email_settings.send_on_booths_acceptance
+    - link = 'Accept with email'
+  - else
+    - link = 'Accept booth'
+  %li= link_to link,
   accept_admin_conference_booth_path(@conference.short_title, booth),
-  method: :patch, id: "accept_booth_#{booth.id}"
+  method: :patch ,id: "accept_booth_#{booth.id}"
 
 - if booth.transition_possible? :reject
-  %li= link_to 'Reject booth',
+  - if @conference.email_settings.send_on_booths_rejection
+    - link = 'Reject with email'
+  - else
+    - link = 'Reject'
+  %li= link_to link,
   reject_admin_conference_booth_path(@conference.short_title, booth),
-  method: :patch, confirm: 'Are you sure?', id: "reject_booth_#{booth.id}"
+  method: :patch, id: "reject_booth_#{booth.id}"
 
 - if booth.transition_possible? :to_reject
   %li= link_to 'To reject booth',
   to_reject_admin_conference_booth_path(@conference.short_title, booth),
-  method: :patch, confirm: 'Are you sure?', id: "to_reject_booth_#{booth.id}"
+  method: :patch, id: "to_reject_booth_#{booth.id}"
 
 - if booth.transition_possible? :restart
   %li= link_to 'Start review',

--- a/app/views/admin/emails/_help.html.haml
+++ b/app/views/admin/emails/_help.html.haml
@@ -55,4 +55,10 @@
       %tr
         %td {conference_splash_link}
         %td The link to conference splash page
-
+    - if @conference.booths
+      %tr
+        %td {submitter_name}
+        %td Submitter's name
+      %tr
+        %td {booth_title}
+        %td Booth's title

--- a/app/views/admin/emails/index.html.haml
+++ b/app/views/admin/emails/index.html.haml
@@ -14,6 +14,8 @@
                 %a{ 'aria-controls' => 'notifications', 'data-toggle' => 'tab', href: '#notifications', role: 'tab' } Update Notifications
               %li{ role: 'presentation' }
                 %a{ 'aria-controls' => 'cfp', 'data-toggle' => 'tab', href: '#cfp', role: 'tab' } Call for Papers
+              %li{ role: 'presentation' }
+                %a{ 'aria-controls' => 'booths', 'data-toggle' => 'tab', href: '#booth', role: 'tab' } Booth
             / Tab panes
             .tab-content
               #onboarding.tab-pane.active{ role: 'tabpanel' }
@@ -100,6 +102,26 @@
                 'data-body-text' => "Dear {name},\n\nThe Conference Call for Papers Details of {conference} has changed.\nNew Dates : {cfp_start_date} - {cfp_end_date}.\n Link to Schedule {schedule_link} \n\nBest wishes\n\n{conference} Team" } Load Template
                 %a.btn.btn-link.control_label.template_help_link{ 'data-name' => 'updated_cfp_help' } Show Help
                 = render partial: 'help', locals: {id: 'updated_cfp_help', show_event_variables: false}
+              #booth.tab-pane{ role: 'tabpanel' }
+                = f.input :send_on_booths_acceptance
+                = f.input :booths_acceptance_subject
+                = f.input :booths_acceptance_body, input_html: { rows:10, cols: 20 }
+                %a.btn.btn-link.control_label.load_template{ 'data-subject-input-id' => 'email_settings_booths_acceptance_subject',
+                'data-subject-text' => 'Your booth has been accepted!',
+                'data-body-input-id' => 'email_settings_booths_acceptance_body',
+                'data-body-text' => "Dear {name},\n\nWe are really pleased to inform you that your booth request {booth_title} has been accepted for the conference {conference}.\nPlease click the confirm button to let us know you can make it as soon as possible!\n\nFeel free to contact us with any questions or concerns.\n\nWe look forward to seeing you there.\n\nBest wishes\n\n{conference} Team"} Load Template
+                %a.btn.btn-link.control_label.template_help_link{ 'data-name' => 'booth_acceptance_help' } Show help
+                =  render partial: 'help', locals: {id: 'booth_acceptance_help', show_event_variables: false}
+                = f.input :send_on_booths_rejection
+                = f.input :booths_rejection_subject
+                = f.input :booths_rejection_body, input_html: { rows:10, cols:20 }
+                %a.btn.btn-link.control_label.load_template{ 'data-subject-input-id' => 'email_settings_booths_rejection_subject',
+                'data-subject-text' => 'Your booth request has been rejected',
+                'data-body-input-id' => 'email_settings_booths_rejection_body',
+                'data-body-text' => "Dear {name},\n\nThank you for your booth request {booth_title} for the conference {conference}.\n\nUnfortunately, we are sorry to inform you that your request has been rejected.\n\n\nBest wishes\n\n{conference} Team" } Load Template
+                %a.btn.btn-link.control_label.template_help_link{ 'data-name' => 'booth_rejection_help' } Show help
+                =  render partial: 'help', locals: {id: 'booth_rejection_help', show_event_variables: false}
+
       .row
         .col-md-12
           = f.action :submit, as: :button, button_html: { class: 'btn btn-primary' }

--- a/db/migrate/20170731161207_add_booths_to_email_settings.rb
+++ b/db/migrate/20170731161207_add_booths_to_email_settings.rb
@@ -1,0 +1,10 @@
+class AddBoothsToEmailSettings < ActiveRecord::Migration
+  def change
+    add_column :email_settings, :send_on_booths_acceptance, :boolean, default: false
+    add_column :email_settings, :booths_acceptance_subject, :string
+    add_column :email_settings, :booths_acceptance_body, :text
+    add_column :email_settings, :send_on_booths_rejection, :boolean, default: false
+    add_column :email_settings, :booths_rejection_subject, :string
+    add_column :email_settings, :booths_rejection_body, :text
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -205,6 +205,12 @@ ActiveRecord::Schema.define(version: 20170807092805) do
     t.string   "cfp_dates_updated_subject"
     t.text     "program_schedule_public_body"
     t.text     "cfp_dates_updated_body"
+    t.boolean  "send_on_booths_acceptance",                     default: false
+    t.string   "booths_acceptance_subject"
+    t.text     "booths_acceptance_body"
+    t.boolean  "send_on_booths_rejection",                      default: false
+    t.string   "booths_rejection_subject"
+    t.text     "booths_rejection_body"
   end
 
   create_table "event_schedules", force: :cascade do |t|


### PR DESCRIPTION
It extends the possibilities of admin/emails. Admin have the ability to send emails that inform the submitter about the acceptance or rejection of their booth request.