### PR TITLE
Skylight instrumentation

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -209,6 +209,9 @@ gem 'sprockets-rails'
 # for multiple speakers select on proposal/event forms
 gem 'selectize-rails'
 
+# For collecting performance data
+gem 'skylight'
+
 # Nokogiri < 1.8.1 is subject to:
 # CVE-2017-0663, CVE-2017-7375, CVE-2017-7376, CVE-2017-9047, CVE-2017-9048,
 # CVE-2017-9049, CVE-2017-9050

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -505,6 +505,8 @@ GEM
       simplecov-html (~> 0.10.0)
     simplecov-html (0.10.0)
     sixarm_ruby_unaccent (1.1.1)
+    skylight (1.5.1)
+      activesupport (>= 3.0.0)
     slop (3.6.0)
     sort_alphabetical (1.0.2)
       unicode_utils (>= 1.2.2)
@@ -668,6 +670,7 @@ DEPENDENCIES
   sass-rails (>= 4.0.2)
   selectize-rails
   shoulda-matchers
+  skylight
   spring-commands-rspec
   sprockets-rails
   sqlite3

--- a/INSTALL.md
+++ b/INSTALL.md
@@ -106,6 +106,8 @@ There are a couple of environment variables you can set to configure OSEM. Check
 | STRIPE_PUBLISHABLE_KEY    | *string*          | Publishable Key for Stripe Gateway
 | STRIPE_SECRET_KEY    | *string*          | Secret Key for Stripe Gateway
 | OSEM_REDIS_URL | *string* | Redis server URL e.g. redis://localhost:6379/1
+| SKYLIGHT_AUTHENTICATION	| *string*			| (Optional) Authentication token for Skylight
+| SKYLIGHT_PUBLIC_DASHBOARD_URL | *string*			| (Optional) URL to your public Skylight dashboard
 
 ### Online Ticket Payments
 We use [Stripe](https://stripe.com) for accepting your ticket payments securely over the web.
@@ -130,3 +132,8 @@ Open a separate terminal and go into the directory where the rails app is presen
 ```
 bundle exec rake jobs:work
 ```
+
+## Performance
+If you are experiencing performance issues (or just curious), you may be able to [apply a free Skylight account](https://www.skylight.io/oss).
+Once you have your account setup, simply set `SKYLIGHT_AUTHENTICATION` and `SKYLIGHT_PUBLIC_DASHBOARD_URL` in your `.env` file.
+If you are reporting a performance issue or submiting a performance patch, it would be helpful (but not required) to link to the relevant Skylight data.

--- a/app/views/layouts/application.html.haml
+++ b/app/views/layouts/application.html.haml
@@ -37,11 +37,14 @@
         %p.muted.text-center
           %small
             This tool is
-            =link_to "free software,", "http://www.gnu.org/philosophy/free-sw.html"
+            #{link_to "free software", "http://www.gnu.org/philosophy/free-sw.html"},
             released under the
-            =link_to "MIT license.", "http://opensource.org/licenses/MIT"
+            #{link_to "MIT license", "http://opensource.org/licenses/MIT"}.
             You can run, copy, distribute, study, change and improve it.
             The source code and the developers are on
-            =link_to "github.", "https://github.com/openSUSE/osem"
+            #{link_to "GitHub", "https://github.com/openSUSE/osem"}.
+            - if ENV["SKYLIGHT_PUBLIC_DASHBOARD_URL"].present?
+              Performance data is available on
+              #{link_to "Skylight", ENV["SKYLIGHT_PUBLIC_DASHBOARD_URL"]}.
     = yield :script_body
     = piwik_tracking_tag

--- a/dotenv.example
+++ b/dotenv.example
@@ -46,6 +46,10 @@ OSEM_SUSE_SECRET=''
 STRIPE_PUBLISHABLE_KEY=''
 STRIPE_SECRET_KEY=''
 
+# (OPTIONAL) Skylight keys. See https://www.skylight.io/oss.
+# SKYLIGHT_AUTHENTICATION=''
+# SKYLIGHT_PUBLIC_DASHBOARD_URL='https://oss.skylight.io/app/applications/xxxxxxxxxxxx'
+
 # Disable linting of factories in the test suite.
 # Speeds up turn around times of tests
 OSEM_FACTORY_LINT="false"

--- a/spec/controllers/application_controller_spec.rb
+++ b/spec/controllers/application_controller_spec.rb
@@ -30,7 +30,45 @@ describe ApplicationController, type: :controller do
           expect(controller.after_sign_in_path_for(user)).to eq conferences_path
         end
       end
+    end
 
+  end
+
+end
+
+describe ApplicationController, type: :request do
+  let(:conference) { create(:conference) }
+
+  describe 'Skylight link' do
+
+    around do |example|
+      original_value = ENV['SKYLIGHT_PUBLIC_DASHBOARD_URL']
+      example.run
+      ENV['SKYLIGHT_PUBLIC_DASHBOARD_URL'] = original_value
+    end
+
+    context 'when SKYLIGHT_PUBLIC_DASHBOARD_URL is set' do
+      before do
+        ENV['SKYLIGHT_PUBLIC_DASHBOARD_URL'] = 'https://oss.skylight.io/app/applications/my-osem'
+      end
+
+      it 'should include a link to view performance data' do
+        get '/'
+        expect(response.body).to match(/Performance data/i)
+        expect(response.body).to include('https://oss.skylight.io/app/applications/my-osem')
+      end
+    end
+
+    context 'when SKYLIGHT_PUBLIC_DASHBOARD_URL is not set' do
+      before do
+        ENV['SKYLIGHT_PUBLIC_DASHBOARD_URL'] = nil
+      end
+
+      it 'should not include a link to view performance data' do
+        get '/'
+        expect(response.body).to_not match(/performance data/i)
+        expect(response.body).to_not match(/skylight/i)
+      end
     end
 
   end


### PR DESCRIPTION
This allows individual installations to optionally collect performance
data using [Skylight for Open Source](https://www.skylight.io/oss).

**Checklist**

- [x] I have read the [Contribution & Best practices Guide](https://github.com/openSUSE/osem/blob/master/CONTRIBUTING.md).
- [x] My branch is up-to-date with the upstream `master` branch.
- [x] The tests pass locally with my changes.
- [x] I have added tests that prove my fix is effective or that my feature works(if appropriate).
- [x] I have added necessary documentation (if appropriate).

**Short description of what this resolves/which [issues](https://github.com/openSUSE/osem/issues) does this fix?:**

Hello!

I work at [Skylight](https://www.skylight.io/). If you’re not already familiar with Skylight, it is a smart profiler for Rails apps. Skylight makes it easy to pinpoint performance issues in Rails applications.

We worked with @bear454 to add Skylight to [Linux Fest Northwest](https://2018.linuxfestnorthwest.org/)'s installation of OSEM. You can check it out [here](https://oss.skylight.io/app/applications/qsmDLnzbof0d).

Since that seemed to be pretty useful for identifying potential performance issues ([for example](https://oss.skylight.io/app/applications/qsmDLnzbof0d/1518137040/6h/endpoints/ConferencesController%23show?responseType=html)), so I prepared a patch to see if this is something you may consider including by default in upstream.

We work on a lot of open source projects ourselves, and in our experience it can be pretty hard to get contributors to work on application performance issues. Few contributors consider working on performance problems, and the ones that might be interested may not even know where to start. By making performance information more accessible, we hope to inspire potential contributors to tackle slow parts of your app, and have a good way to see if their contributions helped.

Those who are interested/curious in performance data can [apply](https://www.skylight.io/oss) for a free Skylight token and set it in the `.env` file, and optionally add a link to their dashboard in the footer using the other variable so other contributors can find it. Those who are not using Skylight can simply leave the ENV variables unset (which is the default in `dotEnv.example`), in which case the Skylight agent may log a message to `log/skylight.log` but won't otherwise prevent the app from working normally (it won't do anything at all).

**Changes proposed in this pull request:**

- Add `skylight` gem to the default Gemfile
- Collect performance data with Skylight if `SKYLIGHT_AUTHENTICATION` is set (otherwise, do nothing)
- Add a link for viewing performance data in the footer if `SKYLIGHT_PUBLIC_DASHBOARD_URL` is set (otherwise, don't)
- Add tests and documentation for the above

This is how the footer link looks in the browser after my change:

<img width="667" alt="osem_and_link_to_oss_faq_from_the_marketing_page_by_chancancode_ _pull_request__907_ _tildeio_direwolf-client" src="https://user-images.githubusercontent.com/55829/36015507-91648646-0d23-11e8-925c-94f1cd55b0fe.png">
