### PR TITLE
Move modals content area to main layout

### DIFF
--- a/app/views/conferences/show.html.haml
+++ b/app/views/conferences/show.html.haml
@@ -53,8 +53,6 @@
       = render 'social_media', contact: @conference.contact
   = render 'footer'
 
-  = yield :modals
-
 - cache [@conference.color, '#splash#inlinejs'] do
   - content_for :script_head do
     :javascript

--- a/app/views/layouts/application.html.haml
+++ b/app/views/layouts/application.html.haml
@@ -32,6 +32,9 @@
           = render 'layouts/messages'
       #content
         = yield
+
+    = yield :modals
+
     #footer
       .container
         %p.muted.text-center


### PR DESCRIPTION
**Checklist**

- [x] I have read the [Contribution & Best practices Guide](https://github.com/openSUSE/osem/blob/master/CONTRIBUTING.md).
- [x] My branch is up-to-date with the upstream `master` branch.
- [x] The tests pass locally with my changes.

**Changes proposed in this pull request:**

<!-- Summarize the changes, using declarative language. -->

- The splashpage includes a content area specifically for modals, at the end of the page, so that modals are not rendered inline with displayed content. This commit moves that content area definition into the main layout, so _any page_ can render modal content in the preferred place.
