### PR TITLE
Ignore current sqlite db locations

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -37,3 +37,5 @@ docker-compose.override.yml
 .DS_Store
 .byebug_history
 .buildconfig
+osem_development
+osem_test


### PR DESCRIPTION
**Short description of what this resolves/which [issues](https://github.com/openSUSE/osem/issues) does this fix?:**

<!-- List the issue number resolved with this change; if there is no open issue, describe the problem this request solves -->

- The current `config/database.yml` litters the root with sqlite files.

**Changes proposed in this pull request:**

<!-- Summarize the changes, using declarative language. -->

- Ignore them.
