### PR TITLE
Consistently use sqlite dev/test dbs

### DIFF
--- a/config/database.yml
+++ b/config/database.yml
@@ -3,6 +3,13 @@
   if ENV['OSEM_DB_ADAPTER'] == 'mysql2'
     encoding = 'utf8'
   end
+
+  development_database = ENV['OSEM_DB_NAME'] || 'osem_development'
+  test_database = ENV['OSEM_DB_NAME'] || 'osem_test'
+  if ENV['OSEM_DB_ADAPTER'] == 'sqlite3'
+    development_database = "db/#{development_database}.sqlite3"
+    test_database = "db/#{test_database}.sqlite3"
+  end
 %>
 
 
@@ -19,14 +26,14 @@ default: &default
 
 development:
   <<: *default
-  database: osem_development
+  database: <%= development_database %>
 
 # Warning: The database defined as "test" will be erased and
 # re-generated when you run "rake".
 # Do not set this db to the same as development or production.
 test:
   <<: *default
-  database: osem_test
+  database: <%= test_database %>
 
 production:
   <<: *default


### PR DESCRIPTION
**Short description of what this resolves/which [issues](https://github.com/openSUSE/osem/issues) does this fix?:**

<!-- List the issue number resolved with this change; if there is no open issue, describe the problem this request solves -->

- The default database.yml caused dev & test sqlite dbs to move from the prior
location, `osem/db/[ENV].sqlite3` to `osem/osem_[ENV]`;

**Changes proposed in this pull request:**

<!-- Summarize the changes, using declarative language. -->

- gitignore Add osem_development & osem_test
- Use the default locations for dev & test sqlite dbs
