### PR TITLE
Explicitly add `.pdf` to make it a PDF file.

### DIFF
--- a/app/mailers/mailbot.rb
+++ b/app/mailers/mailbot.rb
@@ -15,7 +15,7 @@ class Mailbot < ActionMailer::Base
 
     PhysicalTicket.last(ticket_purchase.quantity).each do |physical_ticket|
       pdf = TicketPdf.new(@conference, @user, physical_ticket, @conference.ticket_layout.to_sym, "ticket_for_#{@conference.short_title}_#{physical_ticket.id}")
-      attachments["ticket_for_#{@conference.short_title}_#{physical_ticket.id}"] = pdf.render
+      attachments["ticket_for_#{@conference.short_title}_#{physical_ticket.id}.pdf"] = pdf.render
     end
 
     mail(to: @user.email,


### PR DESCRIPTION
Some SMTP providers would treat all files w/o suffix as `.txt`s. This patch would make it work in most cases.