### PR TITLE
Add button to registration from physical_tickets#index

### DIFF
--- a/app/views/physical_tickets/index.html.haml
+++ b/app/views/physical_tickets/index.html.haml
@@ -3,6 +3,9 @@
     .col-md-12.page-header
       %h2
         Tickets
+        = link_to 'Back to registration',
+                  conference_conference_registration_path(@conference),
+                  class: 'btn btn-success pull-right'
       .text-muted
         Your tickets for the conference
 


### PR DESCRIPTION
Add a button to take us back to our registration#show page from physical tickets.

The current workflow is:
register --> be prompt to buy tickets --> ticket payment --> see your tickets in physical_tickets#index

At this point it is not clear how you go back to your registration details. 
Adding a button to take us there seems to make sense. 