### PR TITLE
Allow root URL to redirect to a conference via ENV var.

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -263,6 +263,8 @@ group :test do
   gem 'json-schema'
   # For using 'assigns' in tests
   gem 'rails-controller-testing'
+  # For managing the environment
+  gem 'climate_control'
 end
 
 group :development, :test do

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -113,6 +113,7 @@ GEM
       railties (> 3.1)
     chronic (0.10.2)
     chunky_png (1.3.8)
+    climate_control (0.2.0)
     cliver (0.3.2)
     cloudinary (1.1.6)
       aws_cf_signer
@@ -594,6 +595,7 @@ DEPENDENCIES
   carrierwave
   carrierwave-bombshelter
   chart-js-rails
+  climate_control
   cloudinary
   cocoon
   countable-rails (~> 0.0.1)
@@ -687,4 +689,4 @@ DEPENDENCIES
   whenever
 
 BUNDLED WITH
-   1.16.0
+   1.16.1

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -214,5 +214,9 @@ Osem::Application.routes.draw do
 
   get '/admin' => redirect('/admin/conferences')
 
-  root to: 'conferences#index', via: [:get, :options]
+  unless ENV['OSEM_ROOT_CONFERENCE'].blank?
+    root to: redirect("/conferences/#{ENV['OSEM_ROOT_CONFERENCE']}")
+  else
+    root to: 'conferences#index', via: [:get, :options]
+  end
 end

--- a/dotenv.example
+++ b/dotenv.example
@@ -16,6 +16,9 @@ OSEM_HOSTNAME="localhost:3000"
 # The address OSEM uses for sending mails
 OSEM_EMAIL_ADDRESS="no-reply@localhost"
 
+# (Optional) The Conference#short_title to redirect the root URL to
+#OSEM_ROOT_CONFERENCE=''
+
 # The api key for transifex.com.
 # See TRANSLATION.md for details
 OSEM_TRANSIFEX_APIKEY=""

--- a/spec/routing/routing_spec.rb
+++ b/spec/routing/routing_spec.rb
@@ -1,0 +1,28 @@
+require 'spec_helper'
+
+feature 'Routing', type: :routing do
+  let(:conference) { create(:conference) }
+
+  context 'the root URL' do
+    it 'routes to conferences#index' do
+      expect(get: '/').to route_to(
+        controller: 'conferences',
+        action:     'index'
+      )
+    end
+
+    # FIXME: this doesn't work due to routes being statically loaded
+    # See https://github.com/rspec/rspec-rails/issues/817 for example
+    # context 'with OSEM_ROOT_CONFERENCE set' do
+    #   it 'redirects to the conference' do
+    #     ClimateControl.modify OSEM_ROOT_CONFERENCE: conference.short_title do
+    #       expect(get: '/').to route_to(
+    #         controller: 'conferences',
+    #         action:     'show',
+    #         id:         conference.short_title
+    #       )
+    #     end
+    #   end
+    # end
+  end
+end


### PR DESCRIPTION
**Checklist**

- [x] I have read the [Contribution & Best practices Guide](https://github.com/openSUSE/osem/blob/master/CONTRIBUTING.md).
- [x] My branch is up-to-date with the upstream `master` branch.
- [x] The tests pass locally with my changes.
- [x] I have added tests that prove my fix is effective or that my feature works(if appropriate).
- [x] I have added necessary documentation (if appropriate).

**Short description of what this resolves/which [issues](https://github.com/openSUSE/osem/issues) does this fix?:**

<!-- List the issue number resolved with this change; if there is no open issue, describe the problem this request solves -->

- #1259

**Changes proposed in this pull request:**

<!-- Summarize the changes, using declarative language. -->

- Unlike #1259 or #1774, this change:
- allows for root to show `conferences#index` by default, 
- avoids the overhead of running the `conferences#index` action and all it's loading work by working in routing, 
- allows `/` to redirect to any specific conference (so you can have one conference current, but start on the next conference ;-)
- peforms a redirect, maintaining the RESTful url (e.g. `/ => 301 /conferences/FOO` ) instead of directly rendering `conferences#show` on the root URL.
