### PR TITLE
Render markdown in splashpage header without arbitrary assignment to h3

### DIFF
--- a/app/views/conferences/_header.haml
+++ b/app/views/conferences/_header.haml
@@ -31,5 +31,4 @@
       .container
         .row
           .col-md-8.col-md-offset-2
-            %h3.text-center
-              = markdown(conference.description)
+            = markdown(conference.description)


### PR DESCRIPTION
**Checklist**

- [x] I have read the [Contribution & Best practices Guide](https://github.com/openSUSE/osem/blob/master/CONTRIBUTING.md).
- [x] My branch is up-to-date with the upstream `master` branch.
- [x] The tests pass locally with my changes.

**Short description of what this resolves/which [issues](https://github.com/openSUSE/osem/issues) does this fix?:**

<!-- List the issue number resolved with this change; if there is no open issue, describe the problem this request solves -->

- `Conference#description` renders unexpectedly as all `h3` content

**Changes proposed in this pull request:**

<!-- Summarize the changes, using declarative language. -->

- Use the markdown tags defined by the user in `Conference#description` instead of assuming content not specified.
