### PR TITLE
Add popup message before eventschedule hours change

### DIFF
--- a/app/views/admin/conferences/edit.html.haml
+++ b/app/views/admin/conferences/edit.html.haml
@@ -22,8 +22,8 @@
         = f.input :timezone, as: :time_zone, hint: 'The conference time zone'
         = f.input :start_date, as: :string, input_html: { id: 'conference-start-datepicker', readonly: 'readonly' }
         = f.input :end_date, as: :string, input_html: { id: 'conference-end-datepicker', readonly: 'readonly' }
-        = f.input :start_hour, input_html: {size: 2, type: 'number', min: 0, max: 23}
-        = f.input :end_hour, input_html: {size: 2, type: 'number', min: 1, max: 24}
+        = f.input :start_hour, input_html: { onclick: 'window.confirm("Are you sure you want to proceed?")', size: 2, type: 'number', min: 0, max: 23}, hint: 'Changing the conference hours will unschedule your scheduled events.'
+        = f.input :end_hour, input_html: { onclick: 'window.confirm("Are you sure you want to proceed?")', size: 2, type: 'number', min: 1, max: 24}, hint: 'Changing the conference hours will unschedule your scheduled events.'
       = f.inputs name: 'Registrations' do
         = f.input :registration_limit, as: :number, in: 0..9999, hint: 'Limit the number of registrations to the conference (0 no limit). Please note that the registration limit doesn\'t apply to speakers of confirmed events (they will still be able to register even if it has been reached). You currently have ' + pluralize(@conference.registrations.count, 'registration')
       = f.inputs name: 'Booths' do


### PR DESCRIPTION
Pop up window is added before editing the conference schedule hours to let the organizer know that it will unschedule the scheduled events
Closes https://github.com/openSUSE/osem/issues/1687