### PR TITLE
Add splashpage option for shuffling highlight tiles

### DIFF
--- a/app/assets/javascripts/osem.js
+++ b/app/assets/javascripts/osem.js
@@ -31,6 +31,19 @@ $(function () {
         });
     });
 
+    /**
+     * Randomize order of parallel elements by shuffling the decks
+     * Adapted from https://stackoverflow.com/questions/7070054
+     */
+
+    $(document).ready( function() {
+        $.each($(".shuffle-deck"), function(index, deck) {
+            for(var i = deck.children.length; i >= 0; i--) {
+                deck.appendChild(deck.children[Math.random() * i | 0]);
+            }
+        });
+    });
+
     $(".select-help-toggle").change(function () {
         var id = $(this).attr('id');
         $('.' + id).collapse('hide');

--- a/app/views/conferences/_highlights.haml
+++ b/app/views/conferences/_highlights.haml
@@ -4,7 +4,7 @@
       Program Highlights
 .row
   .col-md-12
-    .row.row-centered
+    .row.row-centered.shuffle-deck
       - highlights.each do |event|
         - speaker = event.speakers_ordered.first
         .col-md-3.col-sm-3.col-centered.col-top.highlights


### PR DESCRIPTION
Highlights show up, by default in order of ID, and this may imply somepreference of one highlight over another (especially if they render in multiple rows). As a solution, each user is presented with a randomly shuffled set of highlights. Since this is done in JS, the cache of highlighted sessions is preserved, maintaining server-side performance.
