### PR TITLE
Makes all checkboxes toggable with a single click

### DIFF
--- a/app/views/admin/splashpages/_form.html.haml
+++ b/app/views/admin/splashpages/_form.html.haml
@@ -1,3 +1,18 @@
+:javascript
+  $(document).ready(function(){
+    var originalState = true;
+    $('form.splashpage .inputs:first .input.checkbox input[type=checkbox]:not(.select-all)').each(function() {
+      originalState = originalState && $(this).is(':checked');
+    });
+    $('form.splashpage .select-all').prop('checked', originalState);
+    
+    $('form.splashpage').on('change', '.select-all', function(e) {
+      var value = $(this).is(':checked');
+      var parent = $(this).parents('.inputs:first');
+      parent.find('.input.checkbox input[type=checkbox]').prop('checked', value);
+    });
+  });
+
 .row
   .col-md-12
     .page-header
@@ -8,6 +23,13 @@
     .col-md-12
       = f.inputs name: 'Components' do
         %ul.fa-ul
+          %li
+            .boolean.input.optional.form-group.checkbox
+              %span.form-wrapper
+                %label.control-label
+                  %input.select-all{type: 'checkbox'}
+                  %em Select all
+      
           %li
             = f.input :include_cfp, label: 'Display call for papers and call for tracks, while open', input_html: { checked: params[:action] == 'new' || @splashpage.try(:include_cfp) }
           %li

--- a/app/views/admin/splashpages/_form.html.haml
+++ b/app/views/admin/splashpages/_form.html.haml
@@ -5,7 +5,7 @@
       originalState = originalState && $(this).is(':checked');
     });
     $('form.splashpage .select-all').prop('checked', originalState);
-    
+
     $('form.splashpage').on('change', '.select-all', function(e) {
       var value = $(this).is(':checked');
       var parent = $(this).parents('.inputs:first');
@@ -27,7 +27,7 @@
             .boolean.input.optional.form-group.checkbox
               %span.form-wrapper
                 %label.control-label
-                  %input.select-all{type: 'checkbox'}
+                  %input.select-all{ type: 'checkbox' }
                   %em Select all
       
           %li


### PR DESCRIPTION
**Checklist**

- [x] I have read the [Contribution & Best practices Guide](https://github.com/openSUSE/osem/blob/master/CONTRIBUTING.md).
- [x] My branch is up-to-date with the upstream `master` branch.
- [x] The tests pass locally with my changes.
- [ ] I have added tests that prove my fix is effective or that my feature works(if appropriate).
- [ ] I have added necessary documentation (if appropriate).

**Short description of what this resolves/which [issues](https://github.com/openSUSE/osem/issues) does this fix?:**

This adds the feature requested in #2022 by adding a "select all" box on the splashpage admin page.

**Changes proposed in this pull request:**

Adding a "select all" box on the splashpage admin page as requested in #2022. 