### PR TITLE
Fixed growing of doughnut charts on scrolling.

### DIFF
--- a/app/views/admin/conferences/_doughnut_chart.html.haml
+++ b/app/views/admin/conferences/_doughnut_chart.html.haml
@@ -1,6 +1,6 @@
 .text-center
   %h4 #{title}
-  %canvas.doughnut_chart{ id: "dough_#{title}", 'data-chart' => data.to_json }
+  %canvas.doughnut_chart{ id: "dough_#{title.parameterize.underscore}", 'data-chart' => data.to_json }
 - if data
   - data.each do |key, value|
     %span{ 'style' => "border-bottom: 3px solid #{value['color']}" } #{key}: #{value['value']}
@@ -8,7 +8,7 @@
 :javascript
   $(document).ready( function(){
 
-   var d = $("#dough_#{title}");
+   var d = $("#dough_#{title.parameterize.underscore}");
    var dt = d.get(0).getContext('2d');
 
    $(window).resize( respondCanvas );


### PR DESCRIPTION

**Checklist**

- [x] I have read the [Contribution & Best practices Guide](https://github.com/openSUSE/osem/blob/master/CONTRIBUTING.md).
- [x] My branch is up-to-date with the upstream `master` branch.
- [x] The tests pass locally with my changes.
- [ ] I have added tests that prove my fix is effective or that my feature works(if appropriate).
- [ ] I have added necessary documentation (if appropriate).

**Short description of what this resolves/which [issues](https://github.com/openSUSE/osem/issues) does this fix?:**
Fixes #1903
The problem was not limited to physical_tickets#index but almost all pages using doughnut charts because of spaces in title which was used as id causing them not to be responsive.

The new behaviour can be seen on mobile device in this link ( admin/password123) 
http://54.203.114.157:3000/admin/conferences/osemdemo/physical_tickets
![resized-2u6ri](https://user-images.githubusercontent.com/26951824/34291865-57f69ebe-e724-11e7-8fb5-a757c667a78c.jpg)

**Changes proposed in this pull request:**

Removed spaces when setting id on a chart
