### PR TITLE
Fix missing link on public organizations page

### DIFF
--- a/app/controllers/organizations_controller.rb
+++ b/app/controllers/organizations_controller.rb
@@ -4,4 +4,10 @@ class OrganizationsController < ApplicationController
   def index
     @organizations = Organization.all
   end
+
+  def conferences
+    @current = @organization.conferences.upcoming.reorder(start_date: :asc)
+    @antiquated = @organization.conferences.past
+    render '/conferences/index'
+  end
 end

--- a/app/models/ability.rb
+++ b/app/models/ability.rb
@@ -15,7 +15,7 @@ class Ability
 
   # Abilities for not signed in users (guests)
   def not_signed_in
-    can [:index], Organization
+    can [:index, :conferences], Organization
     can [:index], Conference
     can [:show], Conference do |conference|
       conference.splashpage && conference.splashpage.public == true

--- a/app/views/conferences/index.html.haml
+++ b/app/views/conferences/index.html.haml
@@ -4,7 +4,7 @@
       .page-header
         %h2 Upcoming Conferences
   - @current.each do |conference|
-    = render partial: 'conference_details', locals: { conference: conference }
+    = render '/conferences/conference_details', conference: conference
   -if @antiquated and @antiquated.any?
     .row
       .col-md-12
@@ -17,7 +17,7 @@
             %i.fa.fa-chevron-down{ style: 'display: none' }
     #antiquated.collapse
       - @antiquated.each do |conference|
-        = render partial: 'conference_details', locals: { conference: conference}
+        = render '/conferences/conference_details', conference: conference
 
 -content_for :script_body do
   :javascript

--- a/app/views/organizations/index.html.haml
+++ b/app/views/organizations/index.html.haml
@@ -12,5 +12,7 @@
           .caption
             %h4
               = organization.name
-            %button.btn.btn-success Conferences
+            = link_to 'Conferences',
+              conferences_organization_path(organization),
+              class: 'btn btn-success'
             / = link_to 'Edit', edit_organization_path(organization), class: 'btn btn-mini btn-default'

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -149,7 +149,11 @@ Osem::Application.routes.draw do
     get '/revision_history/:id/revert_object' => 'versions#revert_object', as: 'revision_history_revert_object'
     get '/revision_history/:id/revert_attribute' => 'versions#revert_attribute', as: 'revision_history_revert_attribute'
   end
-  resources :organizations, only: [:index]
+  resources :organizations, only: [:index] do
+    member do
+      get :conferences
+    end
+  end
   resources :conferences, only: [:index, :show] do
     resources :booths do
       member do

--- a/spec/controllers/organizations_controller_spec.rb
+++ b/spec/controllers/organizations_controller_spec.rb
@@ -2,6 +2,26 @@ require 'spec_helper'
 
 describe OrganizationsController do
   let!(:organization) { create(:organization) }
+  let!(:conference) do
+    create(
+      :conference,
+      splashpage:   create(:splashpage, public: true),
+      venue:        create(:venue),
+      organization: organization
+    )
+  end
+  let!(:antiquated_conference) do
+    create(
+      :conference,
+      splashpage:   create(:splashpage, public: true),
+      venue:        create(:venue),
+      organization: organization,
+      start_date:   2.weeks.ago,
+      end_date:     1.week.ago
+    )
+  end
+
+  let!(:other_conference) { create(:conference) }
   let!(:user) { create(:user) }
 
   describe 'GET #index' do
@@ -11,5 +31,28 @@ describe OrganizationsController do
     end
 
     it { expect(response).to render_template('index') }
+  end
+
+  describe 'GET #conferences' do
+    before :each do
+      get :conferences, id: organization.id
+    end
+
+    it 'loads the organization' do
+      expect(assigns(:organization)).to eq organization
+    end
+
+    it 'includes organization conferences' do
+      expect(assigns(:current)).to include conference
+    end
+
+    it 'does not include conferences outside organization' do
+      expect(assigns(:current)).not_to include other_conference
+      expect(assigns(:antiquated)).not_to include other_conference
+    end
+
+    it 'includes antiquated organization conferences' do
+      expect(assigns(:antiquated)).to include antiquated_conference
+    end
   end
 end

--- a/spec/features/organization_spec.rb
+++ b/spec/features/organization_spec.rb
@@ -48,4 +48,12 @@ feature Organization do
 
     it_behaves_like 'successfully updates an organization'
   end
+
+  context 'anonymously' do
+    scenario 'index should link to conferences list' do
+      visit organizations_path
+
+      expect(page).to have_link('Conferences', href: "/organizations/#{organization.id}/conferences")
+    end
+  end
 end


### PR DESCRIPTION
When viewing a conference, the Instance Name in the header points to /organizations. On the organizations index, there's a button to see conferences, but it does nothing. This makes it easy for public users to get lost.

This commit:
* Adds a function to the organizations controller to show child conferences
* Adds a public permission to see conferences through an organization
* Represents a subset of conferences, reusing conferences/index view, for the organization