### PR TITLE
Withdrawn events on conference dashboard

### DIFF
--- a/.rubocop_todo.yml
+++ b/.rubocop_todo.yml
@@ -300,7 +300,7 @@ Lint/UnusedBlockArgument:
 
 # Offense count: 136
 Metrics/AbcSize:
-  Max: 86
+  Max: 98
 
 # Offense count: 258
 # Configuration parameters: CountComments, ExcludedMethods.
@@ -320,7 +320,7 @@ Metrics/LineLength:
 # Offense count: 133
 # Configuration parameters: CountComments.
 Metrics/MethodLength:
-  Max: 56
+  Max: 63
 
 # Offense count: 4
 # Configuration parameters: CountComments.

--- a/app/controllers/admin/conferences_controller.rb
+++ b/app/controllers/admin/conferences_controller.rb
@@ -20,6 +20,10 @@ module Admin
       @total_submissions = Event.count
       @new_submissions = Event.where('created_at > ?', current_user.last_sign_in_at).count
 
+      @total_withdrawn = Event.where(state: :withdrawn).count
+      @new_withdrawn = Event
+          .where('state = ? and created_at > ?', 'withdrawn', current_user.last_sign_in_at).count
+
       @active_conferences = Conference.get_active_conferences_for_dashboard # pending or the last two
       @deactive_conferences = Conference
           .get_conferences_without_active_for_dashboard(@active_conferences) # conferences without active
@@ -116,12 +120,18 @@ module Admin
       @total_reg = @conference.registrations.count
       @new_reg = @conference.registrations.where('created_at > ?', current_user.last_sign_in_at).count
 
-      @total_submissions = @program.events.count
-      @new_submissions = @program.events
+      @all_events = @program.events
+
+      @total_submissions = @all_events.count
+      @new_submissions = @all_events
           .where('created_at > ?', current_user.last_sign_in_at).count
 
       @program_length = @conference.current_program_hours
       @new_program_length = @conference.new_program_hours(current_user.last_sign_in_at)
+
+      @total_withdrawn = @all_events.where(state: :withdrawn).count
+      @new_withdrawn = @all_events
+          .where('state = "withdrawn" and created_at > ?', current_user.last_sign_in_at).count
 
       #  Step by step list
       @conference_progress = @conference.get_status
@@ -162,13 +172,17 @@ module Admin
       # Doughnut charts
       @event_type_distribution = @conference.event_type_distribution
       @event_type_distribution_confirmed = @conference.event_type_distribution(:confirmed)
+      @event_type_distribution_withdrawn = @conference.event_type_distribution(:withdrawn)
 
       @difficulty_levels_distribution = @conference.difficulty_levels_distribution
       @difficulty_levels_distribution_confirmed = @conference
           .difficulty_levels_distribution(:confirmed)
+      @difficulty_levels_distribution_withdrawn = @conference
+          .difficulty_levels_distribution(:withdrawn)
 
       @tracks_distribution = @conference.tracks_distribution
       @tracks_distribution_confirmed = @conference.tracks_distribution(:confirmed)
+      @tracks_distribution_withdrawn = @conference.tracks_distribution(:withdrawn)
 
       # Recent actions information
       @recent_events = @conference.program.events.limit(5).order(created_at: :desc)

--- a/app/models/conference.rb
+++ b/app/models/conference.rb
@@ -1029,7 +1029,7 @@ class Conference < ApplicationRecord
   # * +hash+ -> object_type => {color, value}
   def calculate_event_distribution(group_by_id, association_symbol, state = nil)
     grouped = if state
-                program.events.select(group_by_id).where('state = ?', 'confirmed').group(group_by_id)
+                program.events.select(group_by_id).where('state = ?', state).group(group_by_id)
               else
                 program.events.select(group_by_id).group(group_by_id)
               end

--- a/app/views/admin/conferences/index.html.haml
+++ b/app/views/admin/conferences/index.html.haml
@@ -1,5 +1,5 @@
 .row
-  .col-sm-4.col-xs-4
+  .col-sm-3.col-xs-3
     .dashbox.text-center
       %span.fa.fa-user.fa-lg
       %span.fa.fa-lg
@@ -11,7 +11,7 @@
             %span.label.label-success{ title: "+ #{@new_user} since you last logged in!" }
               +
               = @new_user
-  .col-sm-4.col-xs-4
+  .col-sm-3.col-xs-3
     .dashbox.text-center
       %span.fa.fa-check-square.fa-lg
       %span.fa.fa-lg
@@ -23,7 +23,7 @@
             %span.label.label-success{ title: "+#{@new_reg} since you last logged in!" }
               +
               = @new_reg
-  .col-sm-4.col-xs-4
+  .col-sm-3.col-xs-3
     .dashbox.text-center
       %span.fa.fa-file-text.fa-lg
       %span.fa.fa-lg
@@ -35,6 +35,18 @@
             %span.label.label-success{ title: "+#{@new_submissions} since you last logged in!" }
               +
               = @new_submissions
+  .col-sm-3.col-xs-3
+    .dashbox.text-center
+      %span.fa.fa-archive.fa-lg
+      %span.fa.fa-lg
+        = @total_withdrawn
+      %p
+        %small
+          #{'Withdrawn'.pluralize(@total_withdrawn)}
+          - if @new_withdrawn
+            %span.label.label-success{ title: "+#{@new_withdrawn} since you last logged in!" }
+              +
+              = @new_withdrawn
 
 .row#registrations
   .col-md-8

--- a/app/views/admin/conferences/show.html.haml
+++ b/app/views/admin/conferences/show.html.haml
@@ -3,7 +3,7 @@
   Dashboard for #{@conference.title}
 %hr
 .row
-  .col-sm-4.col-xs-4
+  .col-sm-3.col-xs-3
     .dashbox.text-center
       %span.fa.fa-user.fa-lg
       %span.fa.fa-lg
@@ -16,7 +16,7 @@
             +
             = @new_reg
 
-  .col-sm-4.col-xs-4
+  .col-sm-3.col-xs-3
     .dashbox.text-center
       %span.fa.fa-check-square.fa-lg
       %span.fa.fa-lg
@@ -29,7 +29,7 @@
             +
             = @new_submissions
 
-  .col-sm-4.col-xs-4
+  .col-sm-3.col-xs-3
     .dashbox.text-center
       %span.fa.fa-file-text.fa-lg
       %span.fa.fa-lg
@@ -41,6 +41,19 @@
           %span.label.label-success{ title: "+#{@new_program_length} since you last logged in!" }
             +
             = @new_program_length
+
+  .col-sm-3.col-xs-3
+    .dashbox.text-center
+      %span.fa.fa-archive.fa-lg
+      %span.fa.fa-lg
+        = @total_withdrawn
+      %p
+        %small
+          #{'Withdrawn'.pluralize(@total_withdrawn)}
+        - if @new_withdrawn
+          %span.label.label-success{ title: "+#{@new_withdrawn} since you last logged in!" }
+            +
+            = @new_withdrawn
 
 .row
   .col-md-12
@@ -91,6 +104,10 @@
         %a{ href: '#distribution_confirmed', 'data-toggle' => 'tab' }
           %span.fa.fa-comment
           Confirmed
+      %li
+        %a{ href: '#distribution_withdrawn', 'data-toggle' => 'tab' }
+          %span.fa.fa-archive
+          Withdrawn
     .tab-content
       .tab-pane.active#distribution_all
         .row
@@ -108,6 +125,14 @@
             = render partial: 'doughnut_chart', locals: {title: 'Difficulty levels', data: @difficulty_levels_distribution_confirmed}
           .col-md-4
             = render partial: 'doughnut_chart', locals: {title: 'Tracks', data: @tracks_distribution_confirmed}
+      .tab-pane#distribution_withdrawn
+        .row
+          .col-md-4
+            = render partial: 'doughnut_chart', locals: {title: 'Event types', data: @event_type_distribution_withdrawn}
+          .col-md-4
+            = render partial: 'doughnut_chart', locals: {title: 'Difficulty levels', data: @difficulty_levels_distribution_withdrawn}
+          .col-md-4
+            = render partial: 'doughnut_chart', locals: {title: 'Tracks', data: @tracks_distribution_withdrawn}
 
 .row
   .col-md-8

--- a/spec/controllers/admin/conferences_controller_spec.rb
+++ b/spec/controllers/admin/conferences_controller_spec.rb
@@ -95,6 +95,75 @@ describe Admin::ConferencesController do
         get :show, id: conference.short_title
         expect(response).to render_template :show
       end
+
+      it 'assigns conference withdrawn events distribution to event_type_distribution_withdrawn' do
+        conference
+        create(:event, program: conference.program)
+        workshop = create(:event_type, title: 'Workshop', color: '#000000', program: conference.program)
+        lecture = create(:event_type, title: 'Lecture', color: '#ffffff', program: conference.program)
+        get :show, id: conference.short_title
+        expect(assigns(:event_type_distribution_withdrawn)).to be_empty
+        create(:event, program: conference.program, state: 'withdrawn', event_type: lecture)
+        create(:event, program: conference.program, state: 'withdrawn', event_type: workshop)
+        get :show, id: conference.short_title
+        expect(assigns(:event_type_distribution_withdrawn)).not_to be_empty
+        result = {}
+        result['Workshop'] = {
+          'value' => 1,
+          'color' => '#000000'
+        }
+        result['Lecture'] = {
+          'value' => 1,
+          'color' => '#FFFFFF'
+        }
+        expect(assigns(:event_type_distribution_withdrawn)).to eq(result)
+      end
+
+      it 'assigns conference withdrawn difficulty level distribution to difficulty_levels_distribution_withdrawn' do
+        conference
+        create(:event, program: conference.program)
+        get :show, id: conference.short_title
+        expect(assigns(:difficulty_levels_distribution_withdrawn)).to be_empty
+        easy = create(:difficulty_level, title: 'Easy', color: '#000000')
+        hard = create(:difficulty_level, title: 'Hard', color: '#ffffff')
+        create(:event, program: conference.program, state: 'withdrawn', difficulty_level: easy)
+        create(:event, program: conference.program, state: 'withdrawn', difficulty_level: hard)
+        get :show, id: conference.short_title
+        expect(assigns(:difficulty_levels_distribution_withdrawn)).not_to be_empty
+        result = {}
+        result['Easy'] = {
+          'value' => 1,
+          'color' => '#000000'
+        }
+        result['Hard'] = {
+          'value' => 1,
+          'color' => '#FFFFFF'
+        }
+        expect(assigns(:difficulty_levels_distribution_withdrawn)).to eq(result)
+      end
+
+      it 'assigns conference withdrawn track distribution to tracks_distribution_withdrawn' do
+        conference
+        create(:event, program: conference.program)
+        get :show, id: conference.short_title
+        expect(assigns(:tracks_distribution_withdrawn)).to be_empty
+        track_one = create(:track, name: 'Track One', color: '#000000', program: conference.program)
+        track_two = create(:track, name: 'Track Two', color: '#FFFFFF', program: conference.program)
+        create(:event, program: conference.program, state: 'withdrawn', track: track_one)
+        create(:event, program: conference.program, state: 'withdrawn', track: track_two)
+        get :show, id: conference.short_title
+        expect(assigns(:tracks_distribution_withdrawn)).not_to be_empty
+        result = {}
+        result['Track One'] = {
+          'value' => 1,
+          'color' => '#000000'
+        }
+        result['Track Two'] = {
+          'value' => 1,
+          'color' => '#FFFFFF'
+        }
+        expect(assigns(:tracks_distribution_withdrawn)).to eq(result)
+      end
     end
 
     describe 'GET #index' do


### PR DESCRIPTION
Resolves #463.

It adds an alert whenever events on a conference get withdrawn. 

Screenshot:
![image](https://user-images.githubusercontent.com/3460435/32997740-c3afdd4e-cd72-11e7-8fd6-f80363aca8bd.png)