### PR TITLE
Event scheduling for tracks

### DIFF
--- a/.haml-lint_todo.yml
+++ b/.haml-lint_todo.yml
@@ -188,6 +188,7 @@ linters:
       - "app/views/conferences/_call_for_tracks.html.haml"
       - "app/views/admin/tracks/_change_state_dropdown.html.haml"
       - "app/views/proposals/_encouragement_text.html.haml"
+      - "app/views/admin/schedules/_form.html.haml"
 
   # Offense count: 223
   InstanceVariables:
@@ -253,6 +254,7 @@ linters:
       - "app/views/admin/cfps/_tracks_cfp.html.haml"
       - "app/views/conferences/_call_for_tracks.html.haml"
       - "app/views/admin/tracks/_change_state_dropdown.html.haml"
+      - "app/views/admin/schedules/_form.html.haml"
 
   # Offense count: 32
   IdNames:

--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -31,3 +31,4 @@ Metrics/BlockLength:
     - 'spec/models/conference_spec.rb'
     - 'spec/features/ability_spec.rb'
     - 'spec/models/ability_spec.rb'
+    - 'spec/models/admin_ability_spec.rb'

--- a/app/assets/javascripts/osem-schedule.js
+++ b/app/assets/javascripts/osem-schedule.js
@@ -78,11 +78,12 @@ var Schedule = {
 };
 
 $(document).ready( function() {
-  // hide the remove button for unscheduled events
+  // hide the remove button for unscheduled and non schedulable events
   $('.unscheduled-events .schedule-event-delete-button').hide();
+  $('.non_schedulable .schedule-event-delete-button').hide();
 
   // set events as draggable
-  $('.schedule-event').draggable({
+  $('.schedule-event').not('.non_schedulable').draggable({
     snap: '.schedule-room-slot',
     revertDuration: 200,
     revert: function (event, ui) {
@@ -99,7 +100,7 @@ $(document).ready( function() {
   });
 
   // set room cells as droppable
-  $('.schedule-room-slot').droppable({
+  $('.schedule-room-slot').not('.non_schedulable .schedule-room-slot').droppable({
     accept: '.schedule-event',
     tolerance: "pointer",
     drop: function(event, ui) {

--- a/app/assets/stylesheets/osem-schedule.css.scss
+++ b/app/assets/stylesheets/osem-schedule.css.scss
@@ -267,6 +267,10 @@ td.no-padding{
   font-size: 7px;
 }
 
+.non_schedulable{
+  opacity: 0.5;
+}
+
 /* Small devices (tablets, 768px and up) */
 @media (min-width: 768px) {
   .room, .event-title{

--- a/app/controllers/admin/events_controller.rb
+++ b/app/controllers/admin/events_controller.rb
@@ -5,8 +5,6 @@ module Admin
     load_and_authorize_resource :event, through: :program
     load_and_authorize_resource :events_registration, only: :toggle_attendance
 
-    before_action :get_event, except: [:index, :create, :new]
-
     # FIXME: The timezome should only be applied on output, otherwise
     # you get lost in timezone conversions...
     # around_filter :set_timezone_for_this_request
@@ -16,7 +14,6 @@ module Admin
     end
 
     def index
-      @events = @program.events
       @tracks = @program.tracks.confirmed.cfp_active
       @difficulty_levels = @program.difficulty_levels
       @event_types = @program.event_types
@@ -185,16 +182,6 @@ module Admin
 
     def comment_params
       params.require(:comment).permit(:commentable, :body, :user_id)
-    end
-
-    def get_event
-      @event = @conference.program.events.find(params[:id])
-      unless @event
-        redirect_to admin_conference_program_events_path(conference_id: @conference.short_title),
-                    error: 'Error! Could not find event!'
-        return
-      end
-      @event
     end
 
     def update_state(transition, notice, mail = false, subject = false, send_mail = false)

--- a/app/controllers/admin/events_controller.rb
+++ b/app/controllers/admin/events_controller.rb
@@ -4,6 +4,10 @@ module Admin
     load_and_authorize_resource :program, through: :conference, singleton: true
     load_and_authorize_resource :event, through: :program
     load_and_authorize_resource :events_registration, only: :toggle_attendance
+    # For some reason this doesn't work, so a workaround is used
+    # load_and_authorize_resource :track, through: :program, only: [:index, :show, :edit]
+
+    before_action :get_tracks, only: [:index, :show, :edit]
 
     # FIXME: The timezome should only be applied on output, otherwise
     # you get lost in timezone conversions...
@@ -14,7 +18,6 @@ module Admin
     end
 
     def index
-      @tracks = @program.tracks.confirmed.cfp_active
       @difficulty_levels = @program.difficulty_levels
       @event_types = @program.event_types
       @tracks_distribution_confirmed = @conference.tracks_distribution(:confirmed)
@@ -40,7 +43,6 @@ module Admin
     end
 
     def show
-      @tracks = @program.tracks.confirmed.cfp_active
       @event_types = @program.event_types
       @comments = @event.root_comments
       @comment_count = @event.comment_threads.count
@@ -55,7 +57,6 @@ module Admin
 
     def edit
       @event_types = @program.event_types
-      @tracks = @program.tracks.confirmed.cfp_active
       @comments = @event.root_comments
       @comment_count = @event.comment_threads.count
       @user = @event.submitter
@@ -194,6 +195,10 @@ module Admin
         flash[:error] = alert
         return redirect_back_or_to(admin_conference_program_events_path(conference_id: @conference.short_title)) && return
       end
+    end
+
+    def get_tracks
+      @tracks = Track.accessible_by(current_ability).where(program: @program).confirmed.cfp_active
     end
   end
 end

--- a/app/controllers/admin/events_controller.rb
+++ b/app/controllers/admin/events_controller.rb
@@ -198,7 +198,7 @@ module Admin
     end
 
     def get_tracks
-      @tracks = Track.accessible_by(current_ability).where(program: @program).confirmed.cfp_active
+      @tracks = Track.accessible_by(current_ability).where(program: @program).confirmed
     end
   end
 end

--- a/app/controllers/admin/reports_controller.rb
+++ b/app/controllers/admin/reports_controller.rb
@@ -2,9 +2,11 @@ module Admin
   class ReportsController < Admin::BaseController
     load_and_authorize_resource :conference, find_by: :short_title
     load_and_authorize_resource :program, through: :conference, singleton: true
+    # For some reason this doesn't work, so a workaround is used
+    # load_and_authorize_resource :event, through: :program
 
     def index
-      @events = @program.events
+      @events = Event.accessible_by(current_ability).where(program: @program)
       @events_commercials = Commercial.where(commercialable_type: 'Event', commercialable_id: @events.pluck(:id))
       @events_missing_commercial = @events.where.not(id: @events_commercials.pluck(:commercialable_id))
       @events_with_requirements = @events.where.not(description: ['', nil])

--- a/app/controllers/admin/tracks_controller.rb
+++ b/app/controllers/admin/tracks_controller.rb
@@ -101,6 +101,18 @@ module Admin
       update_state(:cancel, "Track #{@track.name} canceled!")
     end
 
+    def update_selected_schedule
+      if @track.update_attributes(params.require(:track).permit(:selected_schedule_id))
+        respond_to do |format|
+          format.js { render json: {} }
+        end
+      else
+        respond_to do |format|
+          format.js { render json: { errors: "The selected schedule couldn't been updated #{@track.errors.to_a.join('. ')}" }, status: 422 }
+        end
+      end
+    end
+
     private
 
     def track_params

--- a/app/controllers/proposals_controller.rb
+++ b/app/controllers/proposals_controller.rb
@@ -49,6 +49,13 @@ class ProposalsController < ApplicationController
     # by default.
     @event.speakers = [current_user]
     @event.submitter = current_user
+
+    if Track.find_by(id: params[:event][:track_id]).try(:cfp_active) == false
+      flash.now[:error] = 'You have selected a track that doesn\'t accept proposals'
+      render action: 'new'
+      return
+    end
+
     if @event.save
       ahoy.track 'Event submission', title: 'New submission'
       redirect_to conference_program_proposals_path(@conference.short_title), notice: 'Proposal was successfully submitted.'
@@ -60,6 +67,12 @@ class ProposalsController < ApplicationController
 
   def update
     @url = conference_program_proposal_path(@conference.short_title, params[:id])
+
+    if Track.find_by(id: params[:event][:track_id]).try(:cfp_active) == false
+      flash.now[:error] = 'You have selected a track that doesn\'t accept proposals'
+      render action: 'edit'
+      return
+    end
 
     if @event.update(event_params)
       redirect_to conference_program_proposals_path(conference_id: @conference.short_title),

--- a/app/controllers/schedules_controller.rb
+++ b/app/controllers/schedules_controller.rb
@@ -24,6 +24,13 @@ class SchedulesController < ApplicationController
     return unless @current_day
     # the schedule takes you to the current time if it is beetween the start and the end time.
     @hour_column = @conference.hours_from_start_time(@conf_start, @conference.end_hour)
+
+    # Ids of the schedules of confrmed self_organized tracks along with the selected_schedule_id
+    @selected_schedules_ids = [@conference.program.selected_schedule_id]
+    @conference.program.tracks.self_organized.confirmed.each do |track|
+      @selected_schedules_ids << track.selected_schedule_id
+    end
+    @selected_schedules_ids.compact!
   end
 
   def events
@@ -32,11 +39,7 @@ class SchedulesController < ApplicationController
     @events_schedules = @program.selected_event_schedules
     @events_schedules = [] unless @events_schedules
 
-    @unscheduled_events = if @program.selected_schedule
-                            @program.events.confirmed - @program.selected_schedule.events
-                          else
-                            @program.events.confirmed
-                          end
+    @unscheduled_events = @program.events.confirmed - @events_schedules.map(&:event)
 
     day = @conference.current_conference_day
     @tag = day.strftime('%Y-%m-%d') if day

--- a/app/helpers/application_helper.rb
+++ b/app/helpers/application_helper.rb
@@ -117,7 +117,7 @@ module ApplicationHelper
 
   def concurrent_events(event)
     return nil unless event.scheduled? && event.program.selected_event_schedules
-    event_schedule = event.program.selected_event_schedules.find_by(event: event)
+    event_schedule = event.program.selected_event_schedules.find { |es| es.event == event }
     other_event_schedules = event.program.selected_event_schedules.reject { |other_event_schedule| other_event_schedule == event_schedule }
     concurrent_events = []
 

--- a/app/models/admin_ability.rb
+++ b/app/models/admin_ability.rb
@@ -298,5 +298,14 @@ class AdminAbility
     can :toggle_user, Role do |role|
       role.resource_type == 'Track' && track_ids_for_track_organizer.include?(role.resource_id)
     end
+
+    # Show Events in the admin sidebar
+    can :update, Event do |event|
+      event.new_record? && conf_ids_for_track_organizer.include?(event.program.conference_id)
+    end
+
+    can :manage, Event, track_id: track_ids_for_track_organizer
+    can :manage, Commercial, commercialable_type: 'Event',
+                             commercialable_id: Event.where(track_id: track_ids_for_track_organizer).pluck(:id)
   end
 end

--- a/app/models/admin_ability.rb
+++ b/app/models/admin_ability.rb
@@ -307,5 +307,18 @@ class AdminAbility
     can :manage, Event, track_id: track_ids_for_track_organizer
     can :manage, Commercial, commercialable_type: 'Event',
                              commercialable_id: Event.where(track_id: track_ids_for_track_organizer).pluck(:id)
+
+    # Show Scheduless in the admin sidebar
+    can :update, Schedule do |schedule|
+      schedule.new_record? && conf_ids_for_track_organizer.include?(schedule.program.conference_id)
+    end
+
+    # Show new track schedule button
+    can :new, Schedule do |schedule|
+      schedule.new_record? && conf_ids_for_track_organizer.include?(schedule.program.conference_id) && schedule.track.try(:new_record?)
+    end
+
+    can :manage, Schedule, track_id: track_ids_for_track_organizer
+    can :manage, EventSchedule, schedule: { track_id: track_ids_for_track_organizer }
   end
 end

--- a/app/models/admin_ability.rb
+++ b/app/models/admin_ability.rb
@@ -39,10 +39,6 @@ class AdminAbility
       event.program.cfp_open? && event.new_record?
     end
 
-    can [:update, :show, :index], Event do |event|
-      event.users.include?(user)
-    end
-
     # can manage the commercials of their own events
     can :manage, Commercial, commercialable_type: 'Event', commercialable_id: user.events.pluck(:id)
 

--- a/app/models/event_schedule.rb
+++ b/app/models/event_schedule.rb
@@ -12,6 +12,8 @@ class EventSchedule < ActiveRecord::Base
   validates :event, uniqueness: { scope: :schedule }
   validate :start_after_end_hour
   validate :start_before_start_hour
+  validate :room_of_track
+  validate :during_track
 
   scope :confirmed, -> { joins(:event).where('state = ?', 'confirmed') }
   scope :canceled, -> { joins(:event).where('state = ?', 'canceled') }
@@ -51,5 +53,27 @@ class EventSchedule < ActiveRecord::Base
 
   def conference_id
     schedule.program.conference_id
+  end
+
+  ##
+  # Validates that the event is scheduled in the same room as it's track
+  #
+  def room_of_track
+    if event && event.track.try(:room) && event.track.room != room
+      errors.add(:room, "must be the same as the track's room (#{event.track.room.name})")
+    end
+  end
+
+  ##
+  # Validates that the event is scheduled within it's track's time slot
+  #
+  def during_track
+    if event && event.track.try(:start_date) && event.track.start_date > start_time
+      errors.add(:start_time, "can't be before the track's start date (#{event.track.start_date})")
+    end
+
+    if event && event.track.try(:end_date) && event.track.end_date + 1.day < end_time
+      errors.add(:end_time, "can't be after the track's end date (#{event.track.end_date})")
+    end
   end
 end

--- a/app/models/program.rb
+++ b/app/models/program.rb
@@ -71,7 +71,11 @@ class Program < ActiveRecord::Base
 
   # Returns all event_schedules for the selected schedule ordered by start_time
   def selected_event_schedules
-    selected_schedule.event_schedules.order(start_time: :asc) if selected_schedule
+    event_schedules = selected_schedule.event_schedules.order(start_time: :asc) if selected_schedule
+    tracks.self_organized.confirmed.order(start_date: :asc).each do |track|
+      event_schedules += track.selected_schedule.event_schedules.order(start_time: :asc) if track.selected_schedule
+    end
+    event_schedules.sort_by(&:start_time) if event_schedules
   end
 
   ##

--- a/app/models/schedule.rb
+++ b/app/models/schedule.rb
@@ -1,5 +1,6 @@
 class Schedule < ActiveRecord::Base
   belongs_to :program
+  belongs_to :track
   has_many :event_schedules, dependent: :destroy
   has_many :events, through: :event_schedules
 

--- a/app/views/admin/schedules/_day_tab.html.haml
+++ b/app/views/admin/schedules/_day_tab.html.haml
@@ -5,7 +5,9 @@
 - date_event_schedules = @event_schedules.select{ |e| e.start_time.to_date.eql? date }
 .row
   - @rooms.each do |room|
-    .col-md-2.col-xs-6
+    - non_schedulable = room.tracks.self_organized.confirmed.any? do |track|
+      - !track.schedules.include?(@schedule) && (track.start_date..track.end_date).include?(date)
+    .col-md-2.col-xs-6{ class: ('non_schedulable' if non_schedulable) }
       .room-name
         - room_date_event_schedules = date_event_schedules.select{ |e| e.room == room }
         = room.name

--- a/app/views/admin/schedules/_event.html.haml
+++ b/app/views/admin/schedules/_event.html.haml
@@ -7,12 +7,13 @@
 / subtracting the padding before calculate the number of lines
 - lines = (height - 7) / 23
 - color = event.track.try(:color).present? ? event.track.try(:color) : 'FFFFFF'
+- non_schedulable = event_schedule_id && (EventSchedule.find(event_schedule_id).schedule != @schedule)
 .schedule-event{ style: "height: #{height}px;  background-color: #{color}; color: #{contrast_color(color)}", |
                  id: "event-#{event.id}", |
                  event_id: event.id, |
                  length: cells_length, |
                  event_schedule_id: event_schedule_id, |
-                 class: ('compact' if compact_grid) }
+                 class: "#{'compact' if compact_grid} #{'non_schedulable' if non_schedulable}" }
   .schedule-event-text{ style: "-webkit-line-clamp: #{lines}; height: #{lines * 23}px;"}
     %span.schedule-event-delete-button{ onclick: "Schedule.remove(\'event-#{event.id}\');" } X
     = event.title

--- a/app/views/admin/schedules/_form.html.haml
+++ b/app/views/admin/schedules/_form.html.haml
@@ -1,0 +1,10 @@
+.row
+  .col-md-12
+    .page-header
+      %h1
+        New Track Schedule
+.row
+  .col-md-12
+    = semantic_form_for @schedule, url: admin_conference_schedules_path(@conference.short_title) do |f|
+      = f.input :track, collection: Track.accessible_by(current_ability).where(program: @program).self_organized.confirmed.pluck(:name, :id), include_blank: false
+      = f.action :submit, as: :button, button_html: { class: 'btn btn-primary' }

--- a/app/views/admin/schedules/index.html.haml
+++ b/app/views/admin/schedules/index.html.haml
@@ -4,42 +4,85 @@
       %h1 Schedules
       %p.text-muted
         The schedules for your conference
-.row
-  .col-md-12
-    %table.table.table-hover#event_types
-      %thead
-        %th Schedule
-        %th Selected
-        %th Actions
-      %tbody
-        - @schedules.each do |schedule|
-          %tr
-            %td
-              Schedule
-              = schedule.id
-            %td
-              = selected_scheduled?(schedule)
-            %td
-              .btn-group{role: "group"}
-                = link_to 'Show', admin_conference_schedule_path(@conference.short_title, schedule.id),
-                method: :get, class: 'btn btn-primary'
-                = link_to 'Delete', admin_conference_schedule_path(@conference.short_title, schedule.id),
-                method: :delete, class: 'btn btn-danger', data: { confirm: "Do you really want to delete Schedule #{schedule.id}?" }
-.row
-  .col-md-12
-    - if @venue.try(:rooms).present?
-      .text-right
-        = link_to 'Add Schedule', admin_conference_schedules_path(@conference.short_title),
-        method: :post, class: 'btn btn-primary'
-    - elsif @venue
-      .h3
-        No Rooms!
-        %small
-          = link_to 'Create rooms', admin_conference_venue_rooms_path
-          before creating the schedule.
-    - else
-      .h3
-        No Venue!
-        %small
-          = link_to 'Create a venue with rooms', new_admin_conference_venue_path
-          before creating the schedule.
+.tabbable
+  %ul.nav.nav-tabs
+    %li.active
+      = link_to 'Conference schedules', '#conference', 'data-toggle' => 'tab'
+    %li
+      = link_to 'Track schedules', '#tracks', 'data-toggle' => 'tab'
+  .tab-content
+    .tab-pane.active#conference
+      .row
+        .col-md-12
+          %table.table.table-hover
+            %thead
+              %th Schedule
+              %th Selected
+              %th Actions
+            %tbody
+              - @schedules.where(track: nil).each do |schedule|
+                %tr
+                  %td
+                    Schedule
+                    = schedule.id
+                  %td
+                    = selected_scheduled?(schedule)
+                  %td
+                    .btn-group{role: "group"}
+                      - if can? :show, schedule
+                        = link_to 'Show', admin_conference_schedule_path(@conference.short_title, schedule),
+                        method: :get, class: 'btn btn-primary'
+                      - if can? :destroy, schedule
+                        = link_to 'Delete', admin_conference_schedule_path(@conference.short_title, schedule),
+                        method: :delete, class: 'btn btn-danger', data: { confirm: "Do you really want to delete Schedule #{schedule.id}?" }
+      .row
+        .col-md-12
+          - if @venue.try(:rooms).present?
+            .text-right
+              - if can? :create, @program.schedules.new
+                = link_to 'Add Schedule', admin_conference_schedules_path(@conference.short_title),
+                method: :post, class: 'btn btn-primary'
+          - elsif @venue
+            .h3
+              No Rooms!
+              %small
+                = link_to 'Create rooms', admin_conference_venue_rooms_path
+                before creating the schedule.
+          - else
+            .h3
+              No Venue!
+              %small
+                = link_to 'Create a venue with rooms', new_admin_conference_venue_path
+                before creating the schedule.
+    .tab-pane#tracks
+      .row
+        .col-md-12
+          %table.table.table-hover
+            %thead
+              %th Schedule
+              %th Track
+              %th Selected
+              %th Actions
+            %tbody
+              - @schedules.where.not(track: nil).each do |schedule|
+                %tr
+                  %td
+                    Schedule
+                    = schedule.id
+                  %td
+                    - track = schedule.track
+                    = link_to track.name, admin_conference_program_track_path(@conference.short_title, track)
+                  %td
+                    = schedule == schedule.track.selected_schedule ? 'Yes' : 'No'
+                  %td
+                    .btn-group{role: "group"}
+                      - if can? :show, schedule
+                        = link_to 'Show', admin_conference_schedule_path(@conference.short_title, schedule), class: 'btn btn-primary'
+                      - if can? :destroy, schedule
+                        = link_to 'Delete', admin_conference_schedule_path(@conference.short_title, schedule),
+                        method: :delete, class: 'btn btn-danger', data: { confirm: "Do you really want to delete Schedule #{schedule.id}?" }
+      .row
+        .col-md-12
+          .text-right
+            - if can? :new, @program.schedules.build(track: @program.tracks.new)
+              = link_to 'Add Track Schedule', new_admin_conference_schedule_path(@conference.short_title), class: 'btn btn-primary'

--- a/app/views/admin/schedules/show.html.haml
+++ b/app/views/admin/schedules/show.html.haml
@@ -11,8 +11,15 @@
   .row
     .col-md-2
       Selected schedule
-      = check_box_tag @conference.short_title, @schedule.id, (@schedule.id == @selected_schedule.try(:id)),
-        method: :patch, url: (admin_conference_program_path(@conference.short_title) + '?[program][selected_schedule_id]='),
+      :ruby
+        if @schedule.track
+          value = @schedule == @schedule.track.selected_schedule
+          url = update_selected_schedule_admin_conference_program_track_path(@conference.short_title, @schedule.track) + '?[track][selected_schedule_id]='
+        else
+          value = @schedule.id == @selected_schedule.try(:id)
+          url = admin_conference_program_path(@conference.short_title) + '?[program][selected_schedule_id]='
+        end
+      = check_box_tag @conference.short_title, @schedule.id, value, method: :patch, url: url,
         class: 'switch-checkbox-schedule', data: { size: 'small',
                                           off_color: 'warning',
                                           on_text: 'Yes',

--- a/app/views/admin/tracks/index.html.haml
+++ b/app/views/admin/tracks/index.html.haml
@@ -63,9 +63,19 @@
               .btn-group{role: "group"}
                 - if can? :edit, track
                   = link_to 'Edit', edit_admin_conference_program_track_path(@conference.short_title, track), class: 'btn btn-primary'
+                  - special_style = true
                 - if can? :destroy, track
                   = link_to 'Delete', admin_conference_program_track_path(@conference.short_title, track), method: :delete, class: 'btn btn-danger',
                   data: { confirm: "Do you really want to delete #{track.name}? Attention: This track will be removed from all Events that have it set" }
+                - if track.self_organized?
+                  - if track.selected_schedule
+                    - if can? :show, track.selected_schedule
+                      = link_to 'Show Schedule', admin_conference_schedule_path(@conference.short_title, track.selected_schedule),
+                      class: 'btn btn-default'
+                  - elsif can? :create, @program.schedules.build(track: track)
+                    = button_to 'Create Schedule', admin_conference_schedules_path(@conference.short_title),
+                    form: { class: 'btn', style: 'padding: 0px 0px; margin-top: -1px;' }, class: 'btn btn-default',
+                    style: ('border-top-left-radius: 0; border-bottom-left-radius: 0;' if special_style), params: { 'schedule[track_id]' => track.id }
 .row
   .col-md-12.text-right
     = link_to 'New Track', new_admin_conference_program_track_path(@conference.short_title), class: 'btn btn-success'

--- a/app/views/admin/tracks/show.html.haml
+++ b/app/views/admin/tracks/show.html.haml
@@ -21,10 +21,20 @@
             - if can? :edit, @track
               = link_to 'Edit', edit_admin_conference_program_track_path(@conference.short_title, @track),
               method: :get, class: 'btn btn-primary'
+              - special_style = true
             - if can? :destroy, @track
               = link_to 'Delete', admin_conference_program_track_path(@conference.short_title, @track),
               method: :delete, class: 'btn btn-danger',
               data: { confirm: "Do you really want to delete #{@track.name}? Attention: This track will be removed from all Events that have it set" }
+            - if @track.self_organized?
+              - if @track.selected_schedule
+                - if can? :show, @track.selected_schedule
+                  = link_to 'Show Schedule', admin_conference_schedule_path(@conference.short_title, @track.selected_schedule),
+                  class: 'btn btn-default'
+              - elsif can? :create, @program.schedules.build(track: @track)
+                = button_to 'Create Schedule', admin_conference_schedules_path(@conference.short_title),
+                form: { class: 'btn', style: 'padding: 0px 0px; margin-top: -1px;' }, class: 'btn btn-default',
+                style: ('border-top-left-radius: 0; border-bottom-left-radius: 0;' if special_style), params: { 'schedule[track_id]' => @track.id }
       .row
         .col-md-12
           %table.table

--- a/app/views/proposals/show.html.haml
+++ b/app/views/proposals/show.html.haml
@@ -114,7 +114,7 @@
                   %dl
                     %dt Start Time:
                     %dd
-                      = event.program.selected_event_schedules.find_by(event: event).start_time.strftime("%Y %B %e %H:%M")
+                      = event.program.selected_event_schedules.find { |es| es.event == event }.start_time.strftime("%Y %B %e %H:%M")
                     %br
                       %dt Room:
                       %dd

--- a/app/views/schedules/_carousel.html.haml
+++ b/app/views/schedules/_carousel.html.haml
@@ -29,7 +29,7 @@
               %td.room{ style: "height: #{ td_height(@rooms) }px;" }
                 .room.elipsis.break-words{ style: "-webkit-line-clamp: #{ room_lines(@rooms) }; height: #{ room_height(@rooms) }px;" }
                   = room.name
-                - event_schedules = room.event_schedules.select{ |e| (e.schedule_id == @conference.program.selected_schedule.id) && (e.end_time > start_time) && (e.start_time <= (start_time + hrs_per_slide.hour)) }
+                - event_schedules = room.event_schedules.select{ |e| @selected_schedules_ids.include?(e.schedule_id) && (e.end_time > start_time) && (e.start_time <= (start_time + hrs_per_slide.hour)) }
                 - (1..intervals).each do |i|
                   - if span > 1
                     - span -= 1

--- a/app/views/tracks/index.html.haml
+++ b/app/views/tracks/index.html.haml
@@ -72,6 +72,8 @@
                       method: :patch, class: 'btn btn-mini btn-success', id: "resubmit_track_request_#{track.id}"
                   - if can? :edit, track
                     = link_to 'Edit', edit_conference_program_track_path(@conference.short_title, track), class: 'btn btn-default'
+                  - if current_user.has_role? :track_organizer, track
+                    = link_to 'Manage', admin_conference_program_track_path(@conference.short_title, track), class: 'btn btn-default'
 
   .row
     .col-md-12

--- a/app/views/tracks/show.html.haml
+++ b/app/views/tracks/show.html.haml
@@ -8,6 +8,8 @@
           .btn-group.pull-right
             - if can? :edit, @track
               = link_to 'Edit Track request', edit_conference_program_track_path(@conference.short_title, @track), class: 'btn btn-primary'
+            - if current_user.has_role? :track_organizer, @track
+              = link_to 'Manage', admin_conference_program_track_path(@conference.short_title, @track), class: 'btn btn-default'
   .row
     .col-md-8
       %dl.dl-horizontal

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -40,7 +40,7 @@ Osem::Application.routes.draw do
     resources :comments, only: [:index]
     resources :conferences do
       resource :contact, except: [:index, :new, :create, :show, :destroy]
-      resources :schedules, only: [:index, :create, :show, :update, :destroy]
+      resources :schedules, except: [:edit, :update]
       resources :event_schedules, only: [:create, :update, :destroy]
       get 'commercials/render_commercial' => 'commercials#render_commercial'
       resources :commercials, only: [:index, :create, :update, :destroy]
@@ -88,6 +88,7 @@ Osem::Application.routes.draw do
             patch :to_reject
             patch :reject
             patch :cancel
+            patch :update_selected_schedule
           end
         end
         resources :event_types

--- a/db/migrate/20170809120927_add_track_reference_to_schedule.rb
+++ b/db/migrate/20170809120927_add_track_reference_to_schedule.rb
@@ -1,0 +1,5 @@
+class AddTrackReferenceToSchedule < ActiveRecord::Migration
+  def change
+    add_reference :schedules, :track, index: true, foreign_key: true
+  end
+end

--- a/db/migrate/20170814174637_add_selected_schedule_to_tracks.rb
+++ b/db/migrate/20170814174637_add_selected_schedule_to_tracks.rb
@@ -1,0 +1,6 @@
+class AddSelectedScheduleToTracks < ActiveRecord::Migration
+  def change
+    add_column :tracks, :selected_schedule_id, :integer
+    add_index :tracks, :selected_schedule_id
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -431,9 +431,11 @@ ActiveRecord::Schema.define(version: 20170816203325) do
     t.integer  "program_id"
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
+    t.integer  "track_id"
   end
 
   add_index "schedules", ["program_id"], name: "index_schedules_on_program_id"
+  add_index "schedules", ["track_id"], name: "index_schedules_on_track_id"
 
   create_table "splashpages", force: :cascade do |t|
     t.integer  "conference_id"
@@ -520,24 +522,26 @@ ActiveRecord::Schema.define(version: 20170816203325) do
   end
 
   create_table "tracks", force: :cascade do |t|
-    t.string   "guid",                         null: false
-    t.string   "name",                         null: false
+    t.string   "guid",                                 null: false
+    t.string   "name",                                 null: false
     t.text     "description"
     t.string   "color"
     t.datetime "created_at"
     t.datetime "updated_at"
     t.integer  "program_id"
-    t.string   "short_name",                   null: false
-    t.string   "state",        default: "new", null: false
-    t.boolean  "cfp_active",                   null: false
+    t.string   "short_name",                           null: false
+    t.string   "state",                default: "new", null: false
+    t.boolean  "cfp_active",                           null: false
     t.integer  "submitter_id"
     t.integer  "room_id"
     t.date     "start_date"
     t.date     "end_date"
     t.text     "relevance"
+    t.integer  "selected_schedule_id"
   end
 
   add_index "tracks", ["room_id"], name: "index_tracks_on_room_id"
+  add_index "tracks", ["selected_schedule_id"], name: "index_tracks_on_selected_schedule_id"
   add_index "tracks", ["submitter_id"], name: "index_tracks_on_submitter_id"
 
   create_table "users", force: :cascade do |t|

--- a/spec/features/track_organizer_ability_spec.rb
+++ b/spec/features/track_organizer_ability_spec.rb
@@ -101,7 +101,7 @@ feature 'Has correct abilities' do
       expect(current_path).to eq root_path
 
       visit admin_conference_program_events_path(conference.short_title)
-      expect(current_path).to eq admin_conference_program_events_path(conference.short_title)
+      expect(current_path).to eq root_path
 
       create(:event, program: conference.program)
       visit edit_admin_conference_program_event_path(conference.short_title, conference.program.events.first)

--- a/spec/features/track_organizer_ability_spec.rb
+++ b/spec/features/track_organizer_ability_spec.rb
@@ -4,7 +4,7 @@ feature 'Has correct abilities' do
 
   let(:organization) { create(:organization) }
   let(:conference) { create(:full_conference, organization: organization) }
-  let(:self_organized_track) { create(:track, :self_organized, program: conference.program) }
+  let(:self_organized_track) { create(:track, :self_organized, program: conference.program, state: 'confirmed', cfp_active: true) }
   let(:role_track_organizer) { Role.where(name: 'track_organizer', resource: self_organized_track).first_or_create }
   let(:user_track_organizer) { create(:user, role_ids: [role_track_organizer.id]) }
 
@@ -28,12 +28,12 @@ feature 'Has correct abilities' do
       expect(page).to_not have_link('Lodgings', href: "/admin/conferences/#{conference.short_title}/lodgings")
       expect(page).to have_link('Program', href: "/admin/conferences/#{conference.short_title}/program")
       expect(page).to_not have_link('Call for Papers', href: "/admin/conferences/#{conference.short_title}/program/cfps")
-      expect(page).to_not have_link('Events', href: "/admin/conferences/#{conference.short_title}/program/events")
+      expect(page).to have_link('Events', href: "/admin/conferences/#{conference.short_title}/program/events")
       expect(page).to have_link('Tracks', href: "/admin/conferences/#{conference.short_title}/program/tracks")
       expect(page).to_not have_link('Event Types', href: "/admin/conferences/#{conference.short_title}/program/event_types")
       expect(page).to_not have_link('Difficulty Levels', href: "/admin/conferences/#{conference.short_title}/program/difficulty_levels")
       expect(page).to_not have_link('Schedules', href: "/admin/conferences/#{conference.short_title}/schedules")
-      expect(page).to_not have_link('Reports', href: "/admin/conferences/#{conference.short_title}/program/reports")
+      expect(page).to have_link('Reports', href: "/admin/conferences/#{conference.short_title}/program/reports")
       expect(page).to_not have_link('Registrations', href: "/admin/conferences/#{conference.short_title}/registrations")
       expect(page).to_not have_link('Registration Period', href: "/admin/conferences/#{conference.short_title}/registration_period")
       expect(page).to_not have_link('Questions', href: "/admin/conferences/#{conference.short_title}/questions")
@@ -101,11 +101,15 @@ feature 'Has correct abilities' do
       expect(current_path).to eq root_path
 
       visit admin_conference_program_events_path(conference.short_title)
-      expect(current_path).to eq root_path
+      expect(current_path).to eq admin_conference_program_events_path(conference.short_title)
 
       create(:event, program: conference.program)
       visit edit_admin_conference_program_event_path(conference.short_title, conference.program.events.first)
       expect(current_path).to eq root_path
+
+      self_organized_track_event = create(:event, program: conference.program, track: self_organized_track)
+      visit edit_admin_conference_program_event_path(conference.short_title, self_organized_track_event)
+      expect(current_path).to eq(edit_admin_conference_program_event_path(conference.short_title, self_organized_track_event))
 
       visit admin_conference_program_event_types_path(conference.short_title)
       expect(current_path).to eq root_path
@@ -219,7 +223,7 @@ feature 'Has correct abilities' do
       expect(current_path).to eq admin_conference_program_track_path(conference.short_title, self_organized_track)
 
       visit edit_admin_conference_program_track_path(conference.short_title, self_organized_track)
-      expect(current_path).to eq edit_admin_conference_program_track_path(conference.short_title, self_organized_track)
+      expect(current_path).to eq root_path
 
       visit admin_conference_roles_path(conference.short_title)
       expect(current_path).to eq admin_conference_roles_path(conference.short_title)

--- a/spec/features/track_organizer_ability_spec.rb
+++ b/spec/features/track_organizer_ability_spec.rb
@@ -4,7 +4,7 @@ feature 'Has correct abilities' do
 
   let(:organization) { create(:organization) }
   let(:conference) { create(:full_conference, organization: organization) }
-  let(:self_organized_track) { create(:track, :self_organized, program: conference.program, state: 'confirmed', cfp_active: true) }
+  let(:self_organized_track) { create(:track, :self_organized, program: conference.program, state: 'confirmed') }
   let(:role_track_organizer) { Role.where(name: 'track_organizer', resource: self_organized_track).first_or_create }
   let(:user_track_organizer) { create(:user, role_ids: [role_track_organizer.id]) }
 
@@ -32,7 +32,7 @@ feature 'Has correct abilities' do
       expect(page).to have_link('Tracks', href: "/admin/conferences/#{conference.short_title}/program/tracks")
       expect(page).to_not have_link('Event Types', href: "/admin/conferences/#{conference.short_title}/program/event_types")
       expect(page).to_not have_link('Difficulty Levels', href: "/admin/conferences/#{conference.short_title}/program/difficulty_levels")
-      expect(page).to_not have_link('Schedules', href: "/admin/conferences/#{conference.short_title}/schedules")
+      expect(page).to have_link('Schedules', href: "/admin/conferences/#{conference.short_title}/schedules")
       expect(page).to have_link('Reports', href: "/admin/conferences/#{conference.short_title}/program/reports")
       expect(page).to_not have_link('Registrations', href: "/admin/conferences/#{conference.short_title}/registrations")
       expect(page).to_not have_link('Registration Period', href: "/admin/conferences/#{conference.short_title}/registration_period")
@@ -130,11 +130,15 @@ feature 'Has correct abilities' do
       expect(current_path).to eq root_path
 
       visit admin_conference_schedules_path(conference.short_title)
-      expect(current_path).to eq root_path
+      expect(current_path).to eq admin_conference_schedules_path(conference.short_title)
 
       create(:schedule, program: conference.program)
       visit admin_conference_schedule_path(conference.short_title, conference.program.schedules.first)
       expect(current_path).to eq root_path
+
+      self_organized_track_schedule = create(:schedule, program: conference.program, track: self_organized_track)
+      visit admin_conference_schedule_path(conference.short_title, self_organized_track_schedule)
+      expect(current_path).to eq admin_conference_schedule_path(conference.short_title, self_organized_track_schedule)
 
       visit admin_conference_program_reports_path(conference.short_title)
       expect(current_path).to eq admin_conference_program_reports_path(conference.short_title)

--- a/spec/models/admin_ability_spec.rb
+++ b/spec/models/admin_ability_spec.rb
@@ -45,7 +45,7 @@ describe 'User with admin role' do
     let!(:my_event_schedule) { create(:event_schedule, schedule: my_schedule) }
     let!(:other_event_schedule) { create(:event_schedule, schedule: other_schedule) }
 
-    let!(:my_self_organized_track) { create(:track, :self_organized, program: my_conference.program, state: 'confirmed', cfp_active: true) }
+    let!(:my_self_organized_track) { create(:track, :self_organized, program: my_conference.program, state: 'confirmed') }
 
     context 'user #is_admin?' do
       let(:venue) { my_conference.venue }
@@ -460,8 +460,12 @@ describe 'User with admin role' do
       let(:user) { create(:user, role_ids: [role.id]) }
       let(:new_track) { build(:track, program: my_conference.program) }
       let(:new_event) { build(:event, program: my_conference.program) }
+      let(:new_schedule) { build(:schedule, program: my_conference.program) }
+      let(:new_track_schedule) { build(:schedule, program: my_conference.program, track: new_track) }
       let(:my_self_organized_track_event) { create(:event, program: my_conference.program, track: my_self_organized_track) }
       let(:my_self_organized_track_event_commercial) { create(:commercial, commercialable: my_self_organized_track_event) }
+      let(:my_self_organized_track_schedule) { create(:schedule, program: my_conference.program, track: my_self_organized_track) }
+      let(:my_self_organized_track_event_schedule) { create(:event_schedule, event: my_self_organized_track_event, schedule: my_self_organized_track_schedule, room: my_self_organized_track.room) }
 
       it{ should_not be_able_to(:new, Conference.new) }
       it{ should_not be_able_to(:create, Conference.new) }
@@ -531,6 +535,11 @@ describe 'User with admin role' do
       it{ should be_able_to(:update, new_event) }
       it{ should be_able_to(:manage, my_self_organized_track_event) }
       it{ should be_able_to(:manage, my_self_organized_track_event_commercial) }
+
+      it{ should be_able_to(:update, new_schedule) }
+      it{ should be_able_to(:new, new_track_schedule) }
+      it{ should be_able_to(:manage, my_self_organized_track_schedule) }
+      it{ should be_able_to(:manage, my_self_organized_track_event_schedule) }
 
       it_behaves_like 'user with any role'
       it_behaves_like 'user with non-organizer role', 'track_organizer'

--- a/spec/models/admin_ability_spec.rb
+++ b/spec/models/admin_ability_spec.rb
@@ -45,7 +45,7 @@ describe 'User with admin role' do
     let!(:my_event_schedule) { create(:event_schedule, schedule: my_schedule) }
     let!(:other_event_schedule) { create(:event_schedule, schedule: other_schedule) }
 
-    let!(:my_self_organized_track) { create(:track, :self_organized, program: my_conference.program, state: 'confirmed') }
+    let!(:my_self_organized_track) { create(:track, :self_organized, program: my_conference.program, state: 'confirmed', cfp_active: true) }
 
     context 'user #is_admin?' do
       let(:venue) { my_conference.venue }
@@ -459,6 +459,9 @@ describe 'User with admin role' do
       let(:role) { Role.where(name: 'track_organizer', resource: my_self_organized_track).first_or_create }
       let(:user) { create(:user, role_ids: [role.id]) }
       let(:new_track) { build(:track, program: my_conference.program) }
+      let(:new_event) { build(:event, program: my_conference.program) }
+      let(:my_self_organized_track_event) { create(:event, program: my_conference.program, track: my_self_organized_track) }
+      let(:my_self_organized_track_event_commercial) { create(:commercial, commercialable: my_self_organized_track_event) }
 
       it{ should_not be_able_to(:new, Conference.new) }
       it{ should_not be_able_to(:create, Conference.new) }
@@ -524,6 +527,10 @@ describe 'User with admin role' do
 
       it{ should_not be_able_to(:assign_org_admins, organization) }
       it{ should_not be_able_to(:unassign_org_admins, organization) }
+
+      it{ should be_able_to(:update, new_event) }
+      it{ should be_able_to(:manage, my_self_organized_track_event) }
+      it{ should be_able_to(:manage, my_self_organized_track_event_commercial) }
 
       it_behaves_like 'user with any role'
       it_behaves_like 'user with non-organizer role', 'track_organizer'

--- a/spec/models/event_schedule_spec.rb
+++ b/spec/models/event_schedule_spec.rb
@@ -45,5 +45,68 @@ describe EventSchedule do
         end
       end
     end
+
+    describe '#room_of_track' do
+      before :each do
+        conference = create(:conference)
+        conference.venue = create(:venue)
+        @room = create(:room, venue: conference.venue)
+        @track = create(:track, program: conference.program, room: @room)
+        @event = create(:event, program: conference.program, track: @track)
+      end
+
+      context 'is valid' do
+        it 'when scheduled in the track\'s room' do
+          event_schedule = build(:event_schedule, event: @event, room: @room)
+          expect(event_schedule.valid?).to eq true
+        end
+
+        it 'when the track doesn\'t have a room' do
+          @track.room = nil
+          @track.save!
+          event_schedule = build(:event_schedule, event: @event)
+          expect(event_schedule.valid?).to eq true
+        end
+      end
+
+      context 'is invalid' do
+        it 'when scheduled in different room than the track\'s' do
+          event_schedule = build(:event_schedule, event: @event)
+          expect(event_schedule.valid?).to eq false
+          expect(event_schedule.errors[:room]).to eq ["must be the same as the track's room (#{@room.name})"]
+        end
+      end
+    end
+
+    describe '#during_track' do
+      before :each do
+        conference = create(:conference, start_date: Date.current - 1.day, start_hour: 0, end_hour: 24)
+        conference.venue = create(:venue)
+        @room = create(:room, venue: conference.venue)
+        @track = create(:track, program: conference.program, room: @room, start_date: Date.current, end_date: Date.current)
+        @event = create(:event, program: conference.program, track: @track)
+      end
+
+      context 'is valid' do
+        it 'when scheduled during the track\'s time slot' do
+          event_schedule = build(:event_schedule, event: @event, room: @room, start_time: Date.current + 3.hours)
+          expect(event_schedule.valid?).to eq true
+        end
+      end
+
+      context 'is invalid' do
+        it 'when scheduled before the track\'s start date' do
+          event_schedule = build(:event_schedule, event: @event, room: @room, start_time: Date.current - 1.hour)
+          expect(event_schedule.valid?).to eq false
+          expect(event_schedule.errors[:start_time]).to eq ["can't be before the track's start date (#{@track.start_date})"]
+        end
+
+        it 'when event ends after the track\'s end date' do
+          event_schedule = build(:event_schedule, event: @event, room: @room, start_time: Date.current + 1.day - 10.minutes)
+          expect(event_schedule.valid?).to eq false
+          expect(event_schedule.errors[:end_time]).to eq ["can't be after the track's end date (#{@track.end_date})"]
+        end
+      end
+    end
   end
 end

--- a/spec/models/schedule_spec.rb
+++ b/spec/models/schedule_spec.rb
@@ -4,6 +4,7 @@ describe Schedule do
 
   describe 'association' do
     it { should belong_to(:program) }
+    it { should belong_to(:track) }
     it { should have_many(:event_schedules).dependent(:destroy) }
     it { should have_many(:events).through(:event_schedules) }
   end


### PR DESCRIPTION
* Don't allow tracks with overlapping dates to use the same room
* Add accepted and self_organized scopes to Track
* Don't allow an event to be scheduled outside of it's track's room and dates
* Remove unnecessary abilities from AdminAbility, in order to allow CanCanCan to load @events and @event in EventsController
* Allow the track organizers to manage the events and the events' commercials of their tracks
* Create associate between Schedule and Track
* Allow the track organizers to create schedules for their tracks and schedule the events of their tracks
* Restrict events of self-organized tracks to be scheduled only in their tracks schedules
* Show scheduled events of self-organized tracks and the rooms those tracks occupy in the conference scheduled as semitransparent
* Add admin/SchedulesController#new action and related form and buttons
* Add buttons to easily access admin//Schedules#create and #show from Tracks#index and #show
* Show a unified schedule in Schedules#show
* Create tabs for conference and track schedules in admin/Schedules#index
* Add selected_schedule_id to Track
* Relax requirement for cfp_active to be enabled in Event and check it in ProposalsController
* Validate that events of self-organized tracks are scheduled only in their track's schedules