### PR TITLE
Add timed cache expiration on CfP partials

### DIFF
--- a/app/views/conferences/_call_for_papers.haml
+++ b/app/views/conferences/_call_for_papers.haml
@@ -1,4 +1,5 @@
-- cache [conference_id, call, event_types, tracks, '#splash#callforpapers'] do
+- cache([conference_id, call, event_types, tracks, '#splash#callforpapers'],
+  expires_in: 1.hour) do
   .col-md-4.col-sm-4.text-center
     %h2
       Call for Papers

--- a/app/views/conferences/_call_for_tracks.haml
+++ b/app/views/conferences/_call_for_tracks.haml
@@ -1,4 +1,5 @@
-- cache [conference_id, call, '#splash#callfortracks'] do
+- cache([conference_id, call, '#splash#callfortracks'],
+  expires_in: 1.hour) do
   .col-md-4.col-sm-4.text-center
     %h2
       Call for Tracks


### PR DESCRIPTION
(cherry picked from commit f339c191c13c204e9c0a78df1bc083e882b2d2eb)

**Checklist**

- [x] I have read the [Contribution & Best practices Guide](https://github.com/openSUSE/osem/blob/master/CONTRIBUTING.md).
- [x] My branch is up-to-date with the upstream `master` branch.
- [x] The tests pass locally with my changes.

**Short description of what this resolves/which [issues](https://github.com/openSUSE/osem/issues) does this fix?:**

<!-- List the issue number resolved with this change; if there is no open issue, describe the problem this request solves -->

- Splashpages partials for content calls do not expire, and therefore may incorrectly indicate the state of those calls when it changes.

**Changes proposed in this pull request:**

<!-- Summarize the changes, using declarative language. -->

- Add a cache expiration period, so the calls can properly show changes in a reasonable timeframe.
