### PR TITLE
explicitely set log_level for production

### DIFF
--- a/config/environments/production.rb
+++ b/config/environments/production.rb
@@ -36,7 +36,7 @@ Osem::Application.configure do
   # config.force_ssl = true
 
   # See everything in the log (default is :info)
-  # config.log_level = :debug
+  config.log_level = :info
 
   # Prepend all log lines with the following tags
   # config.log_tags = [ :subdomain, :uuid ]


### PR DESCRIPTION
Without this setting there is a warning displayed:

DEPRECATION WARNING: You did not specify a `log_level` in `production.rb`