### PR TITLE
Improve performance of admin/conference/*/registrations

### DIFF
--- a/app/controllers/admin/registrations_controller.rb
+++ b/app/controllers/admin/registrations_controller.rb
@@ -8,13 +8,17 @@ module Admin
 
     def index
       authorize! :show, Registration.new(conference_id: @conference.id)
-      @pdf_filename = "#{@conference.title}.pdf"
-      @registrations = @conference.registrations.includes(:user).order('registrations.created_at ASC')
-      @attended = @conference.registrations.where('attended = ?', true).count
+      @registrations = @conference.registrations.eager_load(
+        :qanswers, user: :roles
+      ).order('registrations.created_at ASC').to_a
+      @attended = @registrations.count(&:attended)
+      @questions = @conference.questions.to_a
 
       @registration_distribution = @conference.registration_distribution
       @affiliation_distribution = @conference.affiliation_distribution
       @code_of_conduct = @conference.code_of_conduct.present?
+
+      @pdf_filename = "#{@conference.title}.pdf"
     end
 
     def edit; end

--- a/app/views/admin/registrations/_questions.html.haml
+++ b/app/views/admin/registrations/_questions.html.haml
@@ -1,9 +1,5 @@
-- @conference.questions.each do |q|
-
-  %b Q:
-  = q.title
-
-  %b A:
-  - registration.qanswers.where(question_id: q.id).each do |qa|
-    = qa.answer.title
-  %br
+- cache [:admin, @conference, registration.qanswers] do
+  %dl
+    - registration.qanswers.each do |qa|
+      %dt= qa.question.title
+      %dd= qa.answer.title

--- a/app/views/admin/registrations/index.html.haml
+++ b/app/views/admin/registrations/index.html.haml
@@ -32,54 +32,60 @@
                 %abbr{ title: 'Code of Conduct' } CoC
             %th Arrival
             %th Departure
-            - if @conference.questions.any?
+            - if @questions.any?
               %th Questions
             %th Actions
         %tbody
           - @registrations.each_with_index do |registration, index|
-            %tr
-              %td
-                = registration.id
-              %td
-                = registration.name.present? ? registration.name : registration.username
-                %br
-                - registration.user.roles.where(resource: @conference).each do |role|
-                  %span.label.label-info
-                    = role.name.titleize
-              %td
-                = registration.email
-              - if @code_of_conduct
-                - if registration.accepted_code_of_conduct
-                  %td.text-success.text-center= fa_icon('check', title: 'accepted')
-                - else
-                  %td.text-center.text-warning
-                    = fa_icon('exclamation-circle',
-                      title: 'Has not accepted Code of Conduct')
-              %td
-                - if registration.arrival
-                  = registration.arrival.strftime('%d %b %H:%M')
-                - else
-                  n/a
-              %td
-                - if registration.departure
-                  = registration.departure.strftime('%d %b %H:%M')
-                - else
-                  n/a
-              -if @conference.questions.any?
+            - cache [:admin, registration, registration.user] do
+              %tr
                 %td
-                  = link_to 'Questions','#', class: 'btn btn-success question-btn', 'data-id' => index, 'data-name' => registration.name
-              %td{ 'data-order' => registration.attended.to_s }
-                = check_box_tag "#{@conference.short_title}_#{registration.id}", registration.id, registration.attended,
-                  class: 'switch-checkbox',
-                  url: toggle_attendance_admin_conference_registration_path(@conference.short_title, id: registration.id)+"?attended="
-                .btn-group
-                  = link_to 'Edit', edit_admin_conference_registration_path(@conference.short_title, id: registration),
-                  method: :get, class: 'btn btn-primary'
-                  = link_to 'Delete', admin_conference_registration_path(@conference.short_title, registration),
-                  method: :delete, class: 'btn btn-danger', data: { confirm: "Do you really want to delete the Registration for #{registration.name}?" }
-  - @registrations.each_with_index do |registration, index|
-    .questions{class: "question#{index}", style: 'display:none;'}
-      = render partial: 'questions', locals: { registration: registration }
+                  = registration.id
+                %td
+                  = registration.name.present? ? registration.name : registration.username
+                  %b
+                  - registration.user.roles.select{|r| r.resource == @conference}.each do |role|
+                    %span.label.label-info
+                      = role.name.titleize
+                %td
+                  = registration.email
+                - if @code_of_conduct
+                  - if registration.accepted_code_of_conduct
+                    %td.text-success.text-center= fa_icon('check', title: 'accepted')
+                  - else
+                    %td.text-center.text-warning
+                      = fa_icon('exclamation-circle',
+                        title: 'Has not accepted Code of Conduct')
+                %td
+                  - if registration.arrival
+                    = registration.arrival.strftime('%d %b %H:%M')
+                  - else
+                    n/a
+                %td
+                  - if registration.departure
+                    = registration.departure.strftime('%d %b %H:%M')
+                  - else
+                    n/a
+                -if @questions.any?
+                  %td
+                    = link_to 'Questions','#', class: 'btn btn-success question-btn', 'data-id' => index, 'data-name' => registration.name
+                %td{ 'data-order' => registration.attended.to_s }
+                  = check_box_tag "#{@conference.short_title}_#{registration.id}", registration.id, registration.attended,
+                    class: 'switch-checkbox', method: :patch,
+                    url: toggle_attendance_admin_conference_registration_path(@conference.short_title, id: registration.id)+"?attended=",
+                    data: { size: 'small',
+                            on_color: 'success',
+                            off_color: 'warning',
+                            on_text: 'Present',
+                            off_text: 'Absent' }
+                  .btn-group
+                    = link_to 'Edit', edit_admin_conference_registration_path(@conference.short_title, id: registration),
+                    method: :get, class: 'btn btn-primary'
+                    = link_to 'Delete', admin_conference_registration_path(@conference.short_title, registration),
+                    method: :delete, class: 'btn btn-danger', data: { confirm: "Do you really want to delete the Registration for #{registration.name}?" }
+    - @registrations.each_with_index do |registration, index|
+      .questions{class: "question#{index}", style: 'display:none;'}
+        = render partial: 'questions', locals: { registration: registration }
 
 .modal.fade{ id: 'questions', 'role' => 'dialog', 'aria-hidden' => 'true' }
   .modal-dialog

--- a/app/views/admin/registrations/index.pdf.prawn
+++ b/app/views/admin/registrations/index.pdf.prawn
@@ -23,10 +23,8 @@ prawn_document(force_download: true, filename: @pdf_filename, page_layout: :land
     row << registration.departure.to_s || ''
 
     @conference.questions.each do |question|
-      qa = registration.qanswers.find_by(question: question)
-      answer = ( qa ? qa.answer.title : '' )
-
-      row << answer
+      qa = registration.qanswers.find{|qa| qa.question_id == question.id }
+      row << ( qa ? qa.answer.title : '' )
     end
 
     table_array << row

--- a/app/views/admin/registrations/index.xlsx.axlsx
+++ b/app/views/admin/registrations/index.xlsx.axlsx
@@ -5,7 +5,7 @@ wb.add_worksheet(name: 'registrations') do |sheet|
   bold_style = wb.styles.add_style(b: true)
   row = ['Attended', 'Name', 'Nickname', 'Affilιation', 'Email', 'Arrival', 'Departure']
 
-  @conference.questions.each do |question|
+  @conference.questions.sort_by(&:id).each do |question|
     row << question.title
   end
 
@@ -21,13 +21,10 @@ wb.add_worksheet(name: 'registrations') do |sheet|
     row << registration.arrival.to_s
     row << registration.departure.to_s
     @conference.questions.each do |question|
-      qa = registration.qanswers.find_by(question: question)
-      answer = ( qa ? qa.answer.title : '' )
-
-      row << answer
+      current_qa = registration.qanswers.find{ |qa| qa.question_id == question.id }
+      row << ( current_qa ? current_qa.answer.title : '' )
     end
 
     sheet.add_row row
   end
 end
-


### PR DESCRIPTION
* Add some caching
* Reduce query count, including N+1s on questions & roles

**Checklist**

- [x] I have read the [Contribution & Best practices Guide](https://github.com/openSUSE/osem/blob/master/CONTRIBUTING.md).
- [x] My branch is up-to-date with the upstream `master` branch.
- [x] The tests pass locally with my changes.

**Short description of what this resolves/which [issues](https://github.com/openSUSE/osem/issues) does this fix?:**

<!-- List the issue number resolved with this change; if there is no open issue, describe the problem this request solves -->

- Registrations page was so slow it wouldn't load anymore (Total render time: 123 seconds)

**Changes proposed in this pull request:**

<!-- Summarize the changes, using declarative language. -->

- Add some caching
- Reduce query count, including N+1s on questions & roles

Total render time: 6 seconds. Still slow, but, you know, 1/20 of the time before ;-)
