### PR TITLE
Specify url input type for client-side validation

### DIFF
--- a/app/views/admin/lodgings/_form.html.haml
+++ b/app/views/admin/lodgings/_form.html.haml
@@ -10,7 +10,7 @@
   .col-md-8
     = semantic_form_for(@lodging, url: (@lodging.new_record? ? admin_conference_lodgings_path : admin_conference_lodging_path(@conference.short_title, @lodging))) do |f|
       = f.input :name, input_html: { autofocus: true}
-      = f.input :website_link
+      = f.input :website_link, input_html: { type: :url }
       = f.input :description, input_html: { rows: 5, cols: 20, data: { provide: 'markdown-editable' } }, hint: markdown_hint
       - if @lodging.picture?
         = image_tag @lodging.picture.thumb.url


### PR DESCRIPTION
**Checklist**

- [x] I have read the [Contribution & Best practices Guide](https://github.com/openSUSE/osem/blob/master/CONTRIBUTING.md).
- [x] My branch is up-to-date with the upstream `master` branch.
- [x] The tests pass locally with my changes.
- [ ] I have added tests that prove my fix is effective or that my feature works(if appropriate).
- [ ] I have added necessary documentation (if appropriate).

**Short description of what this resolves/which [issues](https://github.com/openSUSE/osem/issues) does this fix?:**

<!-- List the issue number resolved with this change; if there is no open issue, describe the problem this request solves -->

- Add Validation to lodgings website. #1948

**Changes proposed in this pull request:**

<!-- Summarize the changes, using declarative language. -->

- Change `<input type="text">` to `<input type="url">` for `website_link` control of Lodging edit form.

![123](https://user-images.githubusercontent.com/1443825/37819351-02697aee-2e9f-11e8-8850-5539b3579716.png)