### PR TITLE
Added styling in conferences#show _tickets 

### DIFF
--- a/app/assets/stylesheets/osem.scss
+++ b/app/assets/stylesheets/osem.scss
@@ -110,7 +110,7 @@ p.comment-body {
 .g-recaptcha {
     @include clearfix;
     padding-bottom: 12px;
-    
+
     div {
         float: right;
     }
@@ -120,4 +120,8 @@ p.comment-body {
 #openid-btn-grp{
   display: flex;
   justify-content: center;
+}
+
+.word_break {
+  word-wrap: break-word;
 }

--- a/app/views/conferences/_tickets.haml
+++ b/app/views/conferences/_tickets.haml
@@ -16,9 +16,10 @@
             = link_to(conference_tickets_path(conference.short_title),
               class: 'thumbnail') do
               .caption
-                %h3.text-center
+                %h3.text-center.word_break
                   = ticket.title
-                = markdown(ticket.description)
+                .word_break
+                  = markdown(ticket.description)
                 %button.btn-block.btn.btn-lg.btn-success
                   %i.fa.fa-ticket.fa-fw
                   = humanized_money_with_symbol(ticket.price)


### PR DESCRIPTION
Added styling in conferences#show _tickets so that when the title of the ticket and its description is too large and without spaces, it can wrap in separate lines