### PR TITLE
Prevent error when parsing empty params hash

### DIFF
--- a/app/controllers/ticket_purchases_controller.rb
+++ b/app/controllers/ticket_purchases_controller.rb
@@ -6,7 +6,7 @@ class TicketPurchasesController < ApplicationController
 
   def create
     current_user.ticket_purchases.by_conference(@conference).unpaid.destroy_all
-    message = TicketPurchase.purchase(@conference, current_user, params[:tickets][0])
+    message = TicketPurchase.purchase(@conference, current_user, params[:tickets].try(:first))
     if message.blank?
       if current_user.ticket_purchases.by_conference(@conference).unpaid.any?
         redirect_to new_conference_payment_path,


### PR DESCRIPTION
**Checklist**

- [x] I have read the [Contribution & Best practices Guide](https://github.com/openSUSE/osem/blob/master/CONTRIBUTING.md).
- [x] My branch is up-to-date with the upstream `master` branch.
- [x] The tests pass locally with my changes.

**Short description of what this resolves/which [issues](https://github.com/openSUSE/osem/issues) does this fix?:**

<!-- List the issue number resolved with this change; if there is no open issue, describe the problem this request solves -->

- #1999 

**Changes proposed in this pull request:**

<!-- Summarize the changes, using declarative language. -->

- Instead of hitting a specific array index on `params[:tickets]`, which may be `nil`; try to get the first item.
