### PR TITLE
Make admin scheduling easier

### DIFF
--- a/app/views/admin/schedules/_event.html.haml
+++ b/app/views/admin/schedules/_event.html.haml
@@ -17,4 +17,14 @@
                    class: "#{'compact' if compact_grid} #{'non_schedulable' if non_schedulable}" }
     .schedule-event-text{ style: "-webkit-line-clamp: #{lines}; height: #{lines * 23}px;"}
       %span.schedule-event-delete-button{ onclick: "Schedule.remove(\'event-#{event.id}\');" } X
+      %b
+        = link_to(event.id, admin_conference_program_event_path(@conference, event))
+      = event.speakers.collect(&:name).to_sentence
+      = ':'
       = event.title
+      - if event.difficulty_level
+        %span.label.label-default= event.difficulty_level.title
+      - if event.event_type
+        %span.label.label-default= event.event_type.title
+      - if event.track
+        %span.label.label-default= event.track.short_name

--- a/app/views/admin/schedules/_event.html.haml
+++ b/app/views/admin/schedules/_event.html.haml
@@ -1,19 +1,20 @@
-- cells_length = event.event_type.length / @program.schedule_interval
-/ this height fits the room cells
-- compact_grid = @program.schedule_interval < 15
-- single_cell_height =  compact_grid ? 32 : 58
-- height = (cells_length * single_cell_height)
-- height -= 23 unless compact_grid
-/ subtracting the padding before calculate the number of lines
-- lines = (height - 7) / 23
-- color = event.track.try(:color).present? ? event.track.try(:color) : 'FFFFFF'
-- non_schedulable = event_schedule_id && (EventSchedule.find(event_schedule_id).schedule != @schedule)
-.schedule-event{ style: "height: #{height}px;  background-color: #{color}; color: #{contrast_color(color)}", |
-                 id: "event-#{event.id}", |
-                 event_id: event.id, |
-                 length: cells_length, |
-                 event_schedule_id: event_schedule_id, |
-                 class: "#{'compact' if compact_grid} #{'non_schedulable' if non_schedulable}" }
-  .schedule-event-text{ style: "-webkit-line-clamp: #{lines}; height: #{lines * 23}px;"}
-    %span.schedule-event-delete-button{ onclick: "Schedule.remove(\'event-#{event.id}\');" } X
-    = event.title
+- cache [:admin, @conference, @program, :schedule, event] do
+  - cells_length = event.event_type.length / @program.schedule_interval
+  / this height fits the room cells
+  - compact_grid = @program.schedule_interval < 15
+  - single_cell_height =  compact_grid ? 32 : 58
+  - height = (cells_length * single_cell_height)
+  - height -= 23 unless compact_grid
+  / subtracting the padding before calculate the number of lines
+  - lines = (height - 7) / 23
+  - color = event.track.try(:color).present? ? event.track.try(:color) : 'FFFFFF'
+  - non_schedulable = event_schedule_id && (EventSchedule.find(event_schedule_id).schedule != @schedule)
+  .schedule-event{ style: "height: #{height}px;  background-color: #{color}; color: #{contrast_color(color)}", |
+                   id: "event-#{event.id}", |
+                   event_id: event.id, |
+                   length: cells_length, |
+                   event_schedule_id: event_schedule_id, |
+                   class: "#{'compact' if compact_grid} #{'non_schedulable' if non_schedulable}" }
+    .schedule-event-text{ style: "-webkit-line-clamp: #{lines}; height: #{lines * 23}px;"}
+      %span.schedule-event-delete-button{ onclick: "Schedule.remove(\'event-#{event.id}\');" } X
+      = event.title


### PR DESCRIPTION
**Short description of what this resolves/which [issues](https://github.com/openSUSE/osem/issues) does this fix?:**

<!-- List the issue number resolved with this change; if there is no open issue, describe the problem this request solves -->

- The scheduler makes _a lot_ of queries
- The schedule blocks do not contain enough information to make good scheduling decisions

**Changes proposed in this pull request:**

<!-- Summarize the changes, using declarative language. -->

- Aggregate queries
- Add speaker names and track, difficulty level, and event type labels

Before:
![screenshot from 2018-09-25 17-36-34](https://user-images.githubusercontent.com/108494/46114222-8da60600-c1a6-11e8-9caf-3d1e4beeca0e.png)

After:
![screenshot from 2018-09-25 17-39-43](https://user-images.githubusercontent.com/108494/46114230-9565aa80-c1a6-11e8-97b1-f280d4338b12.png)
