### PR TITLE
Removed duplicate menu button in navbar header.

### DIFF
--- a/app/views/layouts/_navigation.html.haml
+++ b/app/views/layouts/_navigation.html.haml
@@ -2,8 +2,15 @@
   .container
     .navbar-header
       - if @conference && @conference.short_title.present?
-        %button{ "data-target"=>"#side-nav", "data-toggle"=>"collapse", class: 'navbar-toggle side-nav-btn', style: 'float:right', type: 'button' }
-          %span.sr-only Toggle navigation
+        - if can? :access, Admin
+          %button{ "data-target"=>"#side-nav", "data-toggle"=>"collapse", class: 'navbar-toggle side-nav-btn', type: 'button' }
+            %span.sr-only Toggle navigation
+            %span.icon-bar
+            %span.icon-bar
+            %span.icon-bar
+        %button{"data-target"=>"#main-nav", "data-toggle"=>"collapse", class: 'navbar-toggle', type: 'button'}
+          %span.sr-only
+            Toggle navigation
           %span.icon-bar
           %span.icon-bar
           %span.icon-bar

--- a/app/views/layouts/_navigation.html.haml
+++ b/app/views/layouts/_navigation.html.haml
@@ -2,17 +2,11 @@
   .container
     .navbar-header
       - if @conference && @conference.short_title.present?
-        %button{ "data-target"=>"#side-nav", "data-toggle"=>"collapse", class: 'navbar-toggle side-nav-btn', type: 'button' }
+        %button{ "data-target"=>"#side-nav", "data-toggle"=>"collapse", class: 'navbar-toggle side-nav-btn', style: 'float:right', type: 'button' }
           %span.sr-only Toggle navigation
           %span.icon-bar
           %span.icon-bar
           %span.icon-bar
-      %button{"data-target"=>"#main-nav", "data-toggle"=>"collapse", class: 'navbar-toggle', type: 'button'}
-        %span.sr-only
-          Toggle navigation
-        %span.icon-bar
-        %span.icon-bar
-        %span.icon-bar
       = nav_root_link_for conference
 
     .collapse.navbar-collapse#main-nav


### PR DESCRIPTION
**Checklist**

- [x] I have read the [Contribution & Best practices Guide](https://github.com/openSUSE/osem/blob/master/CONTRIBUTING.md).
- [x] My branch is up-to-date with the upstream `master` branch.
- [x] The tests pass locally with my changes.
- [ ] I have added tests that prove my fix is effective or that my feature works(if appropriate).
- [ ] I have added necessary documentation (if appropriate).

**Short description of what this resolves/which [issues](https://github.com/openSUSE/osem/issues) does this fix?:**

<!-- List the issue number resolved with this change; if there is no open issue, describe the problem this request solves -->

- #1910 Extra menu button in navbar when browsing website on mobile (on user side)

**Changes proposed in this pull request:**

<!-- Summarize the changes, using declarative language. -->

- Removed duplicate menu button. 
- Added HTML style tag to float button to the right in the navbar header.
