### PR TITLE
Fix rating_stars parameters in admin/events#show

### DIFF
--- a/app/views/admin/events/_voting.html.haml
+++ b/app/views/admin/events/_voting.html.haml
@@ -48,7 +48,7 @@
             %td
               = vote.name
             %td
-              = rating_stars(vote, max_rating )
+              = rating_stars(vote.rating, max_rating )
 
 :javascript
   $(".myrating").hover(


### PR DESCRIPTION
We were passing vote object instead of vote.rating to the rating_stars helper method