### PR TITLE
Change /vagrant/bin/rails to bundle exec rails in bootstrap.sh

### DIFF
--- a/bootstrap.sh
+++ b/bootstrap.sh
@@ -76,4 +76,4 @@ else
 fi
 
 echo -e "\nProvisioning of your OSEM rails app done!"
-echo -e "To start your development OSEM run: vagrant exec /vagrant/bin/rails server -b 0.0.0.0\n"
+echo -e "To start your development OSEM run: vagrant exec bundle exec rails server -b 0.0.0.0\n"


### PR DESCRIPTION
**Checklist**

- [x] I have read the [Contribution & Best practices Guide](https://github.com/openSUSE/osem/blob/master/CONTRIBUTING.md).
- [x] My branch is up-to-date with the upstream `master` branch.
- [ ] The tests pass locally with my changes.
- [ ] I have added tests that prove my fix is effective or that my feature works(if appropriate).
- [ ] I have added necessary documentation (if appropriate).

**Short description of what this resolves/which [issues](https://github.com/openSUSE/osem/issues) does this fix?:**

<!-- List the issue number resolved with this change; if there is no open issue, describe the problem this request solves -->

- #1915

**Changes proposed in this pull request:**

<!-- Summarize the changes, using declarative language. -->

- Recommend using bundle exec rails instead of /vagrant/bin/rails
