### PR TITLE
added user_propsals to show all talks irrespective of conference

### DIFF
--- a/app/controllers/conferences_controller.rb
+++ b/app/controllers/conferences_controller.rb
@@ -18,6 +18,11 @@ class ConferencesController < ApplicationController
     @program = @conference.program
   end
 
+  def user_proposals
+    event_types = EventType.where(title: 'Talk').collect(&:id)
+    @events = Event.includes(program: :conference).where(event_type_id: event_types).order(created_at: :desc)
+  end
+
   private
 
   def load_conference_by_domain

--- a/app/models/ability.rb
+++ b/app/models/ability.rb
@@ -107,6 +107,8 @@ class Ability
     can [:edit, :update], Track do |track|
       user == track.submitter && !(track.accepted? || track.confirmed?)
     end
+
+    can :user_proposals, Conference
   end
 
   # Abilities for users with roles wandering around in non-admin views.

--- a/app/views/conferences/_tooltip.html.haml
+++ b/app/views/conferences/_tooltip.html.haml
@@ -1,0 +1,30 @@
+- progress_status = event.progress_status
+%ul.list-unstyled
+  - if can? :create, conference.registrations.new
+    %li{'class'=>class_for_todo(progress_status['registered'])}
+      %span{'class'=>icon_for_todo(progress_status['registered'])}
+        - if progress_status['registered']
+          Speaker(s) registered to the conference
+        - else
+          = link_to 'Speaker(s) not registered to the conference', new_conference_conference_registration_path(event.program.conference.short_title)
+  %li{'class'=>class_for_todo(progress_status['biographies'])}
+    %span{'class'=>icon_for_todo(progress_status['biographies'])}
+      - if progress_status['biographies']
+        Speakers have filled out their biographies
+      - elsif current_user.biography.blank? && event.speakers.include?(current_user)
+        = link_to 'Fill out your biography', edit_user_path(current_user)
+      - else
+        Speakers' biographies missing
+  %li{'class'=>class_for_todo(progress_status['subtitle'])}
+    %span{'class'=>icon_for_todo(progress_status['subtitle'])}
+      = link_to 'Add a subtitle', edit_conference_program_proposal_path(event.program.conference.short_title, event)
+  %li{'class'=>class_for_todo(progress_status['commercials'])}
+    %span{'class'=>icon_for_todo(progress_status['commercials'])}
+      = link_to 'Add a commercial', edit_conference_program_proposal_path(event.program.conference.short_title, event, anchor: 'commercials-content')
+  - unless progress_status['track'].nil?
+    %li{'class'=>class_for_todo(progress_status['track'])}
+      %span{'class'=>icon_for_todo(progress_status['track'])}
+        = link_to 'Add a track', edit_conference_program_proposal_path(event.program.conference.short_title, event)
+  %li{'class'=>class_for_todo(progress_status['difficulty_level'])}
+    %span{'class'=>icon_for_todo(progress_status['difficulty_level'])}
+      = link_to 'Add a difficulty level', edit_conference_program_proposal_path(event.program.conference.short_title, event)

--- a/app/views/conferences/user_proposals.html.haml
+++ b/app/views/conferences/user_proposals.html.haml
@@ -1,0 +1,66 @@
+.container
+  .row
+    .col-md-12.page-header
+      %h1
+        User Proposals
+
+
+        %table.table.table-striped#events{ style: "margin-top: 30px;" }
+          - @events.each do |event|
+            %tr
+              %td{ style: "padding:20px 8px 20px 8px;" }
+                %span{ title: event.state.humanize,
+                 class: "fa #{event_status_icon(event)}" }
+
+              %td.col-md-7{ style: "padding:20px 8px 20px 8px;" }
+                = link_to event.title, conference_program_proposal_path(event.conference.short_title, event.id)
+                %br
+                %small.text-muted
+                  = event.event_type.title
+                  = "(#{event.event_type.length} min)"
+                  = "in #{event.track.name}" if event.track
+                  - if event.require_registration
+                    %br
+                    = link_to registered_text(event), registrations_conference_program_proposal_path(event.conference.short_title, event), class: 'btn btn-xs btn-danger'
+
+              %td.col-md-2{ style: "padding:20px 8px 20px 8px;" }
+                = link_to 'Complete your proposal', 'javascript: void(0)', "type"=>"button", "data-trigger"=>"focus", "data-toggle"=>"popover", "title"=>"Your todo list", "data-content"=>"#{render partial: 'tooltip', locals: { event: event,conference: event.conference } }"              
+                - if can? :create, event.conference.registrations.new
+                  - progress_percentage = event.calculate_progress
+                  .progress
+                    %div{ class: "progress-bar #{event_progress_color(progress_percentage)}",
+                     style: "width:#{progress_percentage}%;" }
+                      = event.progress_status.reject{ |_key, value| value || value.nil? }.length
+                      left
+                - else
+                  :ruby
+                    progress_list = event.progress_status
+                    progress_percentage = (100 * progress_list.values.count(true) / (progress_list.values.compact.count-1)).to_s
+                  .progress
+                    %div{ class: "progress-bar #{event_progress_color(progress_percentage)}", style: "width:#{progress_percentage}%;" }
+                      = event.progress_status.reject{ |_key, value| value || value.nil? }.length-1
+                      left
+              %td.col-md-3{ style: "padding:20px 0px 20px 0px;" }
+                .pull-right
+                  - if event.transition_possible? :confirm
+                    = link_to 'Confirm',
+                    confirm_conference_program_proposal_path(event.conference.short_title, event),
+                    method: :patch, class: 'btn btn-mini btn-success', id: "confirm_proposal_#{event.id}"
+
+                  - if event.transition_possible? :withdraw
+                    - if can? :update, event
+                      = link_to 'Withdraw', withdraw_conference_program_proposal_path(event.conference.short_title, event.id), method: :patch,
+                                  data: { confirm: 'Are you sure you want to withdraw this proposal?' }, class: 'btn btn-mini btn-warning',
+                                  id: "delete_proposal_#{event.id}"
+                    - else
+                      = link_to 'Withdraw', withdraw_conference_program_proposal_path(event.conference.short_title, event.id), method: :patch,
+                                  data: { confirm: 'Are you sure you want to withdraw this proposal?' }, class: 'btn disabled btn-mini btn-warning',
+                                  id: "delete_proposal_#{event.id}"                    
+                  - if event.state == 'withdrawn' || event.state == 'rejected'
+                    = link_to 'Re-Submit',
+                    restart_conference_program_proposal_path(event.conference.short_title, event.id),
+                    method: :patch, class: 'btn btn-mini btn-success', id: "review_event_#{event.id}"
+                  - if can? :update, event
+                    = link_to 'Edit', edit_conference_program_proposal_path(event.conference.short_title,event.id), class: 'btn btn-default', id: "edit_proposal_#{event.id}"
+                  - else
+                    = link_to 'Edit', edit_conference_program_proposal_path(event.conference.short_title,event.id), class: 'btn btn-default disabled', id: "edit_proposal_#{event.id}"

--- a/app/views/layouts/_user_menu.html.haml
+++ b/app/views/layouts/_user_menu.html.haml
@@ -1,3 +1,7 @@
+%li
+  = link_to(user_proposals_conferences_path) do
+    %span.fa.fa-comment
+    User Proposals
 - unless ENV['OSEM_ICHAIN_ENABLED'] == 'true'
   %li
     = link_to(edit_user_registration_path) do

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -149,12 +149,17 @@ Osem::Application.routes.draw do
     get '/revision_history/:id/revert_object' => 'versions#revert_object', as: 'revision_history_revert_object'
     get '/revision_history/:id/revert_attribute' => 'versions#revert_attribute', as: 'revision_history_revert_attribute'
   end
+
   resources :organizations, only: [:index] do
     member do
       get :conferences
     end
   end
+
   resources :conferences, only: [:index, :show] do
+    collection do
+      get :user_proposals
+    end
     resources :booths do
       member do
         patch :withdraw


### PR DESCRIPTION


**Checklist**

- [X] I have read the [Contribution & Best practices Guide](https://github.com/openSUSE/osem/blob/master/CONTRIBUTING.md).
- [X] My branch is up-to-date with the upstream `master` branch.
- [X] The tests pass locally with my changes.
- [ ] I have added tests that prove my fix is effective or that my feature works(if appropriate).
- [x] I have added necessary documentation (if appropriate).

**Short description of what this resolves/which [issues](https://github.com/openSUSE/osem/issues) does this fix?:**

<!-- List the issue number resolved with this change; if there is no open issue, describe the problem this request solves -->

-  closes #1810 

**Changes proposed in this pull request:**

<!-- Summarize the changes, using declarative language. -->

![my_pull](https://user-images.githubusercontent.com/22616017/34220877-1a3d3aae-e5dc-11e7-8cad-411fdc88fe02.png)
A list of all proposals(talks) are shown on a single page irrespective of the conference
![my_pull_1](https://user-images.githubusercontent.com/22616017/34220885-1ef7f502-e5dc-11e7-9b25-cd244e29e21d.png)
Link to all_proposals are added to the navbar accordingly
![my_pull_2](https://user-images.githubusercontent.com/22616017/34220895-22643b2e-e5dc-11e7-905c-6b165602f218.png)
Withdraw and edit buttons are disabled if a user is not authorized to update a particular proposal
