### PR TITLE
Update yajl-ruby to 1.3.1

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -555,7 +555,7 @@ GEM
       chronic (>= 0.6.3)
     xpath (2.0.0)
       nokogiri (~> 1.3)
-    yajl-ruby (1.3.0)
+    yajl-ruby (1.3.1)
 
 PLATFORMS
   ruby
@@ -668,4 +668,4 @@ DEPENDENCIES
   whenever
 
 BUNDLED WITH
-   1.15.4
+   1.16.0


### PR DESCRIPTION
There is a security vulnerability in yajl-ruby 1.3.0:

In the yajl-ruby gem 1.3.0 for Ruby, when a crafted JSON file is supplied to `Yajl::Parser.new.parse`, the whole ruby process crashes with a `SIGABRT` in the `yajl_string_decode` function in `yajl_encode.c`. This results in the whole ruby process terminating and potentially a denial of service.

Reference:

https://cve.mitre.org/cgi-bin/cvename.cgi?name=CVE-2017-16516