### PR TITLE
DRY up datatable definitions

### DIFF
--- a/app/assets/stylesheets/osem-datatables.scss
+++ b/app/assets/stylesheets/osem-datatables.scss
@@ -1,0 +1,21 @@
+table.datatable {
+  @extend .table, .table-striped, .table-bordered, .table-hover;
+
+  td.actions {
+    vertical-align: middle;
+    align: center;
+
+    div.btn-group {
+      display: flex;
+    }
+
+    a {
+      @extend .btn;
+    }
+  }
+
+  td.truncate {
+    max-width: 1px;
+    @include text-overflow();
+  }
+}

--- a/app/assets/stylesheets/strap-on.scss
+++ b/app/assets/stylesheets/strap-on.scss
@@ -61,3 +61,6 @@ $navbar-default-link-hover-color: #000000;
 // Utility classes
 @import "bootstrap/utilities";
 @import "bootstrap/responsive-utilities";
+
+// semantic classes
+@import "osem-datatables";

--- a/app/views/admin/booths/index.html.haml
+++ b/app/views/admin/booths/index.html.haml
@@ -54,7 +54,7 @@
           = link_to "#{@conference.booth_limit} booths", edit_admin_conference_path(@conference.short_title)
           )
     - if @booths.any?
-      %table.table.table-striped.table-bordered.table-hover.datatable
+      %table.datatable
         %thead
           %th
             %b ID

--- a/app/views/admin/events/index.html.haml
+++ b/app/views/admin/events/index.html.haml
@@ -59,7 +59,7 @@
 .row
   .col-md-12
     .margin-event-table
-      %table.table.table-striped.table-bordered.table-hover.datatable
+      %table.datatable
         %thead
           %th
             %b ID

--- a/app/views/admin/events/registrations.html.haml
+++ b/app/views/admin/events/registrations.html.haml
@@ -16,7 +16,7 @@
       You have more registrations than the capacity of the room!
 
     .well
-      %table.table.table-hover.table-borderd.table-striped.datatable#registrations
+      %table.datatable#registrations
         %thead
           %th
           %th Name

--- a/app/views/admin/events/show.html.haml
+++ b/app/views/admin/events/show.html.haml
@@ -18,7 +18,7 @@
       = render 'proposal'
     #history-content.tab-pane
       .col-md-12
-        %table.table.table-striped.table-bordered.table-hover.datatable
+        %table.datatable
           %thead
             %th ID
             %th Description

--- a/app/views/admin/organizations/_users_with_org_admin_role.haml
+++ b/app/views/admin/organizations/_users_with_org_admin_role.haml
@@ -1,7 +1,7 @@
 .page-header
   %h3 Users (#{users.length})
 - if users.present?
-  %table.table.table-striped.table-bordered.table-hover.datatable#users
+  %table.datatable#users
     %thead
       %th Name
       %th Email

--- a/app/views/admin/organizations/index.html.haml
+++ b/app/views/admin/organizations/index.html.haml
@@ -9,7 +9,7 @@
         Manage organizations in OSEM
 .row
   .col-md-12
-    %table.table.table-hover.datatable
+    %table.datatable
       %thead
         %th Name
         %th Upcoming Conferences

--- a/app/views/admin/physical_tickets/index.html.haml
+++ b/app/views/admin/physical_tickets/index.html.haml
@@ -16,7 +16,7 @@
   - if @physical_tickets.any?
     .row
       .col-md-12
-        %table.table.table-hover.datatable#tickets
+        %table.datatable#tickets
           %thead
             %th ID
             %th Type

--- a/app/views/admin/questions/show.html.haml
+++ b/app/views/admin/questions/show.html.haml
@@ -11,7 +11,7 @@
   .row
     .col-md-12
 
-      %table.table.table-border.table-hover.datatable#question_users
+      %table.datatable#question_users
         %thead
           %th Name
           %th Username

--- a/app/views/admin/registrations/index.html.haml
+++ b/app/views/admin/registrations/index.html.haml
@@ -19,7 +19,7 @@
 .row
   .col-md-12
     %div.margin-event-table
-      %table.table.table-hover.datatable#registrations
+      %table.datatable#registrations
         %thead
           %tr
             %th ID#

--- a/app/views/admin/reports/_all_events.html.haml
+++ b/app/views/admin/reports/_all_events.html.haml
@@ -8,7 +8,7 @@
         All submissions and the information that they are missing
 
 .col-md-12
-  %table.table.table-striped.table-bordered.table-hover.datatable
+  %table.datatable
     %thead
       %th ID
       %th Title

--- a/app/views/admin/reports/_events_with_requirements.html.haml
+++ b/app/views/admin/reports/_events_with_requirements.html.haml
@@ -7,7 +7,7 @@
       %p.text-muted
         All submissions where the speakers have special requirements
 .col-md-12
-  %table.table.table-striped.table-bordered.table-hover.datatable
+  %table.datatable
     %thead
       %th ID
       %th Title

--- a/app/views/admin/reports/_events_without_commercials.html.haml
+++ b/app/views/admin/reports/_events_without_commercials.html.haml
@@ -7,7 +7,7 @@
       %p.text-muted
         All submissions that have no commercial
 .col-md-12
-  %table.table.table-striped.table-bordered.table-hover.datatable
+  %table.datatable
     %thead
       %th ID
       %th Title

--- a/app/views/admin/reports/_missing_speakers.html.haml
+++ b/app/views/admin/reports/_missing_speakers.html.haml
@@ -7,7 +7,7 @@
       %p.text-muted
         All event speakers who haven't checked in
 .col-md-12
-  %table.table.table-striped.table-bordered.table-hover.datatable
+  %table.datatable
     %thead
       %th Speaker Name
       %th Registered?

--- a/app/views/admin/resources/index.html.haml
+++ b/app/views/admin/resources/index.html.haml
@@ -7,7 +7,7 @@
 - if @conference.resources.any?
   .row
     .col-md-12
-      %table.table.table-hover.datatable
+      %table.datatable
         %thead
           %th Name
           %th Left( Left/Total )
@@ -33,4 +33,3 @@
 .row
   .col-md-12
     = link_to 'Add Resource', new_admin_conference_resource_path, class: 'btn btn-success pull-right', disabled: !(can? :create, Resource.new(conference_id: @conference_id))
-

--- a/app/views/admin/roles/_users.html.haml
+++ b/app/views/admin/roles/_users.html.haml
@@ -1,7 +1,7 @@
 .page-header
   %h3 Users (#{users.length})
 - if users.present?
-  %table.table.table-striped.table-bordered.table-hover.datatable#users
+  %table.datatable#users
     %thead
       - if ( can? :toggle_user, @role )
         %th.col-md-1

--- a/app/views/admin/tickets/index.html.haml
+++ b/app/views/admin/tickets/index.html.haml
@@ -8,7 +8,7 @@
 - if @conference.tickets.any?
   .row
     .col-md-12
-      %table.table.table-hover.datatable#tickets
+      %table.datatable#tickets
         %thead
           %th Title
           %th Price

--- a/app/views/admin/tickets/show.html.haml
+++ b/app/views/admin/tickets/show.html.haml
@@ -12,7 +12,7 @@
         People who bought this ticket
 .row
   .col-md-12
-    %table.table.table-hover.datatable
+    %table.datatable
       %thead
         %th #
         %th Name
@@ -35,4 +35,3 @@
               = buyer.affiliation
             %td
               = @ticket.tickets_paid(buyer)
-

--- a/app/views/admin/tracks/index.html.haml
+++ b/app/views/admin/tracks/index.html.haml
@@ -33,7 +33,7 @@
 .row
   .col-md-12
     - if @tracks.any?
-      %table.table.table-hover.table-striped.table-bordered.datatable#tracks
+      %table.datatable#tracks
         %thead
           %th ID
           %th Name

--- a/app/views/admin/tracks/show.html.haml
+++ b/app/views/admin/tracks/show.html.haml
@@ -112,7 +112,7 @@
 
     .tab-pane#events
       .col-md-12
-        %table.table.table-hover.datatable
+        %table.datatable
           %thead
             %th Title
             %th Type

--- a/app/views/admin/users/_event_registrations.html.haml
+++ b/app/views/admin/users/_event_registrations.html.haml
@@ -5,7 +5,7 @@
 
   .col-md-12
     .well
-      %table.table.table-bordered.table-striped.table-hover.datatable#event_registrations
+      %table.datatable#event_registrations
         %thead
           %th ID
           %th Conference

--- a/app/views/admin/users/_submissions.html.haml
+++ b/app/views/admin/users/_submissions.html.haml
@@ -4,7 +4,7 @@
       Submissions (#{@user.events.length}) for #{@user.name}
   .col-md-12
     .well
-      %table.table.table-bordered.table-striped.table-hover.datatable#submissions
+      %table.datatable#submissions
         %thead
           %th ID
           %th Conference

--- a/app/views/admin/users/index.html.haml
+++ b/app/views/admin/users/index.html.haml
@@ -10,7 +10,7 @@
             = link_to 'Add User', new_admin_user_path, :class => 'button btn btn-default btn-info'
 .row
   .col-md-12.table-responsive
-    %table.table.table-striped.table-bordered.table-hover.datatable
+    %table.datatable
       %thead
         %th ID
         %th Confirmed?

--- a/app/views/proposals/registrations.html.haml
+++ b/app/views/proposals/registrations.html.haml
@@ -13,7 +13,7 @@
           = @event.title
 
       .well
-        %table.table.table-hover.table-borderd.table-striped.datatable#registrations
+        %table.datatable#registrations
           %thead
             %th
             %th Name


### PR DESCRIPTION
**Checklist**

- [x] I have read the [Contribution & Best practices Guide](https://github.com/openSUSE/osem/blob/master/CONTRIBUTING.md).
- [x] My branch is up-to-date with the upstream `master` branch.
- [x] The tests pass locally with my changes.

**Short description of what this resolves/which [issues](https://github.com/openSUSE/osem/issues) does this fix?:**

<!-- List the issue number resolved with this change; if there is no open issue, describe the problem this request solves -->

- Datatable definitions are inconsistently styled, but repeat similarly many times.

**Changes proposed in this pull request:**

<!-- Summarize the changes, using declarative language. -->

- Add a semantic class to aggregate bootstrap classes and consistently apply them to all datatables.
