### PR TITLE
autofill CFP end date

### DIFF
--- a/app/assets/javascripts/osem-datepickers.js
+++ b/app/assets/javascripts/osem-datepickers.js
@@ -98,6 +98,9 @@ $(function () {
 
   $("#registration-period-start-datepicker").on("dp.change",function (e) {
       $('#registration-period-end-datepicker').data("DateTimePicker").setMinDate(e.date);
+      if (!$('#registration-period-end-datepicker').val()) {
+         $('#registration-period-end-datepicker').data("DateTimePicker").setDate(e.date);
+      }
   });
   $("#registration-period-end-datepicker").on("dp.change",function (e) {
       $('#registration-period-start-datepicker').data("DateTimePicker").setMaxDate(e.date);


### PR DESCRIPTION
- automatically setting the end date to the start date when creating CFP or "Registration Period" for UX reasons (fix #1872)

new behaviour:

![new-behaviour](https://user-images.githubusercontent.com/5561794/33796323-35e5e514-dcd9-11e7-835a-9f88eb61d9f7.gif)
