### PR TITLE
Fix a flaky test.

### DIFF
--- a/spec/helpers/application_helper_spec.rb
+++ b/spec/helpers/application_helper_spec.rb
@@ -66,12 +66,12 @@ describe ApplicationHelper, type: :helper do
       end
 
       it 'should use the environment variable' do
-        ENV['OSEM_NAME'] = Faker::Company.name
-        expect(nav_root_link_for(nil)).to match ENV['OSEM_NAME']
+        ENV['OSEM_NAME'] = Faker::Company.name + "'"
+        expect(nav_root_link_for(nil)).to match h(ENV['OSEM_NAME'])
       end
 
       it 'should use the conference organization name' do
-        expect(nav_root_link_for(conference)).to match conference.organization.name
+        expect(nav_root_link_for(conference)).to match h(conference.organization.name)
       end
     end
   end

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -26,6 +26,10 @@ require 'phantomjs'
 # makes it easier to control when PaperTrail is enabled during testing.
 require 'paper_trail/frameworks/rspec'
 
+# Make htmlescape() available
+require 'erb'
+include ERB::Util
+
 # Requires supporting ruby files with custom matchers and macros, etc, in
 # spec/support/ and its subdirectories. Files matching `spec/**/*_spec.rb` are
 # run as spec files by default. This means that files in spec/support that end


### PR DESCRIPTION
Tests were occasionally failing as html escape entities didn't match the expectation string.