### PR TITLE
Control config.force_ssl with an ENV variable

### DIFF
--- a/config/environments/production.rb
+++ b/config/environments/production.rb
@@ -33,7 +33,7 @@ Osem::Application.configure do
   # config.action_dispatch.x_sendfile_header = 'X-Accel-Redirect' # for nginx
 
   # Force all access to the app over SSL, use Strict-Transport-Security, and use secure cookies.
-  # config.force_ssl = true
+  config.force_ssl = !!ENV['FORCE_SSL']
 
   # See everything in the log (default is :info)
   config.log_level = :info

--- a/dotenv.example
+++ b/dotenv.example
@@ -63,3 +63,6 @@ OSEM_SMTP_OPENSSL_VERIFY_MODE=""
 
 # Enable the usage of the devise ichain plugin
 OSEM_ICHAIN_ENABLED=false
+
+# enable this to force SSL
+# FORCE_SSL="1"


### PR DESCRIPTION
Allow the `force_ssl` setting to be controlled with an environment variable; defaults to false just like it did before.