### PR TITLE
autofill conference end date

### DIFF
--- a/app/assets/javascripts/osem-datepickers.js
+++ b/app/assets/javascripts/osem-datepickers.js
@@ -79,6 +79,9 @@ $(function () {
 
   $("#conference-start-datepicker").on("dp.change",function (e) {
       $('#conference-end-datepicker').data("DateTimePicker").setMinDate(e.date);
+      if (!$('#conference-end-datepicker').val()) {
+         $('#conference-end-datepicker').data("DateTimePicker").setDate(e.date);
+      }
   });
   $("#conference-end-datepicker").on("dp.change",function (e) {
       $('#conference-start-datepicker').data("DateTimePicker").setMaxDate(e.date);


### PR DESCRIPTION
based on start date autofill end date (fix #1844)

- **new behaviour**

![new-behaviour](https://user-images.githubusercontent.com/5561794/33531701-f1f67ae0-d877-11e7-9117-647bba946434.gif)
