### PR TITLE
 Change paths of two buttons on conference show page and fixes a typo

### DIFF
--- a/app/views/conferences/_call_for_papers.haml
+++ b/app/views/conferences/_call_for_papers.haml
@@ -23,5 +23,5 @@
         left!
     %p.cta-button
       = link_to "Submit your proposal now",
-        conference_program_proposals_path(conference_id),
+        new_conference_program_proposal_path(conference_id),
         class: 'btn btn-success btn-lg text-center'

--- a/app/views/conferences/_call_for_tracks.haml
+++ b/app/views/conferences/_call_for_tracks.haml
@@ -15,5 +15,5 @@
         left!
     %p.cta-button
       = link_to("Submit your request for track",
-        conference_program_tracks_path(conference_id),
+        new_conference_program_track_path(conference_id),
         class: 'btn btn-success btn-lg text-center')


### PR DESCRIPTION
**Checklist**

- [x] I have read the [Contribution & Best practices Guide](https://github.com/openSUSE/osem/blob/master/CONTRIBUTING.md).
- [x] My branch is up-to-date with the upstream `master` branch.
- [x] The tests pass locally with my changes.
- [x] I have added tests that prove my fix is effective or that my feature works(if appropriate).
- [x] I have added necessary documentation (if appropriate).

**Short description of what this resolves/which [issues](https://github.com/openSUSE/osem/issues) does this fix?:**

<!-- List the issue number resolved with this change; if there is no open issue, describe the problem this request solves -->

- Closes #1813

**Changes proposed in this pull request:**

<!-- Summarize the changes, using declarative language. -->

- Update path of track submission btn to track#new and proposal submission to proposal#new

  