### PR TITLE
Reduce deprecation warnings

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -89,7 +89,7 @@ gem 'jquery-ui-rails', '~> 4.2.1'
 # for languages validation
 gem 'iso-639'
 
-gem 'thor', '0.19.1'
+gem 'thor', '~> 0.19'
 
 # frontend javascripts
 source 'https://rails-assets.org' do

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -119,13 +119,6 @@ GEM
       rest-client
     cocoon (1.2.6)
     coderay (1.1.1)
-    coffee-rails (4.2.2)
-      coffee-script (>= 2.2.0)
-      railties (>= 4.0.0)
-    coffee-script (2.4.1)
-      coffee-script-source
-      execjs
-    coffee-script-source (1.12.2)
     concurrent-ruby (1.0.5)
     countable-rails (0.0.1)
       railties (>= 3.1)
@@ -135,12 +128,12 @@ GEM
     country_select (2.5.2)
       countries (~> 1.2.0)
       sort_alphabetical (~> 1.0)
-    coveralls (0.8.13)
-      json (~> 1.8)
-      simplecov (~> 0.11.0)
+    coveralls (0.8.21)
+      json (>= 1.8, < 3)
+      simplecov (~> 0.14.1)
       term-ansicolor (~> 1.3)
-      thor (~> 0.19.1)
-      tins (~> 1.6.0)
+      thor (~> 0.19.4)
+      tins (~> 1.6)
     crack (0.4.3)
       safe_yaml (~> 1.0.0)
     currencies (0.4.2)
@@ -246,7 +239,7 @@ GEM
       thor (>= 0.14, < 2.0)
     jquery-ui-rails (4.2.1)
       railties (>= 3.2.16)
-    json (1.8.6)
+    json (2.1.0)
     json-schema (2.5.0)
       addressable (~> 2.3)
     jwt (1.0.0)
@@ -280,15 +273,14 @@ GEM
     minitest (5.10.2)
     momentjs-rails (2.8.1)
       railties (>= 3.1)
-    monetize (1.4.0)
-      money (~> 6.7)
-    money (6.7.0)
-      i18n (>= 0.6.4, <= 0.7.0)
-      sixarm_ruby_unaccent (>= 1.1.1, < 2)
-    money-rails (1.6.0)
+    monetize (1.7.0)
+      money (~> 6.9)
+    money (6.10.1)
+      i18n (>= 0.6.4, < 1.0)
+    money-rails (1.10.0)
       activesupport (>= 3.0)
-      monetize (~> 1.4.0)
-      money (~> 6.7)
+      monetize (~> 1.7.0)
+      money (~> 6.10.0)
       railties (>= 3.0)
     multi_json (1.12.1)
     multi_xml (0.5.5)
@@ -499,12 +491,11 @@ GEM
     shellany (0.0.1)
     shoulda-matchers (2.8.0)
       activesupport (>= 3.0.0)
-    simplecov (0.11.2)
+    simplecov (0.14.1)
       docile (~> 1.1.0)
-      json (~> 1.8)
+      json (>= 1.8, < 3)
       simplecov-html (~> 0.10.0)
-    simplecov-html (0.10.0)
-    sixarm_ruby_unaccent (1.1.1)
+    simplecov-html (0.10.2)
     skylight (1.5.1)
       activesupport (>= 3.0.0)
     slop (3.6.0)
@@ -528,17 +519,18 @@ GEM
       multi_json (>= 1.0.0)
       stripe (>= 1.31.0, <= 1.43)
     sysexits (1.2.0)
-    term-ansicolor (1.3.2)
+    term-ansicolor (1.6.0)
       tins (~> 1.0)
-    thor (0.19.1)
+    thor (0.19.4)
     thread_safe (0.3.6)
     tilt (1.4.1)
     timecop (0.7.1)
-    tins (1.6.0)
+    tins (1.16.3)
     transitions (0.1.12)
     ttfunk (1.1.1)
-    turbolinks (2.5.3)
-      coffee-rails
+    turbolinks (5.1.0)
+      turbolinks-source (~> 5.1)
+    turbolinks-source (5.1.0)
     tzinfo (1.2.3)
       thread_safe (~> 0.1)
     uglifier (3.0.0)
@@ -676,7 +668,7 @@ DEPENDENCIES
   sqlite3
   stripe
   stripe-ruby-mock
-  thor (= 0.19.1)
+  thor (~> 0.19)
   timecop
   transitions
   turbolinks
@@ -687,4 +679,4 @@ DEPENDENCIES
   whenever
 
 BUNDLED WITH
-   1.16.0
+   1.16.1

--- a/app/assets/stylesheets/osem-schedule.scss
+++ b/app/assets/stylesheets/osem-schedule.scss
@@ -54,20 +54,7 @@
 }
 
 #schedule td.event {
-background-image: linear-gradient(bottom, rgb(247,250,242) 24%, rgb(194,232,190) 97%, rgb(194,232,190) 100%);
-background-image: -o-linear-gradient(bottom, rgb(247,250,242) 24%, rgb(194,232,190) 97%, rgb(194,232,190) 100%);
-background-image: -moz-linear-gradient(bottom, rgb(247,250,242) 24%, rgb(194,232,190) 97%, rgb(194,232,190) 100%);
-background-image: -webkit-linear-gradient(bottom, rgb(247,250,242) 24%, rgb(194,232,190) 97%, rgb(194,232,190) 100%);
-background-image: -ms-linear-gradient(bottom, rgb(247,250,242) 24%, rgb(194,232,190) 97%, rgb(194,232,190) 100%);
-
-background-image: -webkit-gradient(
-    linear,
-    left bottom,
-    left top,
-    color-stop(0.24, rgb(247,250,242)),
-    color-stop(0.97, rgb(194,232,190)),
-    color-stop(1, rgb(194,232,190))
-);
+    background-image: linear-gradient(to top, rgb(247,250,242) 24%, rgb(194,232,190) 97%, rgb(194,232,190) 100%);
 
 cursor: pointer;
 padding: 3px 2px;
@@ -75,20 +62,7 @@ padding: 3px 2px;
 
 #schedule td.event:hover
 {
-background-image: linear-gradient(bottom, rgb(247,250,242) 24%, rgb(83,171,74) 97%, rgb(83,171,74) 100%);
-background-image: -o-linear-gradient(bottom, rgb(247,250,242) 24%, rgb(83,171,74) 97%, rgb(83,171,74) 100%);
-background-image: -moz-linear-gradient(bottom, rgb(247,250,242) 24%, rgb(83,171,74) 97%, rgb(83,171,74) 100%);
-background-image: -webkit-linear-gradient(bottom, rgb(247,250,242) 24%, rgb(83,171,74) 97%, rgb(83,171,74) 100%);
-background-image: -ms-linear-gradient(bottom, rgb(247,250,242) 24%, rgb(83,171,74) 97%, rgb(83,171,74) 100%);
-
-background-image: -webkit-gradient(
-    linear,
-    left bottom,
-    left top,
-    color-stop(0.24, rgb(247,250,242)),
-    color-stop(0.97, rgb(83,171,74)),
-    color-stop(1, rgb(83,171,74))
-);
+    background-image: linear-gradient(to top, rgb(247,250,242) 24%, rgb(83,171,74) 97%, rgb(83,171,74) 100%);
 }
 
 .flexvideo {

--- a/config/application.rb
+++ b/config/application.rb
@@ -1,6 +1,7 @@
 require File.expand_path('../boot', __FILE__)
 
 require 'rails/all'
+ActiveSupport::Deprecation.debug = true if Rails.env.test?
 include ActionView::Helpers::NumberHelper
 
 if defined?(Bundler)

--- a/spec/controllers/users/omniauth_callbacks_controller_spec.rb
+++ b/spec/controllers/users/omniauth_callbacks_controller_spec.rb
@@ -27,5 +27,5 @@ def stub_env_for_omniauth
                                 }
   )
   request.env['omniauth.auth'] = env
-  @controller.stub(:env).and_return(env)
+  allow(@controller).to receive(:env).and_return(env)
 end


### PR DESCRIPTION
Reduce deprecations as much as possible; the only remaining deprecations are from Hoptoad, which would be addressed by PR #1892 .

* Update _coveralls_ gem (and mandatory depedencies)
* Update _money-rails_ gem (and mandatory dependencies)
* Update `linear-gradient` CSS to match CSS standards ( `to DIR` argument, and drop deprecated browser-specific variants)