### PR TITLE
Fix Style/ReductantReturn rubocop

### DIFF
--- a/.rubocop_todo.yml
+++ b/.rubocop_todo.yml
@@ -646,16 +646,6 @@ Style/RedundantParentheses:
   Exclude:
     - 'app/controllers/admin/base_controller.rb'
 
-# Offense count: 9
-# Cop supports --auto-correct.
-# Configuration parameters: AllowMultipleReturnValues.
-Style/RedundantReturn:
-  Exclude:
-    - 'app/helpers/application_helper.rb'
-    - 'app/helpers/format_helper.rb'
-    - 'app/helpers/paths_helper.rb'
-    - 'app/helpers/users_helper.rb'
-
 # Offense count: 2
 # Cop supports --auto-correct.
 # Configuration parameters: EnforcedStyle, SupportedStyles, AllowInnerSlashes.

--- a/app/helpers/application_helper.rb
+++ b/app/helpers/application_helper.rb
@@ -66,7 +66,7 @@ module ApplicationHelper
     else
       ts = all.join
     end
-    return ts
+    ts
   end
 
   def difficulty_levels(conference)
@@ -80,7 +80,7 @@ module ApplicationHelper
     else
       ts = all.join
     end
-    return ts
+    ts
   end
 
   def unread_notifications(user)

--- a/app/helpers/format_helper.rb
+++ b/app/helpers/format_helper.rb
@@ -101,17 +101,17 @@ module FormatHelper
 
   def icon_for_todo(bool)
     if bool
-      return 'fa fa-check'
+      'fa fa-check'
     else
-      return 'fa fa-times'
+      'fa fa-times'
     end
   end
 
   def class_for_todo(bool)
     if bool
-      return 'todolist-ok'
+      'todolist-ok'
     else
-      return 'todolist-missing'
+      'todolist-missing'
     end
   end
 

--- a/app/helpers/paths_helper.rb
+++ b/app/helpers/paths_helper.rb
@@ -5,9 +5,9 @@ module PathsHelper
 
   def active_nav_li(link)
     if current_page?(link)
-      return 'active'
+      'active'
     else
-      return ''
+      ''
     end
   end
 end

--- a/app/helpers/users_helper.rb
+++ b/app/helpers/users_helper.rb
@@ -18,7 +18,7 @@ module UsersHelper
       providers << provider if !ENV["OSEM_#{provider.upcase}_KEY"].blank? && !ENV["OSEM_#{provider.upcase}_SECRET"].blank?
     end
 
-    return providers.uniq
+    providers.uniq
   end
 
   # Receives a hash, generated from User model, function get_roles


### PR DESCRIPTION
Fixed Style/ReductantReturn rubocop offenses and deleted exclusions from .rubocop_todo.yml
This cop checks for redundant return expressions. It supports autocorrection.
Fixed #1824.

