### PR TITLE
Fix up logical error in schedule

### DIFF
--- a/app/controllers/schedules_controller.rb
+++ b/app/controllers/schedules_controller.rb
@@ -33,7 +33,7 @@ class SchedulesController < ApplicationController
         # the schedule takes you to today if it is a date of the schedule
         @current_day = @conference.current_conference_day
         @day = @current_day.present? ? @current_day : @dates.first
-        unless @current_day
+        if @current_day
           # the schedule takes you to the current time if it is beetween the start and the end time.
           @hour_column = @conference.hours_from_start_time(@conf_start, @conference.end_hour)
         end


### PR DESCRIPTION
**Short description of what this resolves/which [issues](https://github.com/openSUSE/osem/issues) does this fix?:**

<!-- List the issue number resolved with this change; if there is no open issue, describe the problem this request solves -->

- The carousel moves to the current time-of-day, but only if today is *not* part of the conference.

**Changes proposed in this pull request:**

<!-- Summarize the changes, using declarative language. -->

- The carousel starts with the first hour, unless the conference is ongoing; then it starts with the current hour. *good grief*
