### PR TITLE
Add call for booths in cfp section in conference splashpage(conferences#show),modified after the design changes of #1821

### DIFF
--- a/app/controllers/conferences_controller.rb
+++ b/app/controllers/conferences_controller.rb
@@ -33,6 +33,7 @@ class ConferencesController < ApplicationController
         @track_names = @conference.confirmed_tracks.pluck(:name).sort
       end
       @call_for_tracks = cfps.find { |call| call.cfp_type == 'tracks' }
+      @call_for_booths = cfps.find { |call| call.cfp_type == 'booths' }
     end
     if splashpage.include_program
       @highlights = @conference.highlighted_events.eager_load(:speakers)

--- a/app/helpers/conference_helper.rb
+++ b/app/helpers/conference_helper.rb
@@ -1,7 +1,12 @@
 module ConferenceHelper
-  # Return true if only call_for_papers or call_for_tracks is open
+  # Return true if only call_for_papers or call_for_tracks or call_for_booths is open
   def one_call_open(*calls)
     calls.one? { |call| call.try(:open?) }
+  end
+  # Return true if exactly two of those calls are open: call_for_papers , call_for_tracks , call_for_booths
+
+  def two_calls_open(*calls)
+    calls.count{ |call| call.try(:open?) } == 2
   end
 
   # URL for sponsorship emails

--- a/app/views/conferences/_call_for_booths.haml
+++ b/app/views/conferences/_call_for_booths.haml
@@ -1,0 +1,19 @@
+- cache [conference_id, call, '#splash#callforbooths'] do
+  .col-md-4.col-sm-4.text-center
+    %h2
+      Call for Booths
+    %p.lead
+      We are now accepting custom booth requests!
+    %p
+      Would you like to request a new booth?
+      The submission period for booth requests is open
+      %em
+        = date_string(call.start_date, call.end_date) + '.'
+      %b
+        You have
+        = pluralize(call.remaining_days, 'day')
+        left!
+    %p.cta-button
+      = link_to("Submit your request for booth",
+        new_conference_booth_path(conference_id),
+        class: 'btn btn-success btn-lg text-center')

--- a/app/views/conferences/_call_for_content.haml
+++ b/app/views/conferences/_call_for_content.haml
@@ -5,12 +5,18 @@
 %section#call
   .container
     .row
-      - if one_call_open(call_for_events, call_for_tracks)
-        .col-md-3.col-sm-3.hidden-xs &nbsp;
+      - if one_call_open(call_for_events, call_for_tracks, call_for_booths)
+        .col-md-4.col-sm-4.hidden-xs &nbsp;
+      - if two_calls_open(call_for_events, call_for_tracks, call_for_booths)
+        .col-md-2.col-sm-2.hidden-xs &nbsp;
       - if call_for_events.try(:open?)
         = render 'call_for_papers', conference_id: conference.short_title,
           call: call_for_events, event_types: event_types, tracks: tracks
-      .col-md-2.col-sm-2 &nbsp;
       - if call_for_tracks.try(:open?)
         = render 'call_for_tracks', conference_id: conference.short_title,
           call: call_for_tracks
+      - if call_for_booths.try(:open?)
+        = render 'call_for_booths', conference_id: conference.short_title,
+          call: call_for_booths
+      - if two_calls_open(call_for_events, call_for_tracks, call_for_booths)
+        .col-md-2.col-sm-2.hidden-xs &nbsp;

--- a/app/views/conferences/_call_for_papers.haml
+++ b/app/views/conferences/_call_for_papers.haml
@@ -1,5 +1,5 @@
 - cache [conference_id, call, event_types, tracks, '#splash#callforpapers'] do
-  .col-md-5.col-sm-5.text-center
+  .col-md-4.col-sm-4.text-center
     %h2
       Call for Papers
     %p.lead

--- a/app/views/conferences/_call_for_tracks.haml
+++ b/app/views/conferences/_call_for_tracks.haml
@@ -1,5 +1,5 @@
 - cache [conference_id, call, '#splash#callfortracks'] do
-  .col-md-5.col-sm-5.text-center
+  .col-md-4.col-sm-4.text-center
     %h2
       Call for Tracks
     %p.lead

--- a/app/views/conferences/show.html.haml
+++ b/app/views/conferences/show.html.haml
@@ -18,6 +18,7 @@
   - if @conference.splashpage.include_cfp
     = render 'call_for_content', conference: @conference,
       call_for_events: @call_for_events, call_for_tracks: @call_for_tracks,
+      call_for_booths: @call_for_booths,
       event_types: @event_types, tracks: @track_names
 
   - if @conference.splashpage.include_program


### PR DESCRIPTION
This is a change to  #1864 so its up to date with #1821.There was no call for booths tab in the _cfp_ section of the conference splashpage, so it was added while maintaining the general design style and improving functionality and design consistency when one , two or three calls for content(events, tracks,booths) are open.Screenshots provided for further clarity:

- When one call is open:
<img width="1440" alt="screen shot 2018-03-17 at 17 41 29" src="https://user-images.githubusercontent.com/27733299/37557618-f3370304-2a0f-11e8-988b-ccb6fa928717.png">

- When two calls are open:
<img width="1440" alt="screen shot 2018-03-17 at 17 42 05" src="https://user-images.githubusercontent.com/27733299/37557623-007b8328-2a10-11e8-9e94-1cd93c46205c.png">

- When three calls are open:
<img width="1440" alt="screen shot 2018-03-17 at 17 42 41" src="https://user-images.githubusercontent.com/27733299/37557625-0c5a6880-2a10-11e8-872d-39fee46b3397.png">


