### PR TITLE
link_to_organization method in version is fixed

### DIFF
--- a/app/helpers/versions_helper.rb
+++ b/app/helpers/versions_helper.rb
@@ -9,9 +9,14 @@ module VersionsHelper
   def link_to_organization(organization_id)
     return 'deleted organization' unless organization_id
 
-    org = Organization.find_by(id: organization_id)
-    return current_or_last_object_state('Organization', organization_id).try(:name) unless org
-    org.name.to_s
+    organization = Organization.find_by(id: organization_id)
+    if organization
+      link_to organization.name,
+              edit_admin_organization_path(organization.id)
+    else
+      name = current_or_last_object_state('Organization', organization_id).try(:name) || ''
+      " #{name} with ID #{organization_id}"
+    end
   end
 
   def link_to_conference(conference_id)


### PR DESCRIPTION
Closes #1724 
As link_to_conference is returning link to edit_admin_conference_path same is done for link_to_organization which is returning the link to edit_admin_organization_path