### PR TITLE
Dont show emails or real names

### DIFF
--- a/app/helpers/application_helper.rb
+++ b/app/helpers/application_helper.rb
@@ -127,9 +127,13 @@ module ApplicationHelper
   end
 
   def speaker_selector_input(form)
-    users = User.active.pluck(:id, :name, :username, :email).map { |user| [user[0], user[1].blank? ? user[2] : user[1], user[2], user[3]] }.sort_by { |user| user[1].downcase }
+    users = User.active.pluck(:id, :username).map { |user| 
+      [user[0], user[1]] 
+    }.sort_by { |user| 
+      user[1].downcase 
+    }
     form.input :speakers, as: :select,
-                          collection: options_for_select(users.map {|user| ["#{user[1]} (#{user[2]}) #{user[3]}", user[0]]}, @event.speakers.map(&:id)),
+                          collection: options_for_select(users.map {|user| [user[1], user[0]]}, @event.speakers.map(&:id)),
                           include_blank: false, label: 'Speakers', input_html: { class: 'select-help-toggle', multiple: 'true' }
   end
 

--- a/app/helpers/application_helper.rb
+++ b/app/helpers/application_helper.rb
@@ -126,12 +126,13 @@ module ApplicationHelper
     safe_join(event.speakers.map{ |speaker| link_to speaker.name, admin_user_path(speaker) }, ',')
   end
 
-  def speaker_selector_input(form)
-    users = User.active.pluck(:id, :username).map { |user| 
-      [user[0], user[1]] 
-    }.sort_by { |user| 
-      user[1].downcase 
-    }
+  def speaker_selector_input(form, conference)
+    users = conference.participants.pluck(:id, :username).map do |user|
+      [user[0], user[1]]
+    end
+
+    users = users.sort_by { |user| user[1].downcase }
+
     form.input :speakers, as: :select,
                           collection: options_for_select(users.map {|user| [user[1], user[0]]}, @event.speakers.map(&:id)),
                           include_blank: false, label: 'Speakers', input_html: { class: 'select-help-toggle', multiple: 'true' }

--- a/app/views/proposals/_proposal_form.html.haml
+++ b/app/views/proposals/_proposal_form.html.haml
@@ -4,7 +4,7 @@
 
     = f.input :subtitle, as: :string
 
-    = speaker_selector_input f
+    = speaker_selector_input f, @conference
 
     = track_selector_input f
 


### PR DESCRIPTION
**Checklist**

- [x] I have read the [Contribution & Best practices Guide](https://github.com/openSUSE/osem/blob/master/CONTRIBUTING.md).
- [x] My branch is up-to-date with the upstream `master` branch.
- [ ] The tests pass locally with my changes.
- [ ] I have added tests that prove my fix is effective or that my feature works(if appropriate).
- [ ] I have added necessary documentation (if appropriate).

**Short description of what this resolves/which [issues](https://github.com/openSUSE/osem/issues) does this fix?:**

- Fixes #1884 

**Changes proposed in this pull request:**

- Removes ~real names and~ email addresses from speaker select lists
- Trims down the list to just participants in the current conference