### PR TITLE
Add Booth to admin sidebar and confirm from admin/booths#index

### DIFF
--- a/.haml-lint_todo.yml
+++ b/.haml-lint_todo.yml
@@ -152,6 +152,7 @@ linters:
       - "app/views/layouts/_admin_sidebar_index.html.haml"
       - "app/views/layouts/_messages.html.haml"
       - "app/views/layouts/_navigation.html.haml"
+      - "app/views/layouts/_user_menu.html.haml"
       - "app/views/layouts/application.html.haml"
       - "app/views/organizations/index.html.haml"
       - "app/views/payments/_payment.html.haml"

--- a/app/controllers/admin/booths_controller.rb
+++ b/app/controllers/admin/booths_controller.rb
@@ -90,6 +90,10 @@ module Admin
       update_state(:cancel, 'Booth is canceled')
     end
 
+    def confirm
+      update_state(:confirm, 'Booth successfully confirmed')
+    end
+
     private
 
     def update_state(transition, notice)

--- a/app/views/admin/booths/_change_state_dropdown.html.haml
+++ b/app/views/admin/booths/_change_state_dropdown.html.haml
@@ -42,3 +42,8 @@
   %li= link_to 'Cancel booth',
   cancel_admin_conference_booth_path(@conference.short_title, booth),
   method: :patch, id: "cancel_booth_#{booth.id}"
+
+- if booth.transition_possible? :confirm
+  %li= link_to 'Confirm booth',
+  confirm_admin_conference_booth_path(@conference.short_title, booth),
+  method: :patch, id: "confirm_booth_#{booth.id}"

--- a/app/views/layouts/_admin_sidebar.html.haml
+++ b/app/views/layouts/_admin_sidebar.html.haml
@@ -116,7 +116,7 @@
         - if can? :update, @conference.tickets.build
           %li{class: active_nav_li(admin_conference_tickets_path(@conference.short_title)) }
             = link_to 'Tickets', admin_conference_tickets_path(@conference.short_title)
-  - if can? :manage, @conference.booths
+  - if can? :manage, @conference.booths.build
     %li
       = link_to  admin_conference_booths_path(@conference.short_title) do
         %span.fa.fa-shopping-bag

--- a/app/views/layouts/_admin_sidebar.html.haml
+++ b/app/views/layouts/_admin_sidebar.html.haml
@@ -116,7 +116,11 @@
         - if can? :update, @conference.tickets.build
           %li{class: active_nav_li(admin_conference_tickets_path(@conference.short_title)) }
             = link_to 'Tickets', admin_conference_tickets_path(@conference.short_title)
-
+  - if can? :manage, @conference.booths
+    %li
+      = link_to  admin_conference_booths_path(@conference.short_title) do
+        %span.fa.fa-shopping-bag
+        Booths
   - if (can? :manage, @conference.targets.build) || (can? :manage, @conference.campaigns.build)
     %li
       %a

--- a/app/views/layouts/_user_menu.html.haml
+++ b/app/views/layouts/_user_menu.html.haml
@@ -16,6 +16,11 @@
     = link_to(conference_program_tracks_path(@conference.short_title)) do
       %span.fa.fa-road
       My Tracks
+-if @conference && @conference.program && (@conference.program.cfps.for_booths.try(:open?) || current_user.booths.where(conference_id: @conference.id).count > 0)
+  %li
+    = link_to (conference_booths_path(@conference.short_title)) do
+      %span.fa.fa-shopping-bag
+      My Booth Requests
 %li
   - if ENV['OSEM_ICHAIN_ENABLED'] == 'true'
     = link_to(destroy_user_ichain_session_path, method: 'delete') do

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -47,6 +47,7 @@ Osem::Application.routes.draw do
           patch :reset
           patch :to_reject
           patch :cancel
+          patch :confirm
         end
       end
 


### PR DESCRIPTION
I have added 'Booths' to admin sidebar that redirects at admin/booths#index. 
All of the elements in the sidebar have a fontawesome icon, however I couldn't find any kiosk-like and I didn't know which would be more appropriate so I let it blank.

Also, I made possible to confirm a booth from admin/booths#index when organizer is also the submitter.
