### PR TITLE
2046 og tags info about panels

### DIFF
--- a/app/controllers/conferences_controller.rb
+++ b/app/controllers/conferences_controller.rb
@@ -28,6 +28,8 @@ class ConferencesController < ApplicationController
       redirect_to admin_conference_splashpage_path(@conference.short_title) && return
     end
 
+    @image_url = "#{request.protocol}#{request.host}#{@conference.picture}"
+
     if splashpage.include_cfp
       cfps = @conference.program.cfps
       @call_for_events = cfps.find { |call| call.cfp_type == 'events' }

--- a/app/views/conferences/show.html.haml
+++ b/app/views/conferences/show.html.haml
@@ -3,12 +3,18 @@
   %meta{ property: "og:site_name", content: (ENV['OSEM_NAME'] || 'OSEM') }
   %meta{ property: "og:description", content: @conference.description }
   %meta{ property: "og:url", content: conference_url(@conference.short_title) }
+  %meta{ property: "twitter:card", content: "summary_large_image" }
+  %meta{ property: "twitter:image", content: @image_url }
+  %meta{ property: "twitter:title", content: (@conference.title) }
+  %meta{ property: "twitter:description", content: @conference.description }
   - if @conference.picture?
-    %meta{ property: "og:image", content: @conference.picture_url }
-    %meta{ property: "og:image:secure_url", content: @conference.picture_url }
+    %meta{ property: "og:image", content: @image_url }
+    %meta{ property: "og:image:secure_url", content: @image_url }
+
 
 = content_for :title do
   = @conference.title
+
 
 #splash
   - if @conference.code_of_conduct.present?
@@ -49,6 +55,7 @@
     = render 'sponsors', conference: @conference,
       sponsorship_levels: @sponsorship_levels,
       sponsors: @sponsors
+
 
   -# footer
   - if @conference.splashpage.include_social_media

--- a/app/views/conferences/show.html.haml
+++ b/app/views/conferences/show.html.haml
@@ -3,14 +3,15 @@
   %meta{ property: "og:site_name", content: (ENV['OSEM_NAME'] || 'OSEM') }
   %meta{ property: "og:description", content: @conference.description }
   %meta{ property: "og:url", content: conference_url(@conference.short_title) }
-  %meta{ property: "twitter:card", content: "summary_large_image" }
-  %meta{ property: "twitter:image", content: @image_url }
   %meta{ property: "twitter:title", content: (@conference.title) }
   %meta{ property: "twitter:description", content: @conference.description }
   - if @conference.picture?
     %meta{ property: "og:image", content: @image_url }
     %meta{ property: "og:image:secure_url", content: @image_url }
-
+    %meta{ property: "twitter:card", content: "summary_large_image" }
+    %meta{ property: "twitter:image", content: @image_url }
+  - else
+    %meta{ property: "twitter:card", content: "summary" }
 
 = content_for :title do
   = @conference.title


### PR DESCRIPTION
**Checklist**

- [x] I have read the [Contribution & Best practices Guide](https://github.com/openSUSE/osem/blob/master/CONTRIBUTING.md).
- [x] My branch is up-to-date with the upstream `master` branch.
- [x] The tests pass locally with my changes.
- [x] I have added tests that prove my fix is effective or that my feature works(if appropriate).
- [x] I have added necessary documentation (if appropriate).

**Short description of what this resolves/which [issues](https://github.com/openSUSE/osem/issues) does this fix?:**
Primarily the fix needed a proper image URL to display for both the Facebook meta tag as well as the Twitter Card. There was no code to support the twitter card.

I created one instance variable in the conference controller: @image_url
This image_url gets built based on items in the conference object.

<!-- List the issue number resolved with this change; if there is no open issue, describe the problem this request solves -->

This solves issue #2046 
-

**Changes proposed in this pull request:**

<!-- Summarize the changes, using declarative language. -->

This change creates shareable links for Facebook and Twitter by creating meta tags and populating them with conference data.
-
