### PR TITLE
Default to keeping user's email addresses private.

### DIFF
--- a/app/views/admin/events/_proposal.html.haml
+++ b/app/views/admin/events/_proposal.html.haml
@@ -70,9 +70,10 @@
             %b Submitter
           %td
             = link_to @event.submitter.name, admin_user_path(@event.submitter)
-            (
-            = link_to @event.submitter.email, "mailto: #{@event.submitter.email}"
-            )
+            - if @event.submitter.email_public
+              (
+              = link_to @event.submitter.email, "mailto: #{@event.submitter.email}"
+              )
         %tr
           %td
             %b Speakers
@@ -80,9 +81,10 @@
             - @event.speakers.each do |speaker|
               %div
                 = link_to speaker.name, admin_user_path(speaker)
-                (
-                = link_to speaker.email, "mailto: #{speaker.email}"
-                )
+                - if speaker.email_public
+                  (
+                  = link_to speaker.email, "mailto: #{speaker.email}"
+                  )
         %tr
           %td
             %b Biographies

--- a/app/views/booths/show.html.haml
+++ b/app/views/booths/show.html.haml
@@ -44,9 +44,10 @@
             - @booth.responsibles.each_with_index do |responsibles, i|
               .responsibles
                 = link_to responsibles.name, user_path(responsibles)
-                (
-                = responsibles.email
-                )
+                - if responsibles.email_public
+                  (
+                  = responsibles.email
+                  )
                 = ", " unless i == @booth.responsibles.length - 1
         %tr
           %td.col-md-2

--- a/app/views/devise/registrations/edit.html.haml
+++ b/app/views/devise/registrations/edit.html.haml
@@ -8,7 +8,8 @@
       = semantic_form_for(resource, as: resource_name, url: registration_path(resource_name), html: { method: :put }) do |f|
         = f.input :username, required: false, input_html: { autocomplete: 'off' }
         = f.input :email, required: false, input_html: { autocomplete: 'off' }
-        = f.input :email_public
+        = f.input :email_public,
+          hint: "Do you want to your email address publicly? (On sessions, registration lists, etc.)"
         = f.input :password, hint: "(Leave blank if you don't want to change it)", input_html: { autocomplete: 'off' }
         = f.input :password_confirmation, input_html: { autocomplete: 'off' }
         = f.inputs name: 'OpenID' do

--- a/app/views/layouts/_navigation.html.haml
+++ b/app/views/layouts/_navigation.html.haml
@@ -25,10 +25,7 @@
           %ul.nav.navbar-nav.navbar-right
             %li.dropdown
               %a.dropdown-toggle{"data-toggle" => "dropdown", href: '#', id: "current-user-detail"}
-                - if not current_user.name.blank?
-                  #{current_user.name}
-                -else
-                  #{current_user.email}
+                = current_user.name
                 = image_tag(current_user.gravatar_url(size: '18'), title: "Yo #{current_user.name}!", alt: '')
                 %b.caret
               %ul.dropdown-menu

--- a/app/views/proposals/registrations.html.haml
+++ b/app/views/proposals/registrations.html.haml
@@ -26,7 +26,11 @@
               %tr
                 %td= index
                 %td= event_registration.name
-                %td= event_registration.email
+                %td
+                  - if event_registration.registration.user.email_public
+                    = event_registration.email
+                  - else
+                    (private)
                 %td= event_registration.created_at
                 %td.text-center
                   - if event_registration.attended

--- a/db/migrate/20180924221715_user_email_public_defaults_to_false.rb
+++ b/db/migrate/20180924221715_user_email_public_defaults_to_false.rb
@@ -1,0 +1,9 @@
+class UserEmailPublicDefaultsToFalse < ActiveRecord::Migration[5.0]
+  def up
+    change_column_default :users, :email_public, false
+  end
+
+  def down
+    change_column_default :users, :email_public, true
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 20180822125509) do
+ActiveRecord::Schema.define(version: 20180924221715) do
 
   create_table "ahoy_events", force: :cascade do |t|
     t.integer  "visit_id"
@@ -603,7 +603,7 @@ ActiveRecord::Schema.define(version: 20180822125509) do
     t.datetime "created_at"
     t.datetime "updated_at"
     t.string   "name"
-    t.boolean  "email_public",           default: true
+    t.boolean  "email_public",           default: false
     t.text     "biography"
     t.string   "nickname"
     t.string   "affiliation"


### PR DESCRIPTION
**Short description of what this resolves/which [issues](https://github.com/openSUSE/osem/issues) does this fix?:**

<!-- List the issue number resolved with this change; if there is no open issue, describe the problem this request solves -->

- Email addresses default to being shown publicly
- Email addresses are shown in many public contexts, even if `User#email_public` is `false`.

**Changes proposed in this pull request:**

<!-- Summarize the changes, using declarative language. -->

- Default `User#email_public` to false.
- Check `User#email_public` when displaying email address.
