### PR TITLE
Replace flash with flash.now

### DIFF
--- a/app/controllers/admin/booths_controller.rb
+++ b/app/controllers/admin/booths_controller.rb
@@ -22,7 +22,7 @@ module Admin
         redirect_to admin_conference_booths_path,
                     notice: 'Booth successfully created.'
       else
-        flash[:error] = "Creating booth failed. #{@booth.errors.full_messages.to_sentence}."
+        flash.now[:error] = "Creating booth failed. #{@booth.errors.full_messages.to_sentence}."
         render :new
       end
     end
@@ -40,7 +40,7 @@ module Admin
         redirect_to admin_conference_booths_path,
                     notice: "Successfully updated booth for #{@booth.title}."
       else
-        flash[:error] = "An error prohibited the Booth for #{@booth.title} "\
+        flash.now[:error] = "An error prohibited the Booth for #{@booth.title} "\
                     "#{@booth.errors.full_messages.join('. ')}."
         render :edit
       end

--- a/app/controllers/admin/events_controller.rb
+++ b/app/controllers/admin/events_controller.rb
@@ -102,7 +102,7 @@ module Admin
         ahoy.track 'Event submission', title: 'New submission'
         redirect_to admin_conference_program_events_path(@conference.short_title), notice: 'Event was successfully submitted.'
       else
-        flash[:error] = "Could not submit proposal: #{@event.errors.full_messages.join(', ')}"
+        flash.now[:error] = "Could not submit proposal: #{@event.errors.full_messages.join(', ')}"
         render action: 'new'
       end
     end

--- a/app/controllers/booths_controller.rb
+++ b/app/controllers/booths_controller.rb
@@ -23,7 +23,7 @@ class BoothsController < ApplicationController
       redirect_to conference_booths_path,
                   notice: 'Booth successfully created.'
     else
-      flash[:error] = "Creating booth failed. #{@booth.errors.full_messages.to_sentence}."
+      flash.now[:error] = "Creating booth failed. #{@booth.errors.full_messages.to_sentence}."
       render :new
     end
   end
@@ -40,7 +40,7 @@ class BoothsController < ApplicationController
       redirect_to conference_booths_path,
                   notice: 'Booth successfully updated!'
     else
-      flash[:error] = "Booth could not be updated. #{@booth.errors.full_messages.to_sentence}."
+      flash.now[:error] = "Booth could not be updated. #{@booth.errors.full_messages.to_sentence}."
     end
   end
 
@@ -56,7 +56,7 @@ class BoothsController < ApplicationController
       redirect_to conference_booths_path,
                   notice: 'Booth successfully withdrawn'
     else
-      flash[:error] = "Booth could not be withdrawn. #{@booth.errors.full_messages.to_sentence}."
+      flash.now[:error] = "Booth could not be withdrawn. #{@booth.errors.full_messages.to_sentence}."
     end
   end
 
@@ -70,7 +70,7 @@ class BoothsController < ApplicationController
       redirect_to conference_booths_path,
                   notice: 'Booth successfully confirmed'
     else
-      flash[:error] = "Booth could not be confirmed. #{@booth.errors.full_messages.to_sentence}."
+      flash.now[:error] = "Booth could not be confirmed. #{@booth.errors.full_messages.to_sentence}."
     end
   end
 
@@ -84,7 +84,7 @@ class BoothsController < ApplicationController
       redirect_to conference_booths_path,
                   notice: 'Booth successfully re-submitted'
     else
-      flash[:error] = "Booth could not be re-submitted. #{@booth.errors.full_messages.to_sentence}."
+      flash.now[:error] = "Booth could not be re-submitted. #{@booth.errors.full_messages.to_sentence}."
     end
   end
 


### PR DESCRIPTION
Flash[:notice]‘s message will persist to the next action and should be used when redirecting to another action via the ‘redirect_to’ method.
Flash.now[:notice]‘s message will be displayed in the view your are rendering via the ‘render’ method.
Fixes #1656 
