### PR TITLE
Redirect to conference#show

### DIFF
--- a/app/controllers/conferences_controller.rb
+++ b/app/controllers/conferences_controller.rb
@@ -6,6 +6,10 @@ class ConferencesController < ApplicationController
   def index
     @current = Conference.where('end_date >= ?', Date.current).reorder(start_date: :asc)
     @antiquated = @conferences - @current
+
+    redirect_to @current.first if @current.count == 1 &&
+                                  @current.first.splashpage &&
+                                  @current.first.splashpage.public
   end
 
   def show

--- a/spec/controllers/conferences_controller_spec.rb
+++ b/spec/controllers/conferences_controller_spec.rb
@@ -6,9 +6,39 @@ describe ConferencesController do
   let(:room) { create(:room, venue: conference.venue) }
 
   describe 'GET #index' do
-    it 'Response code is 200' do
-      get :index
-      expect(response.response_code).to eq(200)
+    context 'without conference' do
+      it 'Response code is 200' do
+        conference.destroy!
+        get :index
+        expect(response.response_code).to eq(200)
+      end
+    end
+
+    context 'with one next conference' do
+      describe 'with splashpage' do
+        it 'Response code is 200 when is not public' do
+          current = Conference.first
+          current.splashpage.public = false
+          current.splashpage.save
+          get :index
+          expect(response.response_code).to eq(200)
+        end
+        it 'Response code is 302 when is public' do
+          get :index
+          expect(response.response_code).to eq(302)
+        end
+        it 'Redirect to conference#show' do
+          get :index
+          expect(response).to redirect_to(conference_path(conference))
+        end
+      end
+      describe 'without splashpage' do
+        it 'Response code is 200' do
+          conference.splashpage.destroy!
+          get :index
+          expect(response.response_code).to eq(200)
+        end
+      end
     end
   end
 

--- a/spec/features/cfp_ability_spec.rb
+++ b/spec/features/cfp_ability_spec.rb
@@ -75,7 +75,7 @@ feature 'Has correct abilities' do
       # Event, booth, track cfps exist
       call_for_tracks = create(:cfp, cfp_type: 'tracks', program: conference.program)
       visit new_admin_conference_program_cfp_path(conference.short_title)
-      expect(current_path).to eq root_path
+      expect(current_path).to eq conference_path(conference)
 
       # Booth and track cfps exist
       conference.program.cfp.destroy!
@@ -146,17 +146,17 @@ feature 'Has correct abilities' do
 
       create(:registration, user: create(:user), conference: conference)
       visit edit_admin_conference_registration_path(conference.short_title, conference.registrations.first)
-      expect(current_path).to eq(root_path)
+      expect(current_path).to eq(conference_path(conference))
 
       visit new_admin_conference_registration_period_path(conference.short_title)
-      expect(current_path).to eq(root_path)
+      expect(current_path).to eq(conference_path(conference))
 
       create(:registration_period, conference: conference)
       visit edit_admin_conference_registration_period_path(conference.short_title)
-      expect(current_path).to eq(root_path)
+      expect(current_path).to eq(conference_path(conference))
 
       visit admin_conference_questions_path(conference.short_title)
-      expect(current_path).to eq(root_path)
+      expect(current_path).to eq(conference_path(conference))
 
       visit admin_conference_program_tracks_path(conference.short_title)
       expect(current_path).to eq(admin_conference_program_tracks_path(conference.short_title))
@@ -174,99 +174,99 @@ feature 'Has correct abilities' do
       expect(current_path).to eq(admin_organizations_path)
 
       visit edit_admin_organization_path(organization)
-      expect(current_path).to eq(root_path)
+      expect(current_path).to eq(conference_path(conference))
 
       visit new_admin_organization_path
-      expect(current_path).to eq(root_path)
+      expect(current_path).to eq(conference_path(conference))
 
       visit edit_admin_conference_path(conference.short_title)
-      expect(current_path).to eq(root_path)
+      expect(current_path).to eq(conference_path(conference))
 
       visit edit_admin_conference_contact_path(conference.short_title)
-      expect(current_path).to eq(root_path)
+      expect(current_path).to eq(conference_path(conference))
 
       visit admin_conference_commercials_path(conference.short_title)
       expect(current_path).to eq(admin_conference_commercials_path(conference.short_title))
 
       visit new_admin_conference_splashpage_path(conference.short_title)
-      expect(current_path).to eq(root_path)
+      expect(current_path).to eq(conference_path(conference))
 
       visit edit_admin_conference_splashpage_path(conference.short_title)
-      expect(current_path).to eq(root_path)
+      expect(current_path).to eq(conference_path(conference))
 
       visit new_admin_conference_venue_path(conference.short_title)
-      expect(current_path).to eq(root_path)
+      expect(current_path).to eq(conference_path(conference))
 
       conference.venue = create(:venue)
       visit edit_admin_conference_venue_path(conference.short_title)
-      expect(current_path).to eq(root_path)
+      expect(current_path).to eq(conference_path(conference))
 
       visit admin_conference_lodgings_path(conference.short_title)
-      expect(current_path).to eq(root_path)
+      expect(current_path).to eq(conference_path(conference))
 
       visit new_admin_conference_lodging_path(conference.short_title)
-      expect(current_path).to eq(root_path)
+      expect(current_path).to eq(conference_path(conference))
 
       create(:lodging, conference: conference)
       visit edit_admin_conference_lodging_path(conference.short_title, conference.lodgings.first)
-      expect(current_path).to eq(root_path)
+      expect(current_path).to eq(conference_path(conference))
 
       visit new_admin_conference_registration_period_path(conference.short_title)
-      expect(current_path).to eq(root_path)
+      expect(current_path).to eq(conference_path(conference))
 
       create(:registration_period, conference: conference)
       visit edit_admin_conference_registration_period_path(conference.short_title)
-      expect(current_path).to eq(root_path)
+      expect(current_path).to eq(conference_path(conference))
 
       visit admin_conference_sponsorship_levels_path(conference.short_title)
-      expect(current_path).to eq(root_path)
+      expect(current_path).to eq(conference_path(conference))
 
       visit new_admin_conference_sponsorship_level_path(conference.short_title)
-      expect(current_path).to eq(root_path)
+      expect(current_path).to eq(conference_path(conference))
 
       create(:sponsorship_level, conference: conference)
       visit edit_admin_conference_sponsorship_level_path(conference.short_title, conference.sponsorship_levels.first)
-      expect(current_path).to eq(root_path)
+      expect(current_path).to eq(conference_path(conference))
 
       visit admin_conference_sponsors_path(conference.short_title)
-      expect(current_path).to eq(root_path)
+      expect(current_path).to eq(conference_path(conference))
 
       visit new_admin_conference_sponsor_path(conference.short_title)
-      expect(current_path).to eq(root_path)
+      expect(current_path).to eq(conference_path(conference))
 
       create(:sponsor, conference: conference, sponsorship_level: conference.sponsorship_levels.first)
       visit edit_admin_conference_sponsor_path(conference.short_title, conference.sponsors.first)
-      expect(current_path).to eq(root_path)
+      expect(current_path).to eq(conference_path(conference))
 
       visit admin_conference_tickets_path(conference.short_title)
-      expect(current_path).to eq(root_path)
+      expect(current_path).to eq(conference_path(conference))
 
       visit new_admin_conference_ticket_path(conference.short_title)
-      expect(current_path).to eq(root_path)
+      expect(current_path).to eq(conference_path(conference))
 
       create(:ticket, conference: conference)
       visit edit_admin_conference_ticket_path(conference.short_title, conference.tickets.first)
-      expect(current_path).to eq(root_path)
+      expect(current_path).to eq(conference_path(conference))
 
       visit admin_conference_campaigns_path(conference.short_title)
-      expect(current_path).to eq(root_path)
+      expect(current_path).to eq(conference_path(conference))
 
       visit new_admin_conference_campaign_path(conference.short_title)
-      expect(current_path).to eq(root_path)
+      expect(current_path).to eq(conference_path(conference))
 
       create(:campaign, conference: conference)
       visit edit_admin_conference_campaign_path(conference.short_title, conference.campaigns.first)
-      expect(current_path).to eq(root_path)
+      expect(current_path).to eq(conference_path(conference))
 
       visit admin_conference_targets_path(conference.short_title)
-      expect(current_path).to eq(root_path)
+      expect(current_path).to eq(conference_path(conference))
 
       visit new_admin_conference_target_path(conference.short_title)
-      expect(current_path).to eq(root_path)
+      expect(current_path).to eq(conference_path(conference))
 
       create(:target, conference: conference)
       visit edit_admin_conference_target_path(conference.short_title, conference.targets.first)
-      expect(current_path).to eq(root_path)
+      expect(current_path).to eq(conference_path(conference))
 
       visit admin_conference_roles_path(conference.short_title)
       expect(current_path).to eq(admin_conference_roles_path(conference.short_title))
@@ -292,10 +292,10 @@ feature 'Has correct abilities' do
       expect(current_path).to eq(edit_admin_conference_resource_path(conference.short_title, conference.resources.first))
 
       visit admin_users_path
-      expect(current_path).to eq(root_path)
+      expect(current_path).to eq(conference_path(conference))
 
       visit admin_user_path(user_cfp)
-      expect(current_path).to eq(root_path)
+      expect(current_path).to eq(conference_path(conference))
 
       visit admin_revision_history_path
       expect(current_path).to eq(admin_revision_history_path)

--- a/spec/features/info_desk_ability_spec.rb
+++ b/spec/features/info_desk_ability_spec.rb
@@ -52,99 +52,99 @@ feature 'Has correct abilities' do
       expect(current_path).to eq(admin_organizations_path)
 
       visit edit_admin_organization_path(organization)
-      expect(current_path).to eq(root_path)
+      expect(current_path).to eq(conference_path(conference))
 
       visit new_admin_organization_path
-      expect(current_path).to eq(root_path)
+      expect(current_path).to eq(conference_path(conference))
 
       visit edit_admin_conference_path(conference.short_title)
-      expect(current_path).to eq(root_path)
+      expect(current_path).to eq(conference_path(conference))
 
       visit edit_admin_conference_contact_path(conference.short_title)
-      expect(current_path).to eq(root_path)
+      expect(current_path).to eq(conference_path(conference))
 
       visit admin_conference_commercials_path(conference.short_title)
       expect(current_path).to eq(admin_conference_commercials_path(conference.short_title))
 
       visit new_admin_conference_splashpage_path(conference.short_title)
-      expect(current_path).to eq(root_path)
+      expect(current_path).to eq(conference_path(conference))
 
       visit edit_admin_conference_splashpage_path(conference.short_title)
-      expect(current_path).to eq(root_path)
+      expect(current_path).to eq(conference_path(conference))
 
       visit new_admin_conference_venue_path(conference.short_title)
-      expect(current_path).to eq(root_path)
+      expect(current_path).to eq(conference_path(conference))
 
       conference.venue = create(:venue)
       visit edit_admin_conference_venue_path(conference.short_title)
-      expect(current_path).to eq(root_path)
+      expect(current_path).to eq(conference_path(conference))
 
       visit admin_conference_lodgings_path(conference.short_title)
-      expect(current_path).to eq(root_path)
+      expect(current_path).to eq(conference_path(conference))
 
       visit new_admin_conference_lodging_path(conference.short_title)
-      expect(current_path).to eq(root_path)
+      expect(current_path).to eq(conference_path(conference))
 
       create(:lodging, conference: conference)
       visit edit_admin_conference_lodging_path(conference.short_title, conference.lodgings.first)
-      expect(current_path).to eq(root_path)
+      expect(current_path).to eq(conference_path(conference))
 
       visit new_admin_conference_registration_period_path(conference.short_title)
-      expect(current_path).to eq(root_path)
+      expect(current_path).to eq(conference_path(conference))
 
       create(:registration_period, conference: conference)
       visit edit_admin_conference_registration_period_path(conference.short_title)
-      expect(current_path).to eq(root_path)
+      expect(current_path).to eq(conference_path(conference))
 
       visit admin_conference_sponsorship_levels_path(conference.short_title)
-      expect(current_path).to eq(root_path)
+      expect(current_path).to eq(conference_path(conference))
 
       visit new_admin_conference_sponsorship_level_path(conference.short_title)
-      expect(current_path).to eq(root_path)
+      expect(current_path).to eq(conference_path(conference))
 
       create(:sponsorship_level, conference: conference)
       visit edit_admin_conference_sponsorship_level_path(conference.short_title, conference.sponsorship_levels.first)
-      expect(current_path).to eq(root_path)
+      expect(current_path).to eq(conference_path(conference))
 
       visit admin_conference_sponsors_path(conference.short_title)
-      expect(current_path).to eq(root_path)
+      expect(current_path).to eq(conference_path(conference))
 
       visit new_admin_conference_sponsor_path(conference.short_title)
-      expect(current_path).to eq(root_path)
+      expect(current_path).to eq(conference_path(conference))
 
       create(:sponsor, conference: conference, sponsorship_level: conference.sponsorship_levels.first)
       visit edit_admin_conference_sponsor_path(conference.short_title, conference.sponsors.first)
-      expect(current_path).to eq(root_path)
+      expect(current_path).to eq(conference_path(conference))
 
       visit admin_conference_tickets_path(conference.short_title)
-      expect(current_path).to eq(root_path)
+      expect(current_path).to eq(conference_path(conference))
 
       visit new_admin_conference_ticket_path(conference.short_title)
-      expect(current_path).to eq(root_path)
+      expect(current_path).to eq(conference_path(conference))
 
       create(:ticket, conference: conference)
       visit edit_admin_conference_ticket_path(conference.short_title, conference.tickets.first)
-      expect(current_path).to eq(root_path)
+      expect(current_path).to eq(conference_path(conference))
 
       visit admin_conference_campaigns_path(conference.short_title)
-      expect(current_path).to eq(root_path)
+      expect(current_path).to eq(conference_path(conference))
 
       visit new_admin_conference_campaign_path(conference.short_title)
-      expect(current_path).to eq(root_path)
+      expect(current_path).to eq(conference_path(conference))
 
       create(:campaign, conference: conference)
       visit edit_admin_conference_campaign_path(conference.short_title, conference.campaigns.first)
-      expect(current_path).to eq(root_path)
+      expect(current_path).to eq(conference_path(conference))
 
       visit admin_conference_targets_path(conference.short_title)
-      expect(current_path).to eq(root_path)
+      expect(current_path).to eq(conference_path(conference))
 
       visit new_admin_conference_target_path(conference.short_title)
-      expect(current_path).to eq(root_path)
+      expect(current_path).to eq(conference_path(conference))
 
       create(:target, conference: conference)
       visit edit_admin_conference_target_path(conference.short_title, conference.targets.first)
-      expect(current_path).to eq(root_path)
+      expect(current_path).to eq(conference_path(conference))
 
       visit admin_conference_roles_path(conference.short_title)
       expect(current_path).to eq(admin_conference_roles_path(conference.short_title))
@@ -166,63 +166,63 @@ feature 'Has correct abilities' do
       expect(current_path).to eq(admin_conference_path(conference.short_title))
 
       visit admin_conference_venue_rooms_path(conference.short_title)
-      expect(current_path).to eq(root_path)
+      expect(current_path).to eq(conference_path(conference))
 
       create(:room, venue: conference.venue)
       visit edit_admin_conference_venue_room_path(conference.short_title, conference.venue.rooms.first)
-      expect(current_path).to eq(root_path)
+      expect(current_path).to eq(conference_path(conference))
 
       visit new_admin_conference_program_path(conference.short_title)
-      expect(current_path).to eq(root_path)
+      expect(current_path).to eq(conference_path(conference))
 
       visit edit_admin_conference_program_path(conference.short_title)
-      expect(current_path).to eq(root_path)
+      expect(current_path).to eq(conference_path(conference))
 
       visit new_admin_conference_program_cfp_path(conference.short_title)
-      expect(current_path).to eq root_path
+      expect(current_path).to eq conference_path(conference)
 
       conference.program.cfp.destroy!
       visit new_admin_conference_program_cfp_path(conference.short_title)
-      expect(current_path).to eq root_path
+      expect(current_path).to eq conference_path(conference)
       create(:cfp, program: conference.program)
 
       visit edit_admin_conference_program_cfp_path(conference.short_title, conference.program.cfp)
-      expect(current_path).to eq(root_path)
+      expect(current_path).to eq(conference_path(conference))
 
       visit admin_conference_program_events_path(conference.short_title)
-      expect(current_path).to eq(root_path)
+      expect(current_path).to eq(conference_path(conference))
 
       create(:event, program: conference.program)
       visit edit_admin_conference_program_event_path(conference.short_title, conference.program.events.first)
-      expect(current_path).to eq(root_path)
+      expect(current_path).to eq(conference_path(conference))
 
       visit admin_conference_program_event_types_path(conference.short_title)
-      expect(current_path).to eq(root_path)
+      expect(current_path).to eq(conference_path(conference))
 
       visit new_admin_conference_program_event_type_path(conference.short_title)
-      expect(current_path).to eq(root_path)
+      expect(current_path).to eq(conference_path(conference))
 
       visit edit_admin_conference_program_event_type_path(conference.short_title, conference.program.event_types.first)
-      expect(current_path).to eq(root_path)
+      expect(current_path).to eq(conference_path(conference))
 
       visit admin_conference_program_difficulty_levels_path(conference.short_title)
-      expect(current_path).to eq(root_path)
+      expect(current_path).to eq(conference_path(conference))
 
       visit new_admin_conference_program_difficulty_level_path(conference.short_title)
-      expect(current_path).to eq(root_path)
+      expect(current_path).to eq(conference_path(conference))
 
       visit edit_admin_conference_program_difficulty_level_path(conference.short_title, conference.program.difficulty_levels.first)
-      expect(current_path).to eq(root_path)
+      expect(current_path).to eq(conference_path(conference))
 
       visit admin_conference_schedules_path(conference.short_title)
-      expect(current_path).to eq(root_path)
+      expect(current_path).to eq(conference_path(conference))
 
       create(:schedule, program: conference.program)
       visit admin_conference_schedule_path(conference.short_title, conference.program.schedules.first)
-      expect(current_path).to eq(root_path)
+      expect(current_path).to eq(conference_path(conference))
 
       visit admin_conference_program_reports_path(conference.short_title)
-      expect(current_path).to eq(root_path)
+      expect(current_path).to eq(conference_path(conference))
 
       visit admin_conference_registrations_path(conference.short_title)
       expect(current_path).to eq(admin_conference_registrations_path(conference.short_title))
@@ -235,16 +235,16 @@ feature 'Has correct abilities' do
       expect(current_path).to eq(admin_conference_questions_path(conference.short_title))
 
       visit admin_conference_program_tracks_path(conference.short_title)
-      expect(current_path).to eq(root_path)
+      expect(current_path).to eq(conference_path(conference))
 
       visit admin_users_path
-      expect(current_path).to eq(root_path)
+      expect(current_path).to eq(conference_path(conference))
 
       visit admin_user_path(user_info_desk)
-      expect(current_path).to eq(root_path)
+      expect(current_path).to eq(conference_path(conference))
 
       visit admin_conference_emails_path(conference.short_title)
-      expect(current_path).to eq(root_path)
+      expect(current_path).to eq(conference_path(conference))
     end
   end
 end

--- a/spec/features/organization_admin_ability_spec.rb
+++ b/spec/features/organization_admin_ability_spec.rb
@@ -20,7 +20,7 @@ feature 'Has correct abilities' do
       expect(current_path).to eq(edit_admin_organization_path(organization))
 
       visit new_admin_organization_path
-      expect(current_path).to eq(root_path)
+      expect(current_path).to eq(conference_path(conference))
     end
 
     scenario 'for conference attributes' do
@@ -118,7 +118,7 @@ feature 'Has correct abilities' do
       # Event, booth, track cfps exist
       call_for_tracks = create(:cfp, cfp_type: 'tracks', program: conference.program)
       visit new_admin_conference_program_cfp_path(conference.short_title)
-      expect(current_path).to eq root_path
+      expect(current_path).to eq conference_path(conference)
 
       # Booth and track cfps exist
       conference.program.cfp.destroy!

--- a/spec/features/track_organizer_ability_spec.rb
+++ b/spec/features/track_organizer_ability_spec.rb
@@ -50,91 +50,91 @@ feature 'Has correct abilities' do
       expect(page).to_not have_link('New Conference', href: '/admin/conferences/new')
 
       visit edit_admin_conference_path(conference.short_title)
-      expect(current_path).to eq root_path
+      expect(current_path).to eq conference_path(conference)
 
       visit edit_admin_conference_contact_path(conference.short_title)
-      expect(current_path).to eq root_path
+      expect(current_path).to eq conference_path(conference)
 
       visit admin_conference_commercials_path(conference.short_title)
       expect(current_path).to eq admin_conference_commercials_path(conference.short_title)
 
       visit new_admin_conference_splashpage_path(conference.short_title)
-      expect(current_path).to eq root_path
+      expect(current_path).to eq conference_path(conference)
 
       visit edit_admin_conference_splashpage_path(conference.short_title)
-      expect(current_path).to eq root_path
+      expect(current_path).to eq conference_path(conference)
 
       visit new_admin_conference_venue_path(conference.short_title)
-      expect(current_path).to eq root_path
+      expect(current_path).to eq conference_path(conference)
 
       conference.venue = create(:venue)
       visit edit_admin_conference_venue_path(conference.short_title)
-      expect(current_path).to eq root_path
+      expect(current_path).to eq conference_path(conference)
 
       visit admin_conference_venue_rooms_path(conference.short_title)
-      expect(current_path).to eq root_path
+      expect(current_path).to eq conference_path(conference)
 
       create(:room, venue: conference.venue)
       visit edit_admin_conference_venue_room_path(conference.short_title, conference.venue.rooms.first)
-      expect(current_path).to eq root_path
+      expect(current_path).to eq conference_path(conference)
 
       visit admin_conference_lodgings_path(conference.short_title)
-      expect(current_path).to eq root_path
+      expect(current_path).to eq conference_path(conference)
 
       visit new_admin_conference_lodging_path(conference.short_title)
-      expect(current_path).to eq root_path
+      expect(current_path).to eq conference_path(conference)
 
       create(:lodging, conference: conference)
       visit edit_admin_conference_lodging_path(conference.short_title, conference.lodgings.first)
-      expect(current_path).to eq root_path
+      expect(current_path).to eq conference_path(conference)
 
       visit new_admin_conference_program_path(conference.short_title)
-      expect(current_path).to eq root_path
+      expect(current_path).to eq conference_path(conference)
 
       visit edit_admin_conference_program_path(conference.short_title)
-      expect(current_path).to eq root_path
+      expect(current_path).to eq conference_path(conference)
 
       visit new_admin_conference_program_cfp_path(conference.short_title)
-      expect(current_path).to eq root_path
+      expect(current_path).to eq conference_path(conference)
 
       visit edit_admin_conference_program_cfp_path(conference.short_title, conference.program.cfp)
-      expect(current_path).to eq root_path
+      expect(current_path).to eq conference_path(conference)
 
       visit admin_conference_program_events_path(conference.short_title)
       expect(current_path).to eq admin_conference_program_events_path(conference.short_title)
 
       create(:event, program: conference.program)
       visit edit_admin_conference_program_event_path(conference.short_title, conference.program.events.first)
-      expect(current_path).to eq root_path
+      expect(current_path).to eq conference_path(conference)
 
       self_organized_track_event = create(:event, program: conference.program, track: self_organized_track)
       visit edit_admin_conference_program_event_path(conference.short_title, self_organized_track_event)
       expect(current_path).to eq(edit_admin_conference_program_event_path(conference.short_title, self_organized_track_event))
 
       visit admin_conference_program_event_types_path(conference.short_title)
-      expect(current_path).to eq root_path
+      expect(current_path).to eq conference_path(conference)
 
       visit new_admin_conference_program_event_type_path(conference.short_title)
-      expect(current_path).to eq root_path
+      expect(current_path).to eq conference_path(conference)
 
       visit edit_admin_conference_program_event_type_path(conference.short_title, conference.program.event_types.first)
-      expect(current_path).to eq root_path
+      expect(current_path).to eq conference_path(conference)
 
       visit admin_conference_program_difficulty_levels_path(conference.short_title)
-      expect(current_path).to eq root_path
+      expect(current_path).to eq conference_path(conference)
 
       visit new_admin_conference_program_difficulty_level_path(conference.short_title)
-      expect(current_path).to eq root_path
+      expect(current_path).to eq conference_path(conference)
 
       visit edit_admin_conference_program_difficulty_level_path(conference.short_title, conference.program.difficulty_levels.first)
-      expect(current_path).to eq root_path
 
+      expect(current_path).to eq conference_path(conference)
       visit admin_conference_schedules_path(conference.short_title)
       expect(current_path).to eq admin_conference_schedules_path(conference.short_title)
 
       create(:schedule, program: conference.program)
       visit admin_conference_schedule_path(conference.short_title, conference.program.schedules.first)
-      expect(current_path).to eq root_path
+      expect(current_path).to eq conference_path(conference)
 
       self_organized_track_schedule = create(:schedule, program: conference.program, track: self_organized_track)
       visit admin_conference_schedule_path(conference.short_title, self_organized_track_schedule)
@@ -148,92 +148,92 @@ feature 'Has correct abilities' do
 
       create(:registration, user: create(:user), conference: conference)
       visit edit_admin_conference_registration_path(conference.short_title, conference.registrations.first)
-      expect(current_path).to eq root_path
+      expect(current_path).to eq conference_path(conference)
 
       visit new_admin_conference_registration_period_path(conference.short_title)
-      expect(current_path).to eq root_path
+      expect(current_path).to eq conference_path(conference)
 
       create(:registration_period, conference: conference)
       visit edit_admin_conference_registration_period_path(conference.short_title)
-      expect(current_path).to eq root_path
+      expect(current_path).to eq conference_path(conference)
 
       visit admin_conference_questions_path(conference.short_title)
-      expect(current_path).to eq root_path
+      expect(current_path).to eq conference_path(conference)
 
       visit admin_conference_sponsorship_levels_path(conference.short_title)
-      expect(current_path).to eq root_path
+      expect(current_path).to eq conference_path(conference)
 
       visit new_admin_conference_sponsorship_level_path(conference.short_title)
-      expect(current_path).to eq root_path
+      expect(current_path).to eq conference_path(conference)
 
       create(:sponsorship_level, conference: conference)
       visit edit_admin_conference_sponsorship_level_path(conference.short_title, conference.sponsorship_levels.first)
-      expect(current_path).to eq root_path
+      expect(current_path).to eq conference_path(conference)
 
       visit admin_conference_sponsors_path(conference.short_title)
-      expect(current_path).to eq root_path
+      expect(current_path).to eq conference_path(conference)
 
       visit new_admin_conference_sponsor_path(conference.short_title)
-      expect(current_path).to eq root_path
+      expect(current_path).to eq conference_path(conference)
 
       create(:sponsor, conference: conference, sponsorship_level: conference.sponsorship_levels.first)
       visit edit_admin_conference_sponsor_path(conference.short_title, conference.sponsors.first)
-      expect(current_path).to eq root_path
+      expect(current_path).to eq conference_path(conference)
 
       visit admin_conference_tickets_path(conference.short_title)
-      expect(current_path).to eq root_path
+      expect(current_path).to eq conference_path(conference)
 
       visit new_admin_conference_ticket_path(conference.short_title)
-      expect(current_path).to eq root_path
+      expect(current_path).to eq conference_path(conference)
 
       create(:ticket, conference: conference)
       visit edit_admin_conference_ticket_path(conference.short_title, conference.tickets.first)
-      expect(current_path).to eq root_path
+      expect(current_path).to eq conference_path(conference)
 
       visit admin_conference_campaigns_path(conference.short_title)
-      expect(current_path).to eq root_path
+      expect(current_path).to eq conference_path(conference)
 
       visit new_admin_conference_campaign_path(conference.short_title)
-      expect(current_path).to eq root_path
+      expect(current_path).to eq conference_path(conference)
 
       create(:campaign, conference: conference)
       visit edit_admin_conference_campaign_path(conference.short_title, conference.campaigns.first)
-      expect(current_path).to eq root_path
+      expect(current_path).to eq conference_path(conference)
 
       visit admin_conference_targets_path(conference.short_title)
-      expect(current_path).to eq root_path
+      expect(current_path).to eq conference_path(conference)
 
       visit new_admin_conference_target_path(conference.short_title)
-      expect(current_path).to eq root_path
+      expect(current_path).to eq conference_path(conference)
 
       create(:target, conference: conference)
       visit edit_admin_conference_target_path(conference.short_title, conference.targets.first)
-      expect(current_path).to eq root_path
+      expect(current_path).to eq conference_path(conference)
 
       visit admin_conference_program_tracks_path(conference.short_title)
       expect(current_path).to eq admin_conference_program_tracks_path(conference.short_title)
 
       visit new_admin_conference_program_track_path(conference.short_title)
-      expect(current_path).to eq root_path
+      expect(current_path).to eq conference_path(conference)
 
       other_track = create(:track, program: conference.program)
       visit admin_conference_program_track_path(conference.short_title, other_track)
-      expect(current_path).to eq root_path
+      expect(current_path).to eq conference_path(conference)
 
       visit edit_admin_conference_program_track_path(conference.short_title, other_track)
-      expect(current_path).to eq root_path
+      expect(current_path).to eq conference_path(conference)
 
       visit admin_conference_program_track_path(conference.short_title, self_organized_track)
       expect(current_path).to eq admin_conference_program_track_path(conference.short_title, self_organized_track)
 
       visit edit_admin_conference_program_track_path(conference.short_title, self_organized_track)
-      expect(current_path).to eq root_path
+      expect(current_path).to eq conference_path(conference)
 
       visit admin_conference_roles_path(conference.short_title)
       expect(current_path).to eq admin_conference_roles_path(conference.short_title)
 
       visit admin_conference_emails_path(conference.short_title)
-      expect(current_path).to eq root_path
+      expect(current_path).to eq conference_path(conference)
 
       visit admin_conference_resources_path(conference.short_title)
       expect(current_path).to eq admin_conference_resources_path(conference.short_title)
@@ -243,10 +243,10 @@ feature 'Has correct abilities' do
 
       create(:resource, conference: conference)
       visit edit_admin_conference_resource_path(conference.short_title, conference.resources.first)
-      expect(current_path).to eq root_path
+      expect(current_path).to eq conference_path(conference)
 
       visit admin_revision_history_path
-      expect(current_path).to eq root_path
+      expect(current_path).to eq conference_path(conference)
     end
   end
 end

--- a/spec/features/user_ability_spec.rb
+++ b/spec/features/user_ability_spec.rb
@@ -14,7 +14,7 @@ feature 'Has correct abilities' do
     scenario 'for administration views' do
       visit admin_conference_path(conference.short_title)
 
-      expect(current_path).to eq root_path
+      expect(current_path).to eq conference_path(conference)
       expect(flash).to eq 'You are not authorized to access this page.'
     end
   end


### PR DESCRIPTION
In conferences#index, if there are only one current conferences and has a public splashpage, redirect to it

I need to change some tests from root_path to conference_path(conference). I don't kwown if is better to change the conference object (to set splashpage not public for example) in the test and remain root_path. 

fix #1259