### PR TITLE
Fix N+1 queries on SchedulesController

### DIFF
--- a/app/controllers/admin/base_controller.rb
+++ b/app/controllers/admin/base_controller.rb
@@ -1,8 +1,13 @@
 module Admin
   class BaseController < ApplicationController
     before_action :verify_user_admin
+    before_action :load_all_conferences
 
     private
+
+    def load_all_conferences
+      @conferences = Conference.all
+    end
 
     def current_ability
       @current_ability ||= AdminAbility.new(current_user)

--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -3,7 +3,6 @@ class ApplicationController < ActionController::Base
   include ApplicationHelper
   add_flash_types :error
   protect_from_forgery with: :exception, prepend: true
-  before_action :get_conferences
   before_action :store_location
   # Ensure every controller authorizes resource or skips authorization (skip_authorization_check)
   check_authorization unless: :devise_controller?
@@ -33,10 +32,6 @@ class ApplicationController < ActionController::Base
     else
       session[:return_to] || root_path
     end
-  end
-
-  def get_conferences
-    @conferences = Conference.all
   end
 
   def current_ability

--- a/app/controllers/conferences_controller.rb
+++ b/app/controllers/conferences_controller.rb
@@ -4,8 +4,9 @@ class ConferencesController < ApplicationController
   load_and_authorize_resource find_by: :short_title, except: :show
 
   def index
-    @current = Conference.where('end_date >= ?', Date.current).reorder(start_date: :asc)
-    @antiquated = @conferences - @current
+    @current, @antiquated = Conference.reorder(start_date: :asc).all.partition do |conference|
+      conference.end_date >= Date.current
+    end
   end
 
   def show

--- a/app/controllers/schedules_controller.rb
+++ b/app/controllers/schedules_controller.rb
@@ -7,18 +7,18 @@ class SchedulesController < ApplicationController
   before_action :load_withdrawn_event_schedules, only: [:show, :events]
 
   def show
-    @event_schedules = @program.selected_event_schedules(
+    event_schedules = @program.selected_event_schedules(
       includes: [{ event: %i[event_type speakers submitter] }]
     )
 
-    unless @event_schedules
+    unless event_schedules
       redirect_to events_conference_schedule_path(@conference.short_title)
       return
     end
 
     respond_to do |format|
       format.xml do
-        @events_xml = @event_schedules.map(&:event).group_by{ |event| event.time.to_date } if @event_schedules
+        @events_xml = event_schedules.map(&:event).group_by{ |event| event.time.to_date } if event_schedules
       end
 
       format.html do
@@ -41,6 +41,7 @@ class SchedulesController < ApplicationController
           @selected_schedules_ids << track.selected_schedule_id
         end
         @selected_schedules_ids.compact!
+        @event_schedules_by_room_id = event_schedules.select { |s| @selected_schedules_ids.include?(s.schedule_id) }.group_by(&:room_id)
       end
     end
   end

--- a/app/controllers/schedules_controller.rb
+++ b/app/controllers/schedules_controller.rb
@@ -4,39 +4,52 @@ class SchedulesController < ApplicationController
   before_action :respond_to_options
   load_resource :conference, find_by: :short_title
   load_resource :program, through: :conference, singleton: true, except: :index
+  before_action :load_withdrawn_event_schedules, only: [:show, :events]
 
   def show
-    @rooms = @conference.venue.rooms if @conference.venue
-    schedules = @program.selected_event_schedules
-    unless schedules
+    @event_schedules = @program.selected_event_schedules(
+      includes: [{ event: %i[event_type speakers submitter] }]
+    )
+
+    unless @event_schedules
       redirect_to events_conference_schedule_path(@conference.short_title)
+      return
     end
 
-    @events_xml = schedules.map(&:event).group_by{ |event| event.time.to_date } if schedules
-    @dates = @conference.start_date..@conference.end_date
-    @step_minutes = @program.schedule_interval.minutes
-    @conf_start = @conference.start_hour
-    @conf_period = @conference.end_hour - @conf_start
+    respond_to do |format|
+      format.xml do
+        @events_xml = @event_schedules.map(&:event).group_by{ |event| event.time.to_date } if @event_schedules
+      end
 
-    # the schedule takes you to today if it is a date of the schedule
-    @current_day = @conference.current_conference_day
-    @day = @current_day.present? ? @current_day : @dates.first
-    unless @current_day
-      # the schedule takes you to the current time if it is beetween the start and the end time.
-      @hour_column = @conference.hours_from_start_time(@conf_start, @conference.end_hour)
+      format.html do
+        @rooms = @conference.venue.rooms if @conference.venue
+        @dates = @conference.start_date..@conference.end_date
+        @step_minutes = @program.schedule_interval.minutes
+        @conf_start = @conference.start_hour
+        @conf_period = @conference.end_hour - @conf_start
+
+        # the schedule takes you to today if it is a date of the schedule
+        @current_day = @conference.current_conference_day
+        @day = @current_day.present? ? @current_day : @dates.first
+        unless @current_day
+          # the schedule takes you to the current time if it is beetween the start and the end time.
+          @hour_column = @conference.hours_from_start_time(@conf_start, @conference.end_hour)
+        end
+        # Ids of the @event_schedules of confrmed self_organized tracks along with the selected_schedule_id
+        @selected_schedules_ids = [@conference.program.selected_schedule_id]
+        @conference.program.tracks.self_organized.confirmed.each do |track|
+          @selected_schedules_ids << track.selected_schedule_id
+        end
+        @selected_schedules_ids.compact!
+      end
     end
-    # Ids of the schedules of confrmed self_organized tracks along with the selected_schedule_id
-    @selected_schedules_ids = [@conference.program.selected_schedule_id]
-    @conference.program.tracks.self_organized.confirmed.each do |track|
-      @selected_schedules_ids << track.selected_schedule_id
-    end
-    @selected_schedules_ids.compact!
   end
 
   def events
     @dates = @conference.start_date..@conference.end_date
-
-    @events_schedules = @program.selected_event_schedules
+    @events_schedules = @program.selected_event_schedules(
+      includes: [:room, { event: %i[track event_type speakers submitter] }]
+    )
     @events_schedules = [] unless @events_schedules
 
     @unscheduled_events = @program.events.confirmed - @events_schedules.map(&:event)
@@ -51,5 +64,11 @@ class SchedulesController < ApplicationController
     respond_to do |format|
       format.html { head :ok }
     end if request.options?
+  end
+
+  def load_withdrawn_event_schedules
+    # Avoid making repetitive EXISTS queries for these later.
+    # See usage in EventsHelper#canceled_replacement_event_label
+    @withdrawn_event_schedules = EventSchedule.withdrawn_or_canceled_event_schedules(@program.schedule_ids)
   end
 end

--- a/app/helpers/events_helper.rb
+++ b/app/helpers/events_helper.rb
@@ -26,8 +26,8 @@ module EventsHelper
   end
 
   def replacement_event_notice(event_schedule)
-    if event_schedule.present? && event_schedule.replacement?
-      replaced_event = (event_schedule.intersecting_event_schedules.withdrawn.first || event_schedule.intersecting_event_schedules.canceled.first).event
+    if event_schedule.present? && event_schedule.replacement?(@withdrawn_event_schedules)
+      replaced_event = event_schedule.replaced_event_schedule.try(:event)
       content_tag :span do
         concat content_tag :span, 'Please note that this talk replaces '
         concat link_to replaced_event.title, conference_program_proposal_path(@conference.short_title, replaced_event.id)
@@ -38,7 +38,7 @@ module EventsHelper
   def canceled_replacement_event_label(event, event_schedule, *label_classes)
     if event.state == 'canceled' || event.state == 'withdrawn'
       content_tag :span, 'CANCELED', class: (['label', 'label-danger'] + label_classes)
-    elsif event_schedule.present? && event_schedule.replacement?
+    elsif event_schedule.present? && event_schedule.replacement?(@withdrawn_event_schedules)
       content_tag :span, 'REPLACEMENT', class: (['label', 'label-info'] + label_classes)
     end
   end

--- a/app/models/event_schedule.rb
+++ b/app/models/event_schedule.rb
@@ -21,7 +21,16 @@ class EventSchedule < ApplicationRecord
   scope :canceled, -> { joins(:event).where('state = ?', 'canceled') }
   scope :withdrawn, -> { joins(:event).where('state = ?', 'withdrawn') }
 
+  scope :with_event_states, ->(*states){ joins(:event).where('events.state IN (?)', states) }
+
   delegate :guid, to: :room, prefix: true
+
+  def self.withdrawn_or_canceled_event_schedules(schedule_ids)
+    EventSchedule
+      .unscoped
+      .where(schedule_id: schedule_ids)
+      .with_event_states(:withdrawn, :canceled)
+  end
 
   ##
   # Returns end of the event
@@ -34,14 +43,40 @@ class EventSchedule < ApplicationRecord
   # Returns event schedules that are scheduled in the same room and start_time as event
   #
   def intersecting_event_schedules
-    EventSchedule.unscoped.where(room: room, start_time: start_time, schedule: schedule).where.not(id: id)
+    EventSchedule
+      .unscoped
+      .where(room_id: room_id, start_time: start_time, schedule_id: schedule_id)
+      .where.not(id: id)
   end
 
-  def replacement?
-    event.state == 'confirmed' && (!intersecting_event_schedules.canceled.empty? || !intersecting_event_schedules.withdrawn.empty?)
+  # event_schedule_source is a cached enumerable object that helps
+  # avoid repetitive EXISTS queries when rendering the schedule carousel partial
+  def replacement?(event_schedule_source = nil)
+    return false unless event.state == 'confirmed'
+    return replaced_event_schedules.exists? unless event_schedule_source
+    event_schedule_source.any? { |event_schedule| intersects_with?(event_schedule) }
+  end
+
+  # the event schedule that `self` replaced
+  def replaced_event_schedule
+    replaced_event_schedules.first
+  end
+
+  # NOTE: This and `intersecting_event_schedules` share the flaw that they do not
+  # detect overlapping schedules where the start times are different (i.e., where
+  # only a portion of the time intersects).
+  def intersects_with?(other)
+    other != self &&
+      other.room_id == room_id &&
+      other.start_time == start_time &&
+      other.schedule_id == schedule_id
   end
 
   private
+
+  def replaced_event_schedules
+    intersecting_event_schedules.with_event_states(:withdrawn, :canceled)
+  end
 
   def start_after_end_hour
     return unless event && start_time && event.program && event.program.conference && event.program.conference.end_hour

--- a/app/models/program.rb
+++ b/app/models/program.rb
@@ -75,12 +75,14 @@ class Program < ApplicationRecord
   validate :check_languages_format
 
   # Returns all event_schedules for the selected schedule ordered by start_time
-  def selected_event_schedules
-    event_schedules = selected_schedule.event_schedules.order(start_time: :asc) if selected_schedule
-    tracks.self_organized.confirmed.order(start_date: :asc).each do |track|
-      event_schedules += track.selected_schedule.event_schedules.order(start_time: :asc) if track.selected_schedule
+  def selected_event_schedules(includes: [:event])
+    event_schedules = []
+    event_schedules = selected_schedule.event_schedules.includes(*includes).order(start_time: :asc) if selected_schedule
+    tracks.self_organized.confirmed.includes(selected_schedule: { event_schedules: includes }).order(start_date: :asc).each do |track|
+      next unless track.selected_schedule
+      event_schedules += track.selected_schedule.event_schedules
     end
-    event_schedules.sort_by(&:start_time) if event_schedules
+    event_schedules.sort_by(&:start_time)
   end
 
   ##
@@ -169,7 +171,8 @@ class Program < ApplicationRecord
   # * +False+ -> If there is not any event for the given date
   def any_event_for_this_date?(date)
     parsed_date = DateTime.parse("#{date} 00:00").utc
-    EventSchedule.where(schedule: selected_schedule).where(start_time: parsed_date..(parsed_date + 1.day)).any?
+    range = parsed_date..(parsed_date + 1.day)
+    selected_schedule.event_schedules.any? { |es| range.cover?(es.start_time) }
   end
 
   ##

--- a/app/models/program.rb
+++ b/app/models/program.rb
@@ -170,6 +170,7 @@ class Program < ApplicationRecord
   # * +True+ -> If there is any event for the given date
   # * +False+ -> If there is not any event for the given date
   def any_event_for_this_date?(date)
+    return false unless selected_schedule.present?
     parsed_date = DateTime.parse("#{date} 00:00").utc
     range = parsed_date..(parsed_date + 1.day)
     selected_schedule.event_schedules.any? { |es| range.cover?(es.start_time) }

--- a/app/views/schedules/_carousel.html.haml
+++ b/app/views/schedules/_carousel.html.haml
@@ -29,13 +29,13 @@
               %td.room{ style: "height: #{ td_height(@rooms) }px;" }
                 .room.elipsis.break-words{ style: "-webkit-line-clamp: #{ room_lines(@rooms) }; height: #{ room_height(@rooms) }px;" }
                   = room.name
-                - event_schedules = room.event_schedules.select{ |e| @selected_schedules_ids.include?(e.schedule_id) && (e.end_time > start_time) && (e.start_time <= (start_time + hrs_per_slide.hour)) }
+                - event_schedules = @event_schedules.select{ |e| e.room_id == room.id && @selected_schedules_ids.include?(e.schedule_id) && (e.end_time > start_time) && (e.start_time <= (start_time + hrs_per_slide.hour)) }
                 - (1..intervals).each do |i|
                   - if span > 1
                     - span -= 1
                   - else
                     - event_schedule = event_schedules.find{ |e| e.start_time <= start_room_time and e.end_time > start_room_time }
-                    - if event_schedule && (event_schedule.event.state == 'canceled' || event_schedule.event.state == 'withdrawn') && !event_schedule.intersecting_event_schedules.confirmed.empty?
+                    - if event_schedule && (event_schedule.event.state == 'canceled' || event_schedule.event.state == 'withdrawn') && event_schedule.intersecting_event_schedules.confirmed.exists?
                       - replacement_event = event_schedule.intersecting_event_schedules.confirmed.first
                       - event_schedule = (replacement_event.start_time <= start_room_time && replacement_event.end_time > start_room_time) ? replacement_event : nil
 

--- a/app/views/schedules/_carousel.html.haml
+++ b/app/views/schedules/_carousel.html.haml
@@ -1,5 +1,5 @@
-- intervals = hrs_per_slide * 60 / @conference.program.schedule_interval + 1
-- width = 85 / intervals
+- interval_count = hrs_per_slide * 60 / @conference.program.schedule_interval + 1
+- width = 85 / interval_count
 - carousel_number = (@conf_period / hrs_per_slide.to_f).ceil
 .carousel.slide{ id: "carousel-#{ date }-#{ hrs_per_slide }", |
                      "data-ride" => "carousel", |
@@ -14,7 +14,7 @@
           %tr
             %th
             - td_start_time = start_time
-            - (1..intervals).each do |i|
+            - interval_count.times do
               %th.date
                 %span
                   = (td_start_time).strftime("%H:")
@@ -29,8 +29,10 @@
               %td.room{ style: "height: #{ td_height(@rooms) }px;" }
                 .room.elipsis.break-words{ style: "-webkit-line-clamp: #{ room_lines(@rooms) }; height: #{ room_height(@rooms) }px;" }
                   = room.name
-                - event_schedules = @event_schedules.select{ |e| e.room_id == room.id && @selected_schedules_ids.include?(e.schedule_id) && (e.end_time > start_time) && (e.start_time <= (start_time + hrs_per_slide.hour)) }
-                - (1..intervals).each do |i|
+
+                - event_schedules = (@event_schedules_by_room_id[room.id] || []).select{ |e| (e.end_time > start_time) && (e.start_time <= (start_time + hrs_per_slide.hour)) }
+
+                - interval_count.times do |offset|
                   - if span > 1
                     - span -= 1
                   - else
@@ -40,12 +42,12 @@
                       - event_schedule = (replacement_event.start_time <= start_room_time && replacement_event.end_time > start_room_time) ? replacement_event : nil
 
                     - if event_schedule
-                      / There is an event, calculate the span and show it
+                      -# There is an event, calculate the span and show it
                       - event_span =  (event_schedule.end_time.to_i - start_room_time.to_i) / 60 / @conference.program.schedule_interval
-                      - span = ((event_span + i - 1 ) > intervals ? intervals  + 1 - i : event_span)
+                      - span = ((event_span + offset) > interval_count ? interval_count - offset : event_span)
                       = render partial: 'schedule_item', locals: {event: event_schedule.event, event_schedule: event_schedule, span: span, width: width}
                     - else
-                      / if span equals 1 show an empty td
+                      -# if span equals 1 show an empty td
                       %td.no-padding{ width: "#{ width }%"}
                   - start_room_time += @step_minutes
           - start_time = start_room_time - @step_minutes


### PR DESCRIPTION
**Checklist**

- [x] I have read the [Contribution & Best practices Guide](https://github.com/openSUSE/osem/blob/master/CONTRIBUTING.md).
- [x] My branch is up-to-date with the upstream `master` branch.
- [x] The tests pass locally with my changes.
- [x] I have added tests that prove my fix is effective or that my feature works(if appropriate).
- [x] I have added necessary documentation (if appropriate).

**Short description of what this resolves/which [issues](https://github.com/openSUSE/osem/issues) does this fix?:**

N+1 queries on `SchedulesController`

https://oss.skylight.io/app/applications/qsmDLnzbof0d/recent/6h/endpoints/SchedulesController%23show?responseType=html
https://oss.skylight.io/app/applications/qsmDLnzbof0d/recent/6h/endpoints/SchedulesController%23events?responseType=html

- Both endpoints on `SchedulesController` currently load the entry points into the data, then rely on ActiveRecord relationships to fetch the rest as needed.

**Changes proposed in this pull request:**

- Do not load all conferences on every request (move this `before_action` to the `Admin::BaseController` instead)
- Split `SchedulesController#show` into format-based responses, and only load the data necessary for each format
- Optimize the `replacement?` detection by pre-loading the list of withdrawn or canceled events (avoids 2 queries per event per css breakpoint, e.g. ~ 240 queries for a 30-event conference)
- provide a means to eager load associations from `Program#selected_event_schedules`
- improve readability of the `schedules/_carousel` partial

paired with @lbaillie
