### PR TITLE
Improving check-in process

### DIFF
--- a/app/models/ticket_scanning.rb
+++ b/app/models/ticket_scanning.rb
@@ -1,3 +1,13 @@
 class TicketScanning < ActiveRecord::Base
   belongs_to :physical_ticket
+
+  before_create :mark_user_present
+
+  private
+
+  def mark_user_present
+    if physical_ticket.ticket.registration_ticket?
+      physical_ticket.user.mark_attendance_for_conference(physical_ticket.conference)
+    end
+  end
 end

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -47,7 +47,11 @@ class User < ActiveRecord::Base
   has_many :event_users, dependent: :destroy
   has_many :events, -> { uniq }, through: :event_users
   has_many :presented_events, -> { joins(:event_users).where(event_users: {event_role: 'speaker'}).uniq }, through: :event_users, source: :event
-  has_many :registrations, dependent: :destroy
+  has_many :registrations, dependent: :destroy do
+    def for_conference conference
+      where(conference: conference).first
+    end
+  end
   has_many :events_registrations, through: :registrations
   has_many :ticket_purchases, dependent: :destroy
   has_many :payments, dependent: :destroy
@@ -91,6 +95,12 @@ class User < ActiveRecord::Base
 
     return false unless event_registration.present?
     event_registration.attended
+  end
+
+  def mark_attendance_for_conference conference
+    registration = registrations.for_conference(conference)
+    registration.attended = true
+    registration.save
   end
 
   def name

--- a/spec/controllers/admin/ticket_scannings_controller_spec.rb
+++ b/spec/controllers/admin/ticket_scannings_controller_spec.rb
@@ -4,7 +4,9 @@ describe Admin::TicketScanningsController do
   let(:admin) { create(:admin) }
   let(:conference) { create(:conference) }
   let(:user) { create(:user) }
-  let(:paid_ticket_purchase) { create(:ticket_purchase, conference: conference, user: user) }
+  let!(:registration) { create(:registration, conference: conference, user: user) }
+  let(:registration_ticket) { create(:registration_ticket, conference: conference) }
+  let(:paid_ticket_purchase) { create(:ticket_purchase, conference: conference, user: user, ticket: registration_ticket, quantity: 1) }
   let(:physical_ticket) { create(:physical_ticket, ticket_purchase: paid_ticket_purchase) }
 
   context 'logged in as user with no role' do

--- a/spec/factories/ticket_scanning.rb
+++ b/spec/factories/ticket_scanning.rb
@@ -1,0 +1,5 @@
+FactoryGirl.define do
+  factory :ticket_scanning do
+    physical_ticket
+  end
+end

--- a/spec/models/ticket_scanning_spec.rb
+++ b/spec/models/ticket_scanning_spec.rb
@@ -1,0 +1,20 @@
+require 'spec_helper'
+
+describe TicketScanning do
+  let(:conference) { create(:conference) }
+  let(:user) { create(:user) }
+  let(:registration) { create(:registration, conference: conference, user: user) }
+  let(:registration_ticket) { create(:registration_ticket, conference: conference) }
+  let(:paid_ticket_purchase) { create(:ticket_purchase, conference: conference, user: user, ticket: registration_ticket, quantity: 1) }
+  let(:physical_ticket) { create(:physical_ticket, ticket_purchase: paid_ticket_purchase) }
+  let(:ticket_scanning) { create(:ticket_scanning, physical_ticket: physical_ticket) }
+
+  describe 'before_create' do
+    it 'marks user as present' do
+      expect(registration.attended).to eq(false)
+      ticket_scanning
+      registration.reload
+      expect(registration.attended).to eq(true)
+    end
+  end
+end


### PR DESCRIPTION
Mark user as present for the conference when user's registration ticket for that conference is scanned