### PR TITLE
Fix datetimepicker navigation in conference start/end fields

### DIFF
--- a/app/assets/javascripts/osem-datepickers.js
+++ b/app/assets/javascripts/osem-datepickers.js
@@ -80,8 +80,17 @@ $(function () {
   $("#conference-start-datepicker").on("dp.change",function (e) {
       $('#conference-end-datepicker').data("DateTimePicker").setMinDate(e.date);
   });
+
+  $("#conference-start-datepicker").change(function (e) {
+      $('#conference-start-datepicker').val()?$('#conference-end-datepicker').data("DateTimePicker").setMinDate(e.date):$('#conference-end-datepicker').data("DateTimePicker").setMinDate(null);
+  });
+
   $("#conference-end-datepicker").on("dp.change",function (e) {
       $('#conference-start-datepicker').data("DateTimePicker").setMaxDate(e.date);
+  });
+
+  $("#conference-end-datepicker").change(function (e) {
+      $('#conference-end-datepicker').val()?$('#conference-start-datepicker').data("DateTimePicker").setMaxDate(e.date):$('#conference-start-datepicker').data("DateTimePicker").setMaxDate(null);
   });
 
   $("#registration-period-start-datepicker").on("dp.change",function (e) {


### PR DESCRIPTION
Fix datetimepicker navigation for manual clean up of conference start/end fields (fix #1842)

- new behaviour
![new-behaviour](https://user-images.githubusercontent.com/5561794/33532240-07fdfa32-d87f-11e7-9082-06ab11f5055e.gif)
