### PR TITLE
Added condition to user scope for missing speakers report.

### DIFF
--- a/app/views/admin/reports/_missing_speakers.html.haml
+++ b/app/views/admin/reports/_missing_speakers.html.haml
@@ -19,14 +19,15 @@
       - @missing_event_speakers.each do |event_user|
         - speaker = event_user.user
         - event = event_user.event
-        %tr
-          %td= link_to speaker.name, admin_user_path(speaker)
-          %td
-            - if @conference.user_registered?(speaker)
-              = link_to 'Yes', admin_conference_registrations_path(@conference.short_title)
-            - else
-              No
-          %td= link_to event.title, edit_admin_conference_program_event_path(@conference.short_title, event)
-          %td= event.room.name if event.room
-          %td= event.time.to_date if event.time
-          %td= event.time.strftime('%H:%M') if event.time
+        - if @events.include?(event)
+          %tr
+            %td= link_to speaker.name, admin_user_path(speaker)
+            %td
+              - if @conference.user_registered?(speaker)
+                = link_to 'Yes', admin_conference_registrations_path(@conference.short_title)
+              - else
+                No
+            %td= link_to event.title, edit_admin_conference_program_event_path(@conference.short_title, event)
+            %td= event.room.name if event.room
+            %td= event.time.to_date if event.time
+            %td= event.time.strftime('%H:%M') if event.time


### PR DESCRIPTION
**Checklist**

- [x] I have read the [Contribution & Best practices Guide](https://github.com/openSUSE/osem/blob/master/CONTRIBUTING.md).
- [x] My branch is up-to-date with the upstream `master` branch.
- [x] The tests pass locally with my changes.
- [ ] I have added tests that prove my fix is effective or that my feature works(if appropriate).
- [ ] I have added necessary documentation (if appropriate).

**Short description of what this resolves/which [issues](https://github.com/openSUSE/osem/issues) does this fix?:**

<!-- List the issue number resolved with this change; if there is no open issue, describe the problem this request solves -->

- #1942 User with accepted track request can see unregistered speakers of all events. 

**Changes proposed in this pull request:**

<!-- Summarize the changes, using declarative language. -->

- Added condition that checks whether the signed-in user and the missing speaker have an event in common. If they do, the missing speaker should be displayed in the `missing speakers report`.

This is a WIP. Let me know if any of my assumptions about the issue are incorrect.
