### PR TITLE
Fix tickets

### DIFF
--- a/app/models/conference.rb
+++ b/app/models/conference.rb
@@ -517,7 +517,7 @@ class Conference < ApplicationRecord
     if tickets && ticket_purchases
       tickets.each do |ticket|
         result[ticket.title] = {
-          'value' => ApplicationController.helpers.humanized_money(ticket.tickets_turnover_total(ticket.id)).delete(',').to_i,
+          'value' => ApplicationController.helpers.humanized_money(ticket.tickets_turnover_total).delete(',').to_i,
           'color' => "\##{Digest::MD5.hexdigest(ticket.title)[0..5]}"
         }
       end

--- a/app/models/ticket.rb
+++ b/app/models/ticket.rb
@@ -63,11 +63,10 @@ class Ticket < ApplicationRecord
     tickets.inject(0){ |sum, ticket| sum + (ticket.amount_paid * ticket.quantity) }
   end
 
-  def tickets_turnover_total(id)
-    ticket = Ticket.find(id)
-    return Money.new(0, 'USD') unless ticket
-    sum = ticket.ticket_purchases.paid.total
-    Money.new(sum, ticket.price_currency)
+  def tickets_turnover_total
+    purchases = ticket_purchases.paid
+    total = purchases.sum { |purchase| (purchase.price_cents * purchase.quantity) }
+    Money.new(total, price_currency)
   end
 
   def tickets_sold

--- a/app/models/ticket_purchase.rb
+++ b/app/models/ticket_purchase.rb
@@ -71,11 +71,6 @@ class TicketPurchase < ApplicationRecord
     purchase
   end
 
-  # Total amount
-  def self.total
-    sum('amount_paid * quantity')
-  end
-
   def pay(payment)
     update_attributes(paid: true, payment: payment)
     PhysicalTicket.transaction do

--- a/app/pdfs/ticket_pdf.rb
+++ b/app/pdfs/ticket_pdf.rb
@@ -49,7 +49,11 @@ class TicketPdf < Prawn::Document
     if @conference.picture?
       conference_image = case @conference.picture.ticket.url[0, 4]
                          when 'http', 'ftp:' # CDNs
-                           open(@conference.picture.ticket.url)
+                           begin
+                             open(@conference.picture.ticket.url)
+                           rescue OpenURI::HTTPError
+                             nil
+                           end
                          when '/sys' # local storage
                            open([
                              Rails.root,
@@ -57,10 +61,10 @@ class TicketPdf < Prawn::Document
                              @conference.picture.ticket.url
                            ].join)
                          end
-      image conference_image, at: [@mid_horizontal + 30, cursor]
-    else
-      image "#{Rails.root}/public/img/osem-logo.png", at: [@mid_horizontal + 30, cursor], height: 70
     end
+    conference_image ||= open("#{Rails.root}/public/img/osem-logo.png")
+    image conference_image, at: [@mid_horizontal + 30, cursor], fit: [200, 70]
+
     move_down 70
     draw_text @conference.title.to_s, at: [@mid_horizontal + 30, cursor - 30], size: 12
     draw_text @conference.organization.name.to_s, at: [@mid_horizontal + 30, cursor - 50], size: 12

--- a/app/views/admin/tickets/index.html.haml
+++ b/app/views/admin/tickets/index.html.haml
@@ -27,7 +27,7 @@
               %td
                 = ticket.tickets_sold
               %td
-                = humanized_money_with_symbol ticket.tickets_turnover_total(ticket.id)
+                = humanized_money_with_symbol ticket.tickets_turnover_total
               %td
                 = ticket.registration_ticket? ? 'Yes' : 'No'
               %td

--- a/spec/models/ticket_spec.rb
+++ b/spec/models/ticket_spec.rb
@@ -71,7 +71,7 @@ describe Ticket do
     let!(:purchase1) { create :ticket_purchase, ticket: ticket, amount_paid: 5_000, quantity: 1, paid: true, user: user }
     let!(:purchase2) { create :ticket_purchase, ticket: ticket, amount_paid: 5_000, quantity: 2, paid: true, user: user }
     let!(:purchase3) { create :ticket_purchase, ticket: ticket, amount_paid: 5_000, quantity: 10, paid: false, user: user }
-    subject { ticket.tickets_turnover_total ticket.id }
+    subject { ticket.tickets_turnover_total }
 
     it 'returns turnover as Money with ticket\'s currency' do
       is_expected.to eq Money.new(5_000 * 3, ticket.price_currency)


### PR DESCRIPTION
Resolve ~two~three small issues on ticketing:

* Prevent math errors in calculating ticket 'turnover' _(yes this can still be a problem)_
* Gracefully fail out of image handling in ticket PDF ( I see this issue, in particular, when using a database copy to test, that doesn't have access to the same Cloudinary account - e.g. the same asset host).
* ticket_purchases_total no longer requires a redunant ID. `Ticket.find(X).ticket_puchases_total(X)` ?!