### PR TITLE
Add vendor picture interface; include in splash

### DIFF
--- a/app/views/admin/venues/_form.html.haml
+++ b/app/views/admin/venues/_form.html.haml
@@ -15,6 +15,12 @@
         = semantic_form_for(@venue, url: admin_conference_venue_path(@conference.short_title)) do |f|
           = f.inputs :name, :website
           = f.input :description, input_html: { rows: 5, cols: 20, data: { provide: 'markdown-editable' } }, hint: markdown_hint
+          = f.label 'Venue Logo'
+          %br
+          - if @venue.picture?
+            = image_tag @venue.picture.thumb.url
+          = f.input :picture, label: false, hint: 'This will be displayed on the venue are of the splash page.'
+          = f.hidden_field :picture_cache
           = f.inputs :street, :postalcode, :city, :country, :latitude, :longitude
           = f.action :submit, as: :button, button_html: { class: 'btn btn-primary' }
 

--- a/app/views/conferences/_venue_map.html.haml
+++ b/app/views/conferences/_venue_map.html.haml
@@ -1,5 +1,4 @@
 #map{style: "height: 500px;" }
-- popup = "<h3>#{@conference.venue.name}</h3><br>#{@conference.venue.street}<br>#{@conference.venue.city}<br>#{@conference.venue.country_name}"
 - content_for(:script_body) do
   :javascript
     // create a map in the "map" div, set the view to a given place and zoom
@@ -10,8 +9,8 @@
       maxZoom: 18
     }).addTo(map);
     // add a marker in the given location, attach some popup content to it and open the popup
-    L.marker([#{h(@conference.venue.latitude)}, #{h(@conference.venue.longitude)}]).addTo(map)
-      .bindPopup("#{h(popup)}")
+    L.marker([#{h @conference.venue.latitude}, #{h @conference.venue.longitude}]).addTo(map)
+      .bindPopup("#{escape_javascript(render '/conferences/venue_map_marker', venue: @conference.venue)}")
       .openPopup();
     // Turn scrollwheel on when user clicks
     map.on('focus', function(e) {

--- a/app/views/conferences/_venue_map_marker.html.haml
+++ b/app/views/conferences/_venue_map_marker.html.haml
@@ -1,0 +1,13 @@
+- if venue.picture?
+  = image_tag venue.picture.thumb.url,
+    alt: venue.name,
+    class: 'img-responsive pull-right'
+%h3= venue.name
+%p
+  = venue.street
+  %br
+  = venue.city
+  %br
+  = venue.country_name
+- if venue.website
+  %p.text-center.clearfix= sanitize(link_to venue.website, venue.website)

--- a/app/views/proposals/index.html.haml
+++ b/app/views/proposals/index.html.haml
@@ -55,7 +55,7 @@
           %p
             Knowing the number of visitors for the conference helps the organizers plan better.
 
-        %table.table.table-striped
+        %table.table.table-striped#events
           - @events.each do |event|
             %tr
               %td{style: "padding:20px 8px 20px 8px;"}

--- a/spec/features/versions_spec.rb
+++ b/spec/features/versions_spec.rb
@@ -193,7 +193,9 @@ feature 'Version' do
     click_link 'Reject event'
 
     visit conference_program_proposals_path(conference_id: conference.short_title)
-    click_link 'Re-Submit'
+    within('#events') do
+      click_link 'Re-Submit'
+    end
 
     visit admin_conference_program_events_path(conference.short_title)
     click_button 'New'


### PR DESCRIPTION
Vendor has a picture attribute, and was displayed in one form of the splashpage, but it wasn't exposed in the vendor editing form, nor was it included in the "map view" on the splash page.

Additionally, the map popup was rendered inline.

This commit:

* Adds a from input for editing Venue#picture, consistent with other form elements
* Displays the picture on the splash page in either style (map or static)
* Moves the splash page map popup from inline HTML to it's own partial