### PR TITLE
Ignoring rubocop rules for Ruby 3.

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -3,6 +3,7 @@ inherit_from: .rubocop_todo.yml
 
 # Apply rule to all cops
 AllCops:
+  TargetRubyVersion: 2.4
   Include:
     - '**/Rakefile'
     - '**/config.ru'

--- a/.rubocop_todo.yml
+++ b/.rubocop_todo.yml
@@ -714,3 +714,12 @@ Style/TrailingCommaInLiteral:
     - 'Guardfile'
     - 'db/migrate/20140701123203_add_events_per_week_to_conference.rb'
     - 'spec/models/conference_spec.rb'
+
+
+# for ruby 3.0
+Style/FrozenStringLiteralComment:
+  Enabled: false
+Style/NumericPredicate:
+  Enabled: false
+Style/SafeNavigation:
+  Enabled: false


### PR DESCRIPTION
**Checklist**

- [x] I have read the [Contribution & Best practices Guide](https://github.com/openSUSE/osem/blob/master/CONTRIBUTING.md).
- [x] My branch is up-to-date with the upstream `master` branch.
- [x] The tests pass locally with my changes.
- [x] I have added tests that prove my fix is effective or that my feature works(if appropriate).
- [x] I have added necessary documentation (if appropriate).

**Short description of what this resolves/which [issues](https://github.com/openSUSE/osem/issues) does this fix?:**

<!-- List the issue number resolved with this change; if there is no open issue, describe the problem this request solves -->

- Rubocop has introduces some rules for Ruby 3; let's ignore them for now.

**Changes proposed in this pull request:**

<!-- Summarize the changes, using declarative language. -->

- Ignore 3 rubocop rules that are in place for future ruby versions, but that fail on supported ruby versions.
