### PR TITLE
Remove version suffix from binstubs

### DIFF
--- a/bin/bundle
+++ b/bin/bundle
@@ -1,3 +1,3 @@
-#!/usr/bin/env ruby.ruby2.4
+#!/usr/bin/env ruby
 ENV['BUNDLE_GEMFILE'] ||= File.expand_path('../../Gemfile', __FILE__)
 load Gem.bin_path('bundler', 'bundle')

--- a/bin/rake
+++ b/bin/rake
@@ -1,4 +1,4 @@
-#!/usr/bin/env ruby.ruby2.4
+#!/usr/bin/env ruby
 require_relative '../config/boot'
 require 'rake'
 Rake.application.run

--- a/bin/setup
+++ b/bin/setup
@@ -1,4 +1,4 @@
-#!/usr/bin/env ruby.ruby2.4
+#!/usr/bin/env ruby
 require 'pathname'
 require 'fileutils'
 include FileUtils

--- a/bin/update
+++ b/bin/update
@@ -1,4 +1,4 @@
-#!/usr/bin/env ruby.ruby2.4
+#!/usr/bin/env ruby
 require 'pathname'
 require 'fileutils'
 include FileUtils


### PR DESCRIPTION
Binstubs are nice but not with openSUSE specific ruby binary names that
break on other environments.