### PR TITLE
Fix Bundler/OrderedGems Rubocop offenses

### DIFF
--- a/.rubocop_todo.yml
+++ b/.rubocop_todo.yml
@@ -6,14 +6,6 @@
 # Note that changes in the inspected code, or installation of new
 # versions of RuboCop, may require this file to be generated again.
 
-# Offense count: 15
-# Cop supports --auto-correct.
-# Configuration parameters: Include, TreatCommentsAsGroupSeparators.
-# Include: **/Gemfile, **/gems.rb
-Bundler/OrderedGems:
-  Exclude:
-    - 'Gemfile'
-
 # Offense count: 1
 # Cop supports --auto-correct.
 # Configuration parameters: EnforcedStyle, SupportedStyles, IndentationWidth.

--- a/Gemfile
+++ b/Gemfile
@@ -27,8 +27,8 @@ gem 'paper_trail'
 
 # for upload management
 gem 'carrierwave'
-gem 'mini_magick'
 gem 'carrierwave-bombshelter'
+gem 'mini_magick'
 
 # for internationalizing
 gem 'rails-i18n', '~> 4.0.0'
@@ -40,9 +40,9 @@ gem 'devise_ichain_authenticatable'
 # for openID authentication
 gem 'omniauth'
 gem 'omniauth-facebook'
-gem 'omniauth-openid'
-gem 'omniauth-google-oauth2'
 gem 'omniauth-github'
+gem 'omniauth-google-oauth2'
+gem 'omniauth-openid'
 
 # Bot-filtering
 gem 'recaptcha', require: 'recaptcha/rails'
@@ -60,8 +60,8 @@ gem 'unobtrusive_flash', '>=3'
 gem 'transitions', :require => %w( transitions active_record/transitions )
 
 # for comments
-gem 'awesome_nested_set', '~> 3.1.3'
 gem 'acts_as_commentable_with_threading'
+gem 'awesome_nested_set', '~> 3.1.3'
 
 # as templating language
 gem 'haml-rails'
@@ -73,11 +73,11 @@ gem 'sass-rails', '>= 4.0.2'
 gem 'uglifier', '>= 1.3.0'
 
 # as the front-end framework
-gem 'bootstrap-sass', '~> 3.3.4.1'
 gem 'autoprefixer-rails'
-gem 'formtastic-bootstrap'
-gem 'formtastic', '~> 3.1.1'
+gem 'bootstrap-sass', '~> 3.3.4.1'
 gem 'cocoon'
+gem 'formtastic', '~> 3.1.1'
+gem 'formtastic-bootstrap'
 
 # as the JavaScript library
 gem 'jquery-rails'
@@ -108,8 +108,8 @@ source 'https://rails-assets.org' do
   gem 'rails-assets-waypoints'
   # for markdown editors
   gem 'rails-assets-bootstrap-markdown'
-  gem 'rails-assets-to-markdown'
   gem 'rails-assets-markdown'
+  gem 'rails-assets-to-markdown'
 end
 
 # as date picker
@@ -129,9 +129,9 @@ gem 'gravtastic'
 gem 'country_select'
 
 # as PDF generator
+gem 'prawn-qrcode', '~> 0.2.2.1'
 gem 'prawn_rails'
 gem 'rqrcode'
-gem 'prawn-qrcode', '~> 0.2.2.1'
 
 # to render XLS spreadsheets
 gem 'axlsx', git: 'https://github.com/randym/axlsx.git'
@@ -156,13 +156,13 @@ gem 'redcarpet'
 gem 'rdoc-generator-fivefish'
 
 # for visitor tracking
-gem 'ahoy_matey'
 gem 'activeuuid'
+gem 'ahoy_matey'
 gem 'piwik_analytics', '~> 1.0.1'
 
 # for recurring jobs
-gem 'whenever', :require => false
 gem 'delayed_job_active_record'
+gem 'whenever', :require => false
 
 # to run scripts
 gem 'daemons'
@@ -216,8 +216,8 @@ gem 'nokogiri', '>= 1.8.1'
 group :development do
   # to launch specs when files are modified
   gem 'guard-rspec'
-  gem 'spring-commands-rspec'
   gem 'haml_lint', '~> 0.24.0'
+  gem 'spring-commands-rspec'
   # for static code analisys
   gem 'rubocop', '~> 0.51.0', require: false
   # as database
@@ -234,11 +234,11 @@ end
 
 group :test do
   # as test framework
-  gem 'rspec-rails', '~> 3.5', '>= 3.5.2'
-  gem 'database_cleaner'
   gem 'capybara'
-  gem 'poltergeist'
+  gem 'database_cleaner'
   gem 'phantomjs', :require => 'phantomjs/poltergeist'
+  gem 'poltergeist'
+  gem 'rspec-rails', '~> 3.5', '>= 3.5.2'
   # for measuring test coverage
   gem 'coveralls', require: false
   # for describing models


### PR DESCRIPTION
Fixes #1816 
This cop checks that gems are alphabetically sorted within groups. The offenses were fixed using rubocop autocorrection.