### PR TITLE
Fix the dropdown to get enough bottom padding.

### DIFF
--- a/app/assets/stylesheets/osem-navbar.css.scss
+++ b/app/assets/stylesheets/osem-navbar.css.scss
@@ -29,7 +29,7 @@
         }
     }
     .dropdown-menu {
-        padding: 17px 17px 0px 17px;
+        padding: 17px;
         min-width: 225px;
     }
 }


### PR DESCRIPTION
I don't know why we omitted bottom padding. This change will make the ugly dropdown a little bit neater. Sorry if you are doing this by purpose.

Before | After
-------|------
![image](https://user-images.githubusercontent.com/2545261/28956164-df4979b4-78b0-11e7-8917-ac67e8460875.png) | ![image](https://user-images.githubusercontent.com/2545261/28956150-d0a681f4-78b0-11e7-8888-3e9cb0fe92e4.png)

*(Screenshots may look different in many other styles since they were took in our fork, instead of this original OSEM)*