### PR TITLE
Boostrap switch cleanup

### DIFF
--- a/app/assets/javascripts/osem-switch.js
+++ b/app/assets/javascripts/osem-switch.js
@@ -5,7 +5,7 @@ function checkboxSwitch(selector){
 
   $(selector).on('switchChange.bootstrapSwitch', function(event, state) {
     var url = $(this).attr('url') + state;
-    var method = $(this).attr('method');
+    var method = $(this).attr('method') || 'patch';
 
     $.ajax({
       url: url,
@@ -16,13 +16,20 @@ function checkboxSwitch(selector){
 }
 
 $(function () {
+  $.fn.bootstrapSwitch.defaults.onColor = 'success';
+  $.fn.bootstrapSwitch.defaults.offColor = 'warning';
+  $.fn.bootstrapSwitch.defaults.onText = 'Yes';
+  $.fn.bootstrapSwitch.defaults.offText = 'No';
+  $.fn.bootstrapSwitch.defaults.size = 'small';
+
+
   checkboxSwitch("[class='switch-checkbox']");
 
   $("[class='switch-checkbox-schedule']").bootstrapSwitch();
 
   $('input[class="switch-checkbox-schedule"]').on('switchChange.bootstrapSwitch', function(event, state) {
     var url = $(this).attr('url');
-    var method = $(this).attr('method');
+    var method = $(this).attr('method') || 'patch';
 
     if(state){
       url += $(this).attr('value');

--- a/app/assets/javascripts/osem-switch.js
+++ b/app/assets/javascripts/osem-switch.js
@@ -1,7 +1,9 @@
-$(function () {
-  $("[class='switch-checkbox']").bootstrapSwitch();
+function checkboxSwitch(selector){
+  $(selector).bootstrapSwitch(
 
-  $('input[class="switch-checkbox"]').on('switchChange.bootstrapSwitch', function(event, state) {
+  );
+
+  $(selector).on('switchChange.bootstrapSwitch', function(event, state) {
     var url = $(this).attr('url') + state;
     var method = $(this).attr('method');
 
@@ -11,6 +13,10 @@ $(function () {
       dataType: 'script'
     });
   });
+}
+
+$(function () {
+  checkboxSwitch("[class='switch-checkbox']");
 
   $("[class='switch-checkbox-schedule']").bootstrapSwitch();
 

--- a/app/helpers/events_helper.rb
+++ b/app/helpers/events_helper.rb
@@ -168,14 +168,7 @@ module EventsHelper
         event,
         event: { attribute => nil }
       ),
-      method: :patch,
-      class:  'switch-checkbox',
-      data:   {
-        size:      'small',
-        off_color: 'warning',
-        on_text:   'Yes',
-        off_text:  'No'
-      }
+      class:  'switch-checkbox'
     )
   end
 

--- a/app/views/admin/conferences/_recent_users.html.haml
+++ b/app/views/admin/conferences/_recent_users.html.haml
@@ -15,11 +15,9 @@
             %td= user.created_at.strftime('%m/%d/%Y')
             %td
               = check_box_tag user.id, user.id, user.confirmed?,
-                method: :patch,
                 url: "/admin/users/#{user.id}/toggle_confirmation?user[to_confirm]=",
                 class: 'switch-checkbox',
-                readonly: true,
-                data: { size: 'small', on_color: 'success', off_color: 'warning', on_text: 'Yes', off_text: 'No' }
+                readonly: true
 - else
   %h5.text-warning.text-center
     No sign ups!

--- a/app/views/admin/events/registrations.html.haml
+++ b/app/views/admin/events/registrations.html.haml
@@ -32,11 +32,7 @@
               %td= event_registration.email
               %td= event_registration.created_at
               %td
-                = check_box_tag @conference.short_title, @event.id, event_registration.attended, class: 'switch-checkbox', method: :patch, url: "/admin/conferences/#{@conference.short_title}/program/events/#{@event.id}/toggle_attendance?events_registration_id=#{event_registration.id}&&event_registration[attended]=",
-                  data: { size: 'small',
-                          off_color: 'danger',
-                          on_text: 'Yes',
-                          off_text: 'No' }
+                = check_box_tag @conference.short_title, @event.id, event_registration.attended, class: 'switch-checkbox', url: "/admin/conferences/#{@conference.short_title}/program/events/#{@event.id}/toggle_attendance?events_registration_id=#{event_registration.id}&&event_registration[attended]="
               %td
                 - if event_registration.registration.attended
                   %i.fa.fa-check.text-success

--- a/app/views/admin/registrations/index.html.haml
+++ b/app/views/admin/registrations/index.html.haml
@@ -68,13 +68,8 @@
                   = link_to 'Questions','#', class: 'btn btn-success question-btn', 'data-id' => index, 'data-name' => registration.name
               %td{ 'data-order' => registration.attended.to_s }
                 = check_box_tag "#{@conference.short_title}_#{registration.id}", registration.id, registration.attended,
-                  class: 'switch-checkbox', method: :patch,
-                  url: toggle_attendance_admin_conference_registration_path(@conference.short_title, id: registration.id)+"?attended=",
-                  data: { size: 'small',
-                          on_color: 'success',
-                          off_color: 'warning',
-                          on_text: 'Present',
-                          off_text: 'Absent' }
+                  class: 'switch-checkbox',
+                  url: toggle_attendance_admin_conference_registration_path(@conference.short_title, id: registration.id)+"?attended="
                 .btn-group
                   = link_to 'Edit', edit_admin_conference_registration_path(@conference.short_title, id: registration),
                   method: :get, class: 'btn btn-primary'

--- a/app/views/admin/roles/_users.html.haml
+++ b/app/views/admin/roles/_users.html.haml
@@ -14,7 +14,7 @@
           - if ( can? :toggle_user, @role )
             %td.text-right
               = hidden_field_tag "role[user_ids][]", nil
-              = check_box_tag @conference.short_title, @role.id, (@role.user_ids.include? user.id), method: :post, url: "#{@url}?user[email]=#{user.email}&user[state]=", class: 'switch-checkbox', data: { size: 'small', off_color: 'warning', on_text: 'Yes', off_text: 'No' }
+              = check_box_tag @conference.short_title, @role.id, (@role.user_ids.include? user.id), url: "#{@url}?user[email]=#{user.email}&user[state]=", method: :post, class: 'switch-checkbox'
           %td= user.id
           %td= user.name
           %td= user.email

--- a/app/views/admin/schedules/show.html.haml
+++ b/app/views/admin/schedules/show.html.haml
@@ -19,11 +19,8 @@
           value = @schedule.id == @selected_schedule.try(:id)
           url = admin_conference_program_path(@conference.short_title) + '?[program][selected_schedule_id]='
         end
-      = check_box_tag @conference.short_title, @schedule.id, value, method: :patch, url: url,
-        class: 'switch-checkbox-schedule', data: { size: 'small',
-                                          off_color: 'warning',
-                                          on_text: 'Yes',
-                                          off_text: 'No' }
+      = check_box_tag @conference.short_title, @schedule.id, value, url: url,
+        class: 'switch-checkbox-schedule'
       .h4
         Unscheduled events
       .unscheduled-events

--- a/app/views/admin/tracks/index.html.haml
+++ b/app/views/admin/tracks/index.html.haml
@@ -67,13 +67,8 @@
                 = link_to track.submitter.name, admin_user_path(track.submitter) if track.self_organized?
               %td.text-center{ 'id' => "cfp_switch_#{track.id}", 'data-order' => track.cfp_active.to_s }
                 = check_box_tag "#{@conference.short_title}_#{track.short_name}", track.id, track.cfp_active,
-                  class: 'switch-checkbox', method: :patch,
-                  url: toggle_cfp_inclusion_admin_conference_program_track_path(@conference.short_title, id: track.short_name)+"?included=",
-                  data: { size: 'small',
-                          on_color: 'success',
-                          off_color: 'warning',
-                          on_text: 'Yes',
-                          off_text: 'No' }
+                  class: 'switch-checkbox',
+                  url: toggle_cfp_inclusion_admin_conference_program_track_path(@conference.short_title, id: track.short_name)+"?included="
 
               %td.text-center
                 - if track.self_organized?

--- a/app/views/admin/tracks/show.html.haml
+++ b/app/views/admin/tracks/show.html.haml
@@ -78,13 +78,8 @@
                 %b Included in the Cfp?
               %td
                 = check_box_tag "#{@conference.short_title}_#{@track.short_name}", @track.id, @track.cfp_active,
-                  class: 'switch-checkbox', method: :patch,
-                  url: toggle_cfp_inclusion_admin_conference_program_track_path(@conference.short_title, id: @track.short_name)+"?included=",
-                  data: { size: 'small',
-                          on_color: 'success',
-                          off_color: 'warning',
-                          on_text: 'Yes',
-                          off_text: 'No' }
+                  class: 'switch-checkbox',
+                  url: toggle_cfp_inclusion_admin_conference_program_track_path(@conference.short_title, id: @track.short_name)+"?included="
             %tr
               %td
                 %b State

--- a/app/views/admin/users/_form.html.haml
+++ b/app/views/admin/users/_form.html.haml
@@ -6,18 +6,14 @@
           Confirmed?
         - if can? :toggle_confirmation, @user
           = check_box_tag @user.id, @user.id, @user.confirmed?,
-            method: :patch,
             url: "/admin/users/#{@user.id}/toggle_confirmation?user[to_confirm]=",
             class: 'switch-checkbox',
-            readonly: false,
-            data: { size: 'small', on_color: 'success', off_color: 'warning', on_text: 'Yes', off_text: 'No' }
+            readonly: false
         - else
           = check_box_tag @user.id, @user.id, @user.confirmed?,
-            method: :patch,
             url: "/admin/users/#{@user.id}/toggle_confirmation?user[to_confirm]=",
             class: 'switch-checkbox',
-            readonly: true,
-            data: { size: 'small', on_color: 'success', off_color: 'warning', on_text: 'Yes', off_text: 'No' }
+            readonly: true
     = f.input :is_admin, hint: 'An admin can create a new conference, manage users and make other users admins.'
     = f.input :name, as: :string
     = f.input :username, :as => :string if @user.new_record?

--- a/app/views/admin/users/show.html.haml
+++ b/app/views/admin/users/show.html.haml
@@ -27,7 +27,7 @@
                   %td
                     = markdown(@user.biography)
                 - elsif attr == 'email'
-                  %td 
+                  %td
                     = @user.send(attr)
                   %tr
                     %td
@@ -35,19 +35,15 @@
                         Confirmed?
                     %td
                       - if can? :toggle_confirmation, @user
-                        = check_box_tag @user.id, @user.id, @user.confirmed?, 
-                          method: :patch, 
-                          url: "/admin/users/#{@user.id}/toggle_confirmation?user[to_confirm]=", 
-                          class: 'switch-checkbox', 
-                          readonly: false,
-                          data: { size: 'small', on_color: 'success', off_color: 'warning', on_text: 'Yes', off_text: 'No' } 
+                        = check_box_tag @user.id, @user.id, @user.confirmed?,
+                          url: "/admin/users/#{@user.id}/toggle_confirmation?user[to_confirm]=",
+                          class: 'switch-checkbox',
+                          readonly: false
                       - else
-                        = check_box_tag @user.id, @user.id, @user.confirmed?, 
-                          method: :patch, 
-                          url: "/admin/users/#{@user.id}/toggle_confirmation?user[to_confirm]=", 
-                          class: 'switch-checkbox', 
-                          readonly: true,
-                          data: { size: 'small', on_color: 'success', off_color: 'warning', on_text: 'Yes', off_text: 'No' }
+                        = check_box_tag @user.id, @user.id, @user.confirmed?,
+                          url: "/admin/users/#{@user.id}/toggle_confirmation?user[to_confirm]=",
+                          class: 'switch-checkbox',
+                          readonly: true
                 - else
                   %td= @user.send(attr)
         #submissions-content.tab-pane{class: "#{'active' if params[:tab] == 'submissions-content'}"}

--- a/spec/helpers/events_helper_spec.rb
+++ b/spec/helpers/events_helper_spec.rb
@@ -71,9 +71,8 @@ describe EventsHelper, type: :helper do
       )
     end
 
-    it 'should patch to the admin event url' do
+    it 'should use the admin event url' do
       expect(result).to include(
-        'method="patch"',
         "url=\"/admin/conferences/#{conference.short_title}/program" \
           "/events/#{event.id}?event%5Bis_highlight%5D=\""
       )


### PR DESCRIPTION
**Checklist**

- [x] I have read the [Contribution & Best practices Guide](https://github.com/openSUSE/osem/blob/master/CONTRIBUTING.md).
- [x] My branch is up-to-date with the upstream `master` branch.
- [x] The tests pass locally with my changes.
- [x] I have added tests that prove my fix is effective or that my feature works(if appropriate).

**Short description of what this resolves/which [issues](https://github.com/openSUSE/osem/issues) does this fix?:**

<!-- List the issue number resolved with this change; if there is no open issue, describe the problem this request solves -->

- Repetitive arguments on boostrapSwitch instances
- bootstrapSwitch can only be set up on page load

**Changes proposed in this pull request:**

<!-- Summarize the changes, using declarative language. -->

- DRY up the configuration using default values
-  Set up an external function for setting up a bootstrapSwitch
