### PR TITLE
  Fix oauth open-id btn alignment

### DIFF
--- a/app/assets/stylesheets/osem.scss
+++ b/app/assets/stylesheets/osem.scss
@@ -115,3 +115,9 @@ p.comment-body {
         float: right;
     }
 }
+
+/* omniauth btn grp */
+#openid-btn-grp{
+  display: flex;
+  justify-content: center;
+}

--- a/app/views/devise/shared/_openid_links.html.haml
+++ b/app/views/devise/shared/_openid_links.html.haml
@@ -1,5 +1,5 @@
 .text-center
-  .btn-group.btn-group-lg
+  .btn-group.btn-group-lg#openid-btn-grp
     - omniauth_configured.each do |provider|
       = link_to "user_#{provider}_omniauth_authorize".to_sym, class: "btn btn-success btn-lg",
                                                         id: "omniauth-#{provider}",


### PR DESCRIPTION
**Checklist**

- [x] I have read the [Contribution & Best practices Guide](https://github.com/openSUSE/osem/blob/master/CONTRIBUTING.md).
- [x] My branch is up-to-date with the upstream `master` branch.
- [x] The tests pass locally with my changes.
- [ ] I have added tests that prove my fix is effective or that my feature works(if appropriate).
- [ ] I have added necessary documentation (if appropriate).

**Short description of what this resolves/which [issues](https://github.com/openSUSE/osem/issues) does this fix?:**

- #1931 

**Changes proposed in this pull request:**
- better aligment of oauth btn grp
- resolved horizontal scroll of conference#show page.

**in pc : ** 
![screenshot-2018-1-16 osem](https://user-images.githubusercontent.com/13421233/34995713-4d7b152c-fafd-11e7-9581-ba601acce74b.png)

**in mobile : **
![screenshot-2018-1-16 osem 1](https://user-images.githubusercontent.com/13421233/34995743-686f9574-fafd-11e7-8ecb-b1f3cc607223.png)
