### PR TITLE
Collapse two redundant helpers

### DIFF
--- a/app/helpers/format_helper.rb
+++ b/app/helpers/format_helper.rb
@@ -4,24 +4,11 @@ module FormatHelper
   ##
   # Includes functions related to formatting (like adding classes, colors)
   ##
-  def event_status_icon(event)
-    case event.state
-    when 'new'
-      'fa-eye'
-    when 'unconfirmed'
-      'fa-check text-muted'
-    when 'confirmed'
-      'fa-check text-success'
-    when 'rejected', 'withdrawn', 'canceled'
-      'fa-ban'
-    end
-  end
-
-  def booth_status_icon(booth)
-    case booth.state
+  def status_icon(object)
+    case object.state
     when 'new', 'to_reject', 'to_accept'
       'fa-eye'
-    when 'accepted'
+    when 'unconfirmed', 'accepted'
       'fa-check text-muted'
     when 'confirmed'
       'fa-check text-success'

--- a/app/views/booths/index.html.haml
+++ b/app/views/booths/index.html.haml
@@ -24,7 +24,7 @@
                   - show_state = 'new'
                 - else
                   - show_state = booth.state
-                %span{ title: show_state, class: "fa #{booth_status_icon(booth)}" }
+                %span{ title: show_state, class: "fa #{status_icon(booth)}" }
               %td
                 - if booth.logo_link
                   = image_tag(booth.picture.thumb.url, width: '20%')

--- a/app/views/proposals/index.html.haml
+++ b/app/views/proposals/index.html.haml
@@ -67,7 +67,7 @@
           - @events.each do |event|
             %tr
               %td{style: "padding:20px 8px 20px 8px;"}
-                %span{ title: event.state.humanize, class: "fa #{event_status_icon(event)}" }
+                %span{ title: event.state.humanize, class: "fa #{status_icon(event)}" }
 
               %td.col-md-7{style: "padding:20px 8px 20px 8px;"}
                 = link_to event.title, conference_program_proposal_path(@conference.short_title, event.id)


### PR DESCRIPTION
Fold one-used `event_status_icon` and once-used `booth_status_icon` into `status_icon`, used twice; since there is no conflict on the status-driven description.

**Checklist**

- [x] I have read the [Contribution & Best practices Guide](https://github.com/openSUSE/osem/blob/master/CONTRIBUTING.md).
- [x] My branch is up-to-date with the upstream `master` branch.
- [x] The tests pass locally with my changes.

**Short description of what this resolves/which [issues](https://github.com/openSUSE/osem/issues) does this fix?:**

<!-- List the issue number resolved with this change; if there is no open issue, describe the problem this request solves -->

- Two helpers were defined for setting status icons; each was used only once, and both defined redundant states.

**Changes proposed in this pull request:**

<!-- Summarize the changes, using declarative language. -->

- Refactor into a single helper for both object type's states.
