### PR TITLE
Change quotes style for better DB compatibility

### DIFF
--- a/app/datatables/user_datatable.rb
+++ b/app/datatables/user_datatable.rb
@@ -40,8 +40,10 @@ class UserDatatable < AjaxDatatablesRails::Base
 
   # rubocop:disable Naming/AccessorMethodName
   def get_raw_records
-    User.left_outer_joins(:registrations, :roles).distinct
-      .select('users.*, COUNT(CASE WHEN registrations.attended = "t" THEN 1 END) AS attended_count').group('users.id')
+    User.left_outer_joins(:registrations, :roles)
+      .distinct
+      .select("users.*, COUNT(CASE WHEN registrations.attended = 't' THEN 1 END) AS attended_count")
+      .group('users.id')
   end
   # rubocop:enable Naming/AccessorMethodName
 


### PR DESCRIPTION
Postgres 10 doesn't like the double-quoted values.

**Checklist**

- [x] I have read the [Contribution & Best practices Guide](https://github.com/openSUSE/osem/blob/master/CONTRIBUTING.md).
- [x] My branch is up-to-date with the upstream `master` branch.
- [x] The tests pass locally with my changes.

**Short description of what this resolves/which [issues](https://github.com/openSUSE/osem/issues) does this fix?:**

<!-- List the issue number resolved with this change; if there is no open issue, describe the problem this request solves -->

- Postgres 10 would not accept `"t"` as a value for comparison; Postgres 9.4 & MariaDB are fine either way.

**Changes proposed in this pull request:**

<!-- Summarize the changes, using declarative language. -->

- Do it the Postgres 10 way!
