### PR TITLE
Disable codecov comments

### DIFF
--- a/.codecov.yml
+++ b/.codecov.yml
@@ -1,0 +1,1 @@
+comment: off


### PR DESCRIPTION
We are only interested in details if coverage drops below the threshold, not always.
