### PR TITLE
Only one collapsed menu on non-admin pages

### DIFF
--- a/app/views/layouts/_admin_sidebar_index.html.haml
+++ b/app/views/layouts/_admin_sidebar_index.html.haml
@@ -1,4 +1,4 @@
-%ul.nav.nav-pills.nav-stacked.mySidebar
+%ul.nav.nav-stacked.nav-pills.mySidebar.collapse.navbar-collapse#side-nav
   .btn-group
     %button{type: 'button', class: 'btn btn-default btn-link dropdown-toggle', 'data-toggle'=>'dropdown'}
       %span.fa.fa-home

--- a/app/views/layouts/_navigation.html.haml
+++ b/app/views/layouts/_navigation.html.haml
@@ -1,7 +1,8 @@
 .navbar.navbar-default.navbar-fixed-top.nav-osem{role: 'navigation'}
   .container
     .navbar-header
-      - if @conference && @conference.short_title.present?
+
+      - if controller.class.name.split("::").first=="Admin"
         %button{ "data-target"=>"#side-nav", "data-toggle"=>"collapse", class: 'navbar-toggle side-nav-btn', type: 'button' }
           %span.sr-only Toggle navigation
           %span.icon-bar


### PR DESCRIPTION
(cherry picked from commit 96ff845120e7a9c83d5d4c30908b283bb9449247)

**Checklist**

- [x] I have read the [Contribution & Best practices Guide](https://github.com/openSUSE/osem/blob/master/CONTRIBUTING.md).
- [x] My branch is up-to-date with the upstream `master` branch.
- [x] The tests pass locally with my changes.

**Short description of what this resolves/which [issues](https://github.com/openSUSE/osem/issues) does this fix?:**

<!-- List the issue number resolved with this change; if there is no open issue, describe the problem this request solves -->

- #1910 

**Changes proposed in this pull request:**

<!-- Summarize the changes, using declarative language. -->

- Instead of trying to fold up all the menus, leave the 2nd hamburger for the admin menus, but only on admin pages (as the only content is the left-hand admin menu).
