### PR TITLE
Add Button that links to /admin/organizations in admin/conferences#index

### DIFF
--- a/app/views/layouts/_admin_sidebar_index.html.haml
+++ b/app/views/layouts/_admin_sidebar_index.html.haml
@@ -27,6 +27,11 @@
       = link_to(admin_users_path) do
         %span.fa.fa-user
         Users
+  - if can? :index, Organization
+    %li
+      = link_to(admin_organizations_path) do
+        %span.fa.fa-users
+        Organizations
   - if can? :index, PaperTrail::Version
     %li
       = link_to(admin_revision_history_path) do


### PR DESCRIPTION
Solution for  issue #1822.
Before:
![screen shot 2017-12-02 at 22 41 32](https://user-images.githubusercontent.com/27733299/33519586-464399a0-d7b2-11e7-9592-ad65994d89e6.png)
After:
![screen shot 2017-12-02 at 22 41 22](https://user-images.githubusercontent.com/27733299/33519588-502937c2-d7b2-11e7-91b1-fc1d6b2ea54e.png)

(Green color preferred because it makes the button easier to spot and also matches the color theme of the entire page)