### PR TITLE
Disable Travis branch builds except for master

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -4,6 +4,9 @@ language: ruby
 cache: bundler
 rvm:
   - 2.4.0@osem --ignore-gemsets
+branches:
+  only:
+    - master
 before_install:
   - "echo 'gem: --no-ri --no-rdoc' > ~/.gemrc"
   - "echo `phantomjs -v`"


### PR DESCRIPTION
This is neccesarry to not build depfu branches now that we have enabled depfu.