### PR TITLE
Use distinct instead of uniq in user.rb because deprectation

### DIFF
--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -45,8 +45,8 @@ class User < ApplicationRecord
   attr_accessor :login
 
   has_many :event_users, dependent: :destroy
-  has_many :events, -> { uniq }, through: :event_users
-  has_many :presented_events, -> { joins(:event_users).where(event_users: {event_role: 'speaker'}).uniq }, through: :event_users, source: :event
+  has_many :events, -> { distinct }, through: :event_users
+  has_many :presented_events, -> { joins(:event_users).where(event_users: {event_role: 'speaker'}).distinct }, through: :event_users, source: :event
   has_many :registrations, dependent: :destroy do
     def for_conference conference
       where(conference: conference).first


### PR DESCRIPTION
Fix deprecation warning in user.rb:

```
DEPRECATION WARNING: uniq is deprecated and will be removed from Rails 5.1 (use distinct instead) (called from block in <class:User> at /vagrant/app/models/user.rb:48)
```