### PR TITLE
Update mariadb to 10.2 to solve Travis failures

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -8,7 +8,7 @@ before_install:
   - "echo 'gem: --no-ri --no-rdoc' > ~/.gemrc"
   - "echo `phantomjs -v`"
 addons:
-  mariadb: '10.1'
+  mariadb: '10.2'
 notifications:
   email:
     on_success: change

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -287,7 +287,7 @@ GEM
     multi_json (1.12.1)
     multi_xml (0.5.5)
     multipart-post (2.0.0)
-    mysql2 (0.4.2)
+    mysql2 (0.4.9)
     nenv (0.3.0)
     netrc (0.11.0)
     nokogiri (1.8.0)


### PR DESCRIPTION
Our test suite is failing in Travis as it complains about not finding `libmysqlclient-dev` which is needed for mysql2. But installing `libmysqlclient-dev` conflicts with MariaDB 10.1. So I updated MariaDB to 10.2 and mysql to the last version as the old one is not compatible with MariaDB 10.2. The missed `libmysqlclient-dev` is not needed any more. This should fix the Travis failures! :bowtie: 