### PR TITLE
Fix missing quote mark in docker ENV example

### DIFF
--- a/docker-compose.env.example
+++ b/docker-compose.env.example
@@ -22,7 +22,7 @@ DATABASE_PORT=3306
 OSEM_NAME="Dockerized OSEM"
 OSEM_HOSTNAME="http://localhost:9292"
 OSEM_ERRBIT_HOST="localhost"
-SECRET_KEY_BASE=changemechangemechangeme"
+SECRET_KEY_BASE="changemechangemechangeme"
 
 # these settings work for the MailHog server that is enabled by default in
 # docker-compose.yml


### PR DESCRIPTION
**Checklist**

- [x] I have read the [Contribution & Best practices Guide](https://github.com/openSUSE/osem/blob/master/CONTRIBUTING.md).
- [x] My branch is up-to-date with the upstream `master` branch.

**Short description of what this resolves/which [issues](https://github.com/openSUSE/osem/issues) does this fix?:**

The docker-compose.env.example file is missing a quotation mark around the `SECRET_KEY_BASE` value.

**Changes proposed in this pull request:**

Add a quotation mark at beginning of `changemechangemechangeme` value to line up with the rest of the flags in the OSEM section.

