### PR TITLE
Redirect to conference#show

### DIFF
--- a/app/controllers/conferences_controller.rb
+++ b/app/controllers/conferences_controller.rb
@@ -9,7 +9,7 @@ class ConferencesController < ApplicationController
 
     redirect_to @current.first if @current.count == 1 and
                                    @current.first.splashpage and
-                                   @current.first.splashpage.public==true
+                                   @current.first.splashpage.public
 
   end
 

--- a/app/controllers/conferences_controller.rb
+++ b/app/controllers/conferences_controller.rb
@@ -6,6 +6,11 @@ class ConferencesController < ApplicationController
   def index
     @current = Conference.where('end_date >= ?', Date.current).reorder(start_date: :asc)
     @antiquated = @conferences - @current
+
+    redirect_to @current.first if @current.count == 1 and
+                                   @current.first.splashpage and
+                                   @current.first.splashpage.public==true
+
   end
 
   def show

--- a/spec/controllers/conferences_controller_spec.rb
+++ b/spec/controllers/conferences_controller_spec.rb
@@ -6,9 +6,39 @@ describe ConferencesController do
   let(:room) { create(:room, venue: conference.venue) }
 
   describe 'GET #index' do
-    it 'Response code is 200' do
-      get :index
-      expect(response.response_code).to eq(200)
+    context 'without conference' do
+      it 'Response code is 200' do
+        conference.destroy!
+        get :index
+        expect(response.response_code).to eq(200)
+      end
+    end
+
+    context 'with one next conference' do
+      describe 'with splashpage' do
+        it 'Response code is 200 when is not public' do
+          current = Conference.first
+          current.splashpage.public = false
+          current.splashpage.save
+          get :index
+          expect(response.response_code).to eq(200)
+        end
+        it 'Response code is 302 when is public' do
+          get :index
+          expect(response.response_code).to eq(302)
+        end
+        it 'Redirect to conference#show' do
+          get :index
+          expect(response).to redirect_to(conference_path(conference))
+        end
+      end
+      describe 'without splashpage' do
+        it 'Response code is 200' do
+          conference.splashpage.destroy!
+          get :index
+          expect(response.response_code).to eq(200)
+        end
+      end
     end
   end
 


### PR DESCRIPTION
In conferences#index, if there are only one current conferences and has a public splashpage, redirect to it. fix #1259