### PR TITLE
Move notifications into user menu

### DIFF
--- a/app/views/layouts/_navigation.html.haml
+++ b/app/views/layouts/_navigation.html.haml
@@ -32,21 +32,6 @@
                 %b.caret
               %ul.dropdown-menu
                 = render 'layouts/user_menu'
-          - if can? :index, Comment
-            %ul.nav.navbar-nav.navbar-right
-              %li.dropdown
-                %a.dropdown-toggle{"data-toggle" => "dropdown", :href => "#"}
-                  Notifications (#{unread_notifications(current_user).length})
-                  %span.fa.fa-comment
-                  %b.caret
-                %ul.dropdown-menu
-                  - if unread_notifications(current_user).length > 0
-                    %li.dropdown-header Last 5 Comments for:
-                    - unread_notifications(current_user).limit(5).group_by{ |comment| comment.commentable}.each do |event, comments|
-                      %li= link_to("#{event.title}(#{comments.count})", admin_conference_program_event_path(event.program.conference.short_title, event.id))
-                    %li.divider
-                    %li= link_to "See all unread Comments (#{unread_notifications(current_user).length})", admin_comments_path
-                  %li= link_to 'See all Comments', admin_comments_path(anchor: 'all_comments')
       - else
         %ul.nav.navbar-nav.navbar-right
           - if ENV['OSEM_ICHAIN_ENABLED'] == 'true'

--- a/app/views/layouts/_user_menu.html.haml
+++ b/app/views/layouts/_user_menu.html.haml
@@ -1,3 +1,15 @@
+- if can? :index, Comment
+  %li.dropdown-header
+    %span.fa.fa-comment
+    Notifications (#{unread_notifications(current_user).length})
+  - if unread_notifications(current_user).length > 0
+    %li.dropdown-header Last 5 Comments for:
+    - unread_notifications(current_user).limit(5).group_by{ |comment| comment.commentable}.each do |event, comments|
+      %li= link_to("#{event.title}(#{comments.count})", admin_conference_program_event_path(event.program.conference.short_title, event.id))
+    %li.divider
+    %li= link_to "See all unread Comments (#{unread_notifications(current_user).length})", admin_comments_path
+  %li= link_to 'See all Comments', admin_comments_path(anchor: 'all_comments')
+  %li.divider
 - unless ENV['OSEM_ICHAIN_ENABLED'] == 'true'
   %li
     = link_to(edit_user_registration_path) do


### PR DESCRIPTION
**Checklist**

- [x] I have read the [Contribution & Best practices Guide](https://github.com/openSUSE/osem/blob/master/CONTRIBUTING.md).
- [x] My branch is up-to-date with the upstream `master` branch.
- [x] The tests pass locally with my changes.

**Short description of what this resolves/which [issues](https://github.com/openSUSE/osem/issues) does this fix?:**

<!-- List the issue number resolved with this change; if there is no open issue, describe the problem this request solves -->

- Too many navigation items on the top menu!

**Changes proposed in this pull request:**

<!-- Summarize the changes, using declarative language. -->

- Move the comments menu onto the user menu (where it collapses on mobile anyway).

![screenshot from 2018-06-08 18-17-16](https://user-images.githubusercontent.com/108494/41186508-86b3da26-6b4c-11e8-9e27-dad3fa1bf2c9.png)

