### PR TITLE
Add Procfile (for environments like Heroku)

### DIFF
--- a/Procfile
+++ b/Procfile
@@ -1,0 +1,2 @@
+web: bundle exec puma -C config/puma.rb
+worker: bundle exec rails jobs:work


### PR DESCRIPTION
**Checklist**

- [x] I have read the [Contribution & Best practices Guide](https://github.com/openSUSE/osem/blob/master/CONTRIBUTING.md).
- [x] My branch is up-to-date with the upstream `master` branch.
- [x] The tests pass locally with my changes.

**Short description of what this resolves/which [issues](https://github.com/openSUSE/osem/issues) does this fix?:**

<!-- List the issue number resolved with this change; if there is no open issue, describe the problem this request solves -->

- When running in an environment that expects a `Procfile`, operators must create one from scratch, despite the conditions being already defined.

**Changes proposed in this pull request:**

<!-- Summarize the changes, using declarative language. -->

- Include a `Procfile` based on existing configuration