### PR TITLE
Fix total price for tickets

### DIFF
--- a/app/assets/javascripts/osem-tickets.js
+++ b/app/assets/javascripts/osem-tickets.js
@@ -9,7 +9,7 @@ function update_price($this){
     // Calculate total price
     var total = 0;
     $('.total_row').each(function( index ) {
-        total += parseInt($(this).text());
+        total += parseFloat($(this).text());
     });
     $('#total_price').text(total);
 }


### PR DESCRIPTION
While buying the ticket, user was only able to see the integer part in total.So in javascript parseInt was replaced with parseFloat to show the decimal part too.
Fixes https://github.com/openSUSE/osem/issues/1702