### PR TITLE
Find source of queries

### DIFF
--- a/config/initializers/active_record_log_subscriber.rb
+++ b/config/initializers/active_record_log_subscriber.rb
@@ -1,0 +1,17 @@
+# http://www.jkfill.com/2015/02/14/log-which-line-caused-a-query/
+module LogQuerySource
+  def debug(*args, &block)
+    return unless super
+
+    backtrace = Rails.backtrace_cleaner.clean caller
+
+    relevant_caller_line = backtrace.detect do |caller_line|
+      !caller_line.include?('/initializers/')
+    end
+
+    if relevant_caller_line
+      logger.debug("  ↳ #{ relevant_caller_line.sub("#{ Rails.root }/", '') }")
+    end
+  end
+end
+ActiveRecord::LogSubscriber.send :prepend, LogQuerySource


### PR DESCRIPTION
(cherry picked from commit 458392ef0d334173f65eac41eb23345e3201a024)

**Checklist**

- [x] I have read the [Contribution & Best practices Guide](https://github.com/openSUSE/osem/blob/master/CONTRIBUTING.md).
- [x] My branch is up-to-date with the upstream `master` branch.
- [x] The tests pass locally with my changes.

**Short description of what this resolves/which [issues](https://github.com/openSUSE/osem/issues) does this fix?:**

<!-- List the issue number resolved with this change; if there is no open issue, describe the problem this request solves -->

- Rails logs are inherently ambiguous about the source of a specific query, adding unnecessary difficulty when debugging or performance profiling queries.

**Changes proposed in this pull request:**

<!-- Summarize the changes, using declarative language. -->

- Add a log entry, after each ActiveRecord entry, showing the current stack line that triggered the query.
