### PR TITLE
Add email for proposal submission

### DIFF
--- a/app/controllers/admin/emails_controller.rb
+++ b/app/controllers/admin/emails_controller.rb
@@ -25,7 +25,10 @@ module Admin
     private
 
     def email_params
-      params.require(:email_settings).permit(:send_on_registration, :send_on_accepted, :send_on_rejected, :send_on_confirmed_without_registration,
+      params.require(:email_settings).permit(:send_on_registration,
+                                             :send_on_accepted, :send_on_rejected, :send_on_confirmed_without_registration,
+                                             :send_on_submitted_proposal,
+                                             :submitted_proposal_subject, :submitted_proposal_body,
                                              :registration_subject, :accepted_subject, :rejected_subject, :confirmed_without_registration_subject,
                                              :registration_body, :accepted_body, :rejected_body, :confirmed_without_registration_body,
                                              :send_on_conference_dates_updated, :conference_dates_updated_subject, :conference_dates_updated_body,

--- a/app/controllers/proposals_controller.rb
+++ b/app/controllers/proposals_controller.rb
@@ -62,6 +62,7 @@ class ProposalsController < ApplicationController
 
     if @event.save
       ahoy.track 'Event submission', title: 'New submission'
+      Mailbot.submitted_proposal_mail(@event).deliver_later if @conference.email_settings.send_on_submitted_proposal
       redirect_to conference_program_proposals_path(@conference.short_title), notice: 'Proposal was successfully submitted.'
     else
       flash.now[:error] = "Could not submit proposal: #{@event.errors.full_messages.join(', ')}"

--- a/app/mailers/mailbot.rb
+++ b/app/mailers/mailbot.rb
@@ -35,6 +35,15 @@ class Mailbot < ActionMailer::Base
          body: conference.email_settings.generate_event_mail(event, conference.email_settings.accepted_body))
   end
 
+  def submitted_proposal_mail(event)
+    conference = event.program.conference
+
+    mail(to: event.submitter.email,
+         from: conference.contact.email,
+         subject: conference.email_settings.submitted_proposal_subject,
+         body: conference.email_settings.generate_event_mail(event, conference.email_settings.submitted_proposal_body))
+  end
+
   def rejection_mail(event)
     conference = event.program.conference
 

--- a/app/views/admin/emails/index.html.haml
+++ b/app/views/admin/emails/index.html.haml
@@ -28,6 +28,13 @@
                 %a.btn.btn-link.control_label.template_help_link{ 'data-name' => 'registration_help' } Show Help
                 = render partial: 'help', locals: { id: 'registration_help', show_event_variables: false }
               #proposal.tab-pane{ role: 'tabpanel' }
+                = f.input :send_on_submitted_proposal, label: 'Send an email when the proposal is submitted', input_html: { 'data-name' => 'email_settings_proposal_submited_subject', 'class' => 'send_on_radio' }
+                = f.input :submitted_proposal_subject
+                = f.input :submitted_proposal_body, input_html: { rows: 10, cols: 20 }
+                %a.btn.btn-link.control_label.load_template{ 'data-subject-input-id' => 'email_settings_submitted_proposal_subject', 'data-subject-text' => 'Your proposal has been submitted successfully', 'data-body-input-id' => 'email_settings_submitted_proposal_body', 'data-body-text' => "Dear {name}\n\nThank you for submitting your proposal {eventtitle}.\n\nOur team will review it and get back to you as soon as possible.\n\nFeel free to contact us with any questions or concerns.\n\nBest wishes\n\n{conference} Team" } Load Template
+                %a.btn.btn-link.control_label.template_help_link{ 'data-name' => 'submitted_proposal_help' } Show Help
+                = render partial: 'help', locals: { id: 'submitted_proposal_help', show_event_variables: true }
+
                 = f.input :send_on_accepted, label: 'Send an email when the proposal is accepted?', input_html: { 'data-name' => 'email_settings_accepted_subject', 'class' => 'send_on_radio' }
                 = f.input :accepted_subject
                 = f.input :accepted_body, input_html: { rows: 10, cols: 20 }

--- a/db/migrate/20180822125509_add_submitted_proposal_attributes_in_email_settings.rb
+++ b/db/migrate/20180822125509_add_submitted_proposal_attributes_in_email_settings.rb
@@ -1,0 +1,9 @@
+# frozen_string_literal: true
+
+class AddSubmittedProposalAttributesInEmailSettings < ActiveRecord::Migration[5.0]
+  def change
+    add_column :email_settings, :send_on_submitted_proposal, :boolean, default: false
+    add_column :email_settings, :submitted_proposal_subject, :string
+    add_column :email_settings, :submitted_proposal_body, :text
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 20180316220446) do
+ActiveRecord::Schema.define(version: 20180822125509) do
 
   create_table "ahoy_events", force: :cascade do |t|
     t.integer  "visit_id"
@@ -210,6 +210,9 @@ ActiveRecord::Schema.define(version: 20180316220446) do
     t.boolean  "send_on_booths_rejection",                      default: false
     t.string   "booths_rejection_subject"
     t.text     "booths_rejection_body"
+    t.boolean  "send_on_submitted_proposal",                    default: false
+    t.string   "submitted_proposal_subject"
+    t.text     "submitted_proposal_body"
   end
 
   create_table "event_schedules", force: :cascade do |t|


### PR DESCRIPTION
Adds an email template for when a proposal is submitted.

This is related to https://github.com/SeaGL/osem/issues/18 which I think is a good idea to have.