### PR TITLE
Fix commercials does not accept slideshare https url

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -179,7 +179,7 @@ gem 'acts_as_list'
 gem 'bootstrap-switch-rails', '~> 3.0.0'
 
 # for parsing OEmbed data
-gem 'ruby-oembed'
+gem 'ruby-oembed', '~>0.12.0'
 
 # for uploading images to the cloud
 gem 'cloudinary'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -479,7 +479,7 @@ GEM
       rainbow (>= 2.2.2, < 3.0)
       ruby-progressbar (~> 1.7)
       unicode-display_width (~> 1.0, >= 1.0.1)
-    ruby-oembed (0.8.14)
+    ruby-oembed (0.12.0)
     ruby-openid (2.5.0)
     ruby-progressbar (1.9.0)
     ruby_dep (1.5.0)
@@ -662,7 +662,7 @@ DEPENDENCIES
   rspec-activemodel-mocks
   rspec-rails (~> 3.5, >= 3.5.2)
   rubocop (~> 0.51.0)
-  ruby-oembed
+  ruby-oembed (~> 0.12.0)
   sass-rails (>= 4.0.2)
   selectize-rails
   shoulda-matchers


### PR DESCRIPTION
Updated ruby-oembed to latest version 0.12.0, issue was due to ruby-oembed version 0.8.14 not accepting https slideshare links.
Fixes #1775 

Ref:
Latest version: https://github.com/ruby-oembed/ruby-oembed/blob/master/lib/oembed/providers.rb#L234
Version 0.8.14: https://github.com/ruby-oembed/ruby-oembed/blob/v0.8.14/lib/oembed/providers/embedly_urls.yml#L33