### PR TITLE
Show Edit Registration button for registered users

### DIFF
--- a/app/views/conferences/_registration.haml
+++ b/app/views/conferences/_registration.haml
@@ -28,6 +28,11 @@
                 registration_period.end_date)
           - if conference.registration_open?
             %p.cta-button
-              = link_to('Register Now',
-                new_conference_conference_registration_path(conference_id),
-                class: 'btn btn-lg btn-success')
+              - if conference.user_registered?(current_user)
+                = link_to("Edit Your Registration",
+                  conference_conference_registration_path(conference_id),
+                  class: 'btn btn-success')
+              - else
+                = link_to('Register Now',
+                  new_conference_conference_registration_path(conference_id),
+                  class: 'btn btn-lg btn-success')


### PR DESCRIPTION
Registered users should see a button on the main conference page to edit their current registration instead of being asked to create/add a new one.

The button is smaller since it's less of a pending task.

Fixes #2041

Before:

![register now](https://user-images.githubusercontent.com/743877/40881053-0b114ffe-668b-11e8-9da5-ba0c35ee3768.png)

After

![edit registration](https://user-images.githubusercontent.com/743877/40881054-0df8c472-668b-11e8-812e-5694cd60df9e.png)

**Checklist**

- [x] I have read the [Contribution & Best practices Guide](https://github.com/openSUSE/osem/blob/master/CONTRIBUTING.md).
- [x] My branch is up-to-date with the upstream `master` branch.
- [ ] The tests pass locally with my changes.
- [ ] I have added tests that prove my fix is effective or that my feature works(if appropriate).

Can't yet work out how to run the current tests in Docker or Vagrant, so I did not include any here.