### PR TITLE
Add hint and popup on conference#edit

### DIFF
--- a/app/controllers/admin/conferences_controller.rb
+++ b/app/controllers/admin/conferences_controller.rb
@@ -193,6 +193,7 @@ module Admin
     def edit
       @conferences = Conference.all
       @date_string = date_string(@conference.start_date, @conference.end_date)
+      @affected_event_count = @conference.program.events.scheduled(@conference.program.selected_schedule_id).count
       respond_to do |format|
         format.html
         format.json { render json: @conference.to_json }

--- a/app/helpers/application_helper.rb
+++ b/app/helpers/application_helper.rb
@@ -163,6 +163,12 @@ module ApplicationHelper
     end
   end
 
+  def rescheduling_hint(affected_event_count)
+    if affected_event_count > 0
+      "You have #{affected_event_count} scheduled #{'event'.pluralize(affected_event_count)}. Changing the conference hours will unschedule those scheduled outside the conference hours."
+    end
+  end
+
   ##
   # ====Gets
   # a conference object

--- a/app/views/admin/conferences/edit.html.haml
+++ b/app/views/admin/conferences/edit.html.haml
@@ -22,8 +22,8 @@
         = f.input :timezone, as: :time_zone, hint: 'The conference time zone'
         = f.input :start_date, as: :string, input_html: { id: 'conference-start-datepicker', readonly: 'readonly' }
         = f.input :end_date, as: :string, input_html: { id: 'conference-end-datepicker', readonly: 'readonly' }
-        = f.input :start_hour, input_html: {size: 2, type: 'number', min: 0, max: 23}
-        = f.input :end_hour, input_html: {size: 2, type: 'number', min: 1, max: 24}
+        = f.input :start_hour, input_html: {size: 2, type: 'number', min: 0, max: 23}, hint: rescheduling_hint(@affected_event_count)
+        = f.input :end_hour, input_html: {size: 2, type: 'number', min: 1, max: 24}, hint: rescheduling_hint(@affected_event_count)
       = f.inputs name: 'Registrations' do
         = f.input :registration_limit, as: :number, in: 0..9999, hint: 'Limit the number of registrations to the conference (0 no limit). Please note that the registration limit doesn\'t apply to speakers of confirmed events (they will still be able to register even if it has been reached). You currently have ' + pluralize(@conference.registrations.count, 'registration')
       = f.inputs name: 'Booths' do

--- a/app/views/admin/conferences/edit.html.haml
+++ b/app/views/admin/conferences/edit.html.haml
@@ -29,4 +29,4 @@
       = f.inputs name: 'Booths' do
         = f.input :booth_limit, as: :number, in: 0..9999,
         hint: 'Booth limit is the maximum number of booths that you can accept for this conference. By setting this number (0 no limit) you can be sure that you are not going to accept more booths than the conference can accommodate. You currently have ' + pluralize(@conference.booths.accepted.count, 'accepted booth') +'.'
-      = f.action :submit, as: :button, button_html: {class: 'btn btn-primary'}
+      = f.action :submit, as: :button, button_html: { class: 'btn btn-primary', data: { confirm: 'Are you sure you want to proceed?' } }


### PR DESCRIPTION
Pop up and hint are added to let the user know that changing conference hours will unschedule their scheduled changes.
Closes  #1687 