### PR TITLE
Add call for booths section in conference splashpage(conferences#show)

### DIFF
--- a/app/views/conferences/_call_for_booths.html.haml
+++ b/app/views/conferences/_call_for_booths.html.haml
@@ -1,0 +1,30 @@
+= content_for :splash_nav do
+  %li
+    %a.smoothscroll{ href: '#callforbooths' } Call For Booths
+
+.container
+  .row
+    .col-md-12.text-center
+      %h2
+        Call for Booths
+      %p.lead
+        We are ready to accept requests for booths!
+  .row
+    .col-md-6.col-md-offset-3.col-sm-10.col-sm-offset-1
+      %p
+        The submission period for booth requests has begun
+        %em.notranslate
+          = @conference.program.cfps.for_booths.start_date.strftime('%A, %B %-d. %Y')
+        and closes
+        %em.notranslate
+          = @conference.program.cfps.for_booths.end_date.strftime('%A, %B %-d. %Y.')
+        - if @conference.program.cfps.for_booths.try(:open?)
+          That means you have only
+          %b.notranslate= pluralize(@conference.program.cfps.for_booths.remaining_days, 'day')
+          left!
+        - else
+          The submission period for booth requests is closed.
+  .row
+    .col-md-12.text-center
+      %p.cta-button
+        = link_to "Submit your request for booth", conference_booths_path(@conference.short_title), class: 'btn btn-success btn-lg text-center'

--- a/app/views/conferences/show.html.haml
+++ b/app/views/conferences/show.html.haml
@@ -53,6 +53,10 @@
       %section#callfortracks
         = render 'call_for_tracks'
 
+    - if @conference.program.cfps.for_booths.try(:open?) && @conference.splashpage.include_cfp
+      %section#callforbooths
+        = render 'call_for_booths'
+
     - if @conference.venue and @conference.splashpage.include_venue
       %section#venue
         = render 'venue'


### PR DESCRIPTION
There was no section in conference splash page for call for papers(_cfp_) regarding booths. The section was added with design similar to _cfp_ for tracks so that all _cfps_ have a consistent look. 