### PR TITLE
Update navbar link for "one-organization" profile

### DIFF
--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -37,6 +37,7 @@ class ApplicationController < ActionController::Base
 
   def get_conferences
     @conferences = Conference.all
+    @one_organization = (Organization.count <= 1)
   end
 
   def current_ability

--- a/app/helpers/application_helper.rb
+++ b/app/helpers/application_helper.rb
@@ -171,4 +171,18 @@ module ApplicationHelper
   def hidden_if_conference_over(conference)
     'hidden' if Date.today > conference.end_date
   end
+
+  def nav_root_link_for(conference)
+    link_text = (
+      conference.try(:organization).try(:name) ||
+      ENV['OSEM_NAME'] ||
+      'OSEM'
+    )
+    link_to(
+      link_text,
+      root_path,
+      class: 'navbar-brand',
+      title: 'Open Source Event Manager'
+    )
+  end
 end

--- a/app/views/layouts/_navigation.html.haml
+++ b/app/views/layouts/_navigation.html.haml
@@ -13,10 +13,8 @@
         %span.icon-bar
         %span.icon-bar
         %span.icon-bar
-      - if conference.nil? || conference.new_record?
-        = link_to (ENV['OSEM_NAME'] || 'OSEM'), root_path, class: 'navbar-brand', title: 'Open Source Event Manager'
-      - else
-        = link_to conference.organization.name, organizations_path, class: 'navbar-brand', title: 'Open Source Event Manager'
+      = nav_root_link_for conference
+
     .collapse.navbar-collapse#main-nav
       - if content_for :splash_nav
         %ul.nav.navbar-nav#splash-nav

--- a/app/views/layouts/application.html.haml
+++ b/app/views/layouts/application.html.haml
@@ -21,7 +21,9 @@
 
     = yield(:head)
   %body
-    = render 'layouts/navigation', conference: @conference
+    = render 'layouts/navigation',
+      conference: @conference,
+      one_organization: @one_organization
     -# Admin area
     - if controller.class.name.split("::").first=="Admin"
       = render 'layouts/admin'

--- a/spec/features/splashpage_spec.rb
+++ b/spec/features/splashpage_spec.rb
@@ -62,14 +62,18 @@ feature Splashpage do
     end
   end
 
-  context 'public splashpage already created' do
+  context 'navigation' do
     let!(:splashpage) { create(:splashpage, conference: conference, public: true)}
 
-    scenario 'should have organization name', feature: true, js: true do
-      sign_in participant
-      visit conference_path(conference.short_title)
+    context 'multiple organizations' do
+      let!(:additional_organization) { create(:organization) }
 
-      expect(page).to have_text(conference.organization.name)
+      scenario 'should have organization name', feature: true, js: true do
+        sign_in participant
+        visit conference_path(conference.short_title)
+
+        expect(page).to have_text(conference.organization.name)
+      end
     end
   end
 end

--- a/spec/helpers/application_helper_spec.rb
+++ b/spec/helpers/application_helper_spec.rb
@@ -58,5 +58,21 @@ describe ApplicationHelper, type: :helper do
         expect(concurrent_events(event).present?).to eq false
       end
     end
+
+    describe 'navigation title link' do
+      it 'should default to OSEM' do
+        ENV.delete('OSEM_NAME')
+        expect(nav_root_link_for(nil)).to match 'OSEM'
+      end
+
+      it 'should use the environment variable' do
+        ENV['OSEM_NAME'] = Faker::Company.name
+        expect(nav_root_link_for(nil)).to match ENV['OSEM_NAME']
+      end
+
+      it 'should use the conference organization name' do
+        expect(nav_root_link_for(conference)).to match conference.organization.name
+      end
+    end
   end
 end


### PR DESCRIPTION
When osem is run with only one organization, it should function roughly the same as it did without organizations; the state in either case is that osem is functionally hosting only one organization, and therefore organizational settings can be at the top-level.

Only If multiple organizations are present, e.g. in a 'hosted' setting, do we need handle the organizational scope.

So, for the top navigational bar, only show the organizational link if there is more than one organization; otherwise show the top-level site link.

Resolves #1651 

*screenshots from specs*

Before:
![capybara-201405010001114928339693](https://user-images.githubusercontent.com/108494/31788991-6f34086e-b4c5-11e7-9a36-3f0c83028944.png)

After:
![capybara-201405010001136080047312](https://user-images.githubusercontent.com/108494/31789003-781975d6-b4c5-11e7-8cfb-2305960e9a31.png)
