### PR TITLE
Fix travis dependencies

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -5,6 +5,7 @@ cache: bundler
 rvm:
   - 2.4.0
 before_install:
+  - sudo apt install libmariadbclient-dev
   - "echo 'gem: --no-ri --no-rdoc' > ~/.gemrc"
   - "echo `phantomjs -v`"
 addons:


### PR DESCRIPTION
It looks like that libmariadbclient-dev is missing in the travis environment and this causes the mysql2 gem's native extensions to not be build. breaking the bundle install phase.