### PR TITLE
Switch coverage host from coveralls -> codecov

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -18,8 +18,6 @@ notifications:
       - "chat.freenode.net#osem"
     on_success: change
     on_failure: change
-  webhooks:
-    - https://coveralls.io/webhook?repo_token=DMmQ05c9XLEiHsflEFD8f9RkFDequKGVA
 before_script:
   - cp config/database.yml.travis config/database.yml
   - cp config/secrets.yml.example config/secrets.yml
@@ -31,7 +29,6 @@ env:
   global:
     - CI_NODE_TOTAL=4
     - TEST_SUITE=rspec
-    - COVERALLS_PARALLEL=true
   matrix:
     - TEST_SUITE=linters
     - CI_NODE_INDEX=0

--- a/Gemfile
+++ b/Gemfile
@@ -250,7 +250,7 @@ group :test do
   gem 'poltergeist'
   gem 'rspec-rails', '~> 3.5', '>= 3.5.2'
   # for measuring test coverage
-  gem 'coveralls', require: false
+  gem 'codecov', require: false
   # for describing models
   gem 'shoulda-matchers', require: false
   # for stubing/mocking models

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -122,6 +122,10 @@ GEM
       aws_cf_signer
       rest-client
     cocoon (1.2.6)
+    codecov (0.1.10)
+      json
+      simplecov
+      url
     coderay (1.1.1)
     concurrent-ruby (1.0.5)
     countable-rails (0.0.1)
@@ -132,12 +136,6 @@ GEM
     country_select (2.5.2)
       countries (~> 1.2.0)
       sort_alphabetical (~> 1.0)
-    coveralls (0.8.21)
-      json (>= 1.8, < 3)
-      simplecov (~> 0.14.1)
-      term-ansicolor (~> 1.3)
-      thor (~> 0.19.4)
-      tins (~> 1.6)
     crack (0.4.3)
       safe_yaml (~> 1.0.0)
     crass (1.0.3)
@@ -161,7 +159,7 @@ GEM
     devise_ichain_authenticatable (0.3.1)
       devise (>= 2.2)
     diff-lcs (1.3)
-    docile (1.1.5)
+    docile (1.3.0)
     domain_name (0.5.20160310)
       unf (>= 0.0.5, < 1.0.0)
     dotenv (2.2.1)
@@ -497,8 +495,8 @@ GEM
     shellany (0.0.1)
     shoulda-matchers (2.8.0)
       activesupport (>= 3.0.0)
-    simplecov (0.14.1)
-      docile (~> 1.1.0)
+    simplecov (0.16.1)
+      docile (~> 1.1)
       json (>= 1.8, < 3)
       simplecov-html (~> 0.10.0)
     simplecov-html (0.10.2)
@@ -525,13 +523,10 @@ GEM
       multi_json (>= 1.0.0)
       stripe (>= 1.31.0, <= 1.43)
     sysexits (1.2.0)
-    term-ansicolor (1.6.0)
-      tins (~> 1.0)
     thor (0.19.4)
     thread_safe (0.3.6)
     tilt (1.4.1)
     timecop (0.7.1)
-    tins (1.16.3)
     transitions (0.1.12)
     ttfunk (1.1.1)
     turbolinks (5.1.0)
@@ -548,6 +543,7 @@ GEM
     unicode_utils (1.4.0)
     unobtrusive_flash (3.1.0)
       railties
+    url (0.3.2)
     user_agent_parser (2.4.0)
     uuidtools (2.1.5)
     warden (1.2.4)
@@ -596,9 +592,9 @@ DEPENDENCIES
   climate_control
   cloudinary
   cocoon
+  codecov
   countable-rails (~> 0.0.1)
   country_select
-  coveralls
   daemons
   dalli
   database_cleaner

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 [![Build Status](https://travis-ci.org/openSUSE/osem.svg?branch=master)](https://travis-ci.org/openSUSE/osem)
 [![Code Climate](https://codeclimate.com/github/openSUSE/osem.png)](https://codeclimate.com/github/openSUSE/osem)
-[![Coverage Status](https://coveralls.io/repos/openSUSE/osem/badge.png)](https://coveralls.io/r/openSUSE/osem)
+[![codecov](https://codecov.io/gh/opensuse/osem/branch/master/graph/badge.svg)](https://codecov.io/gh/opensuse/osem)
 [![Security Status](https://hakiri.io/github/openSUSE/osem/master.svg)](https://hakiri.io/github/openSUSE/osem/master)
 <a href="https://heroku.com/deploy?template=https://github.com/openSUSE/osem/tree/v1.0">
   <img src="https://www.herokucdn.com/deploy/button.svg" height="20px" alt="Deploy">

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -5,12 +5,10 @@ require 'knapsack'
 require 'simplecov'
 
 if ENV['TRAVIS']
-  require 'coveralls'
-  SimpleCov.formatter = Coveralls::SimpleCov::Formatter
-  Coveralls.wear!('rails')
-else
-  SimpleCov.start 'rails'
+  require 'codecov'
+  SimpleCov.formatter = SimpleCov::Formatter::Codecov
 end
+SimpleCov.start 'rails'
 
 ENV['RAILS_ENV'] ||= 'test'
 require File.expand_path('../../config/environment', __FILE__)


### PR DESCRIPTION
Coveralls seems incapable of cleanly handling parallel results.

https://codecov.io/gh/bear454/osem/branch/codecov vs. https://coveralls.io/builds/16994722

**Checklist**

- [x] I have read the [Contribution & Best practices Guide](https://github.com/openSUSE/osem/blob/master/CONTRIBUTING.md).
- [x] My branch is up-to-date with the upstream `master` branch.
- [x] The tests pass locally with my changes.
- [x] I have added tests that prove my fix is effective or that my feature works(if appropriate).
- [x] I have added necessary documentation (if appropriate).

**Short description of what this resolves/which [issues](https://github.com/openSUSE/osem/issues) does this fix?:**

<!-- List the issue number resolved with this change; if there is no open issue, describe the problem this request solves -->

- coveralls.io does not aggregate coverage from parallel tests in a sane way; unless *every* run includes a line, it isn't considered "green".

**Changes proposed in this pull request:**

<!-- Summarize the changes, using declarative language. -->

- Utilize _codecov.io_ instead.
