### PR TITLE
Event reservations switch

### DIFF
--- a/.haml-lint_todo.yml
+++ b/.haml-lint_todo.yml
@@ -23,7 +23,9 @@ linters:
       - "app/views/admin/cfps/_events_cfp.html.haml"
       - "app/views/admin/cfps/_form.html.haml"
       - "app/views/admin/cfps/_tracks_cfp.html.haml"
+      - "app/views/admin/cfps/edit.haml"
       - "app/views/admin/cfps/index.html.haml"
+      - "app/views/admin/cfps/new.haml"
       - "app/views/admin/cfps/show.html.haml"
       - "app/views/admin/comments/_all_comments.html.haml"
       - "app/views/admin/comments/_posted_comments.html.haml"
@@ -262,10 +264,6 @@ linters:
   InstanceVariables:
     exclude:
       - "app/views/admin/booths/_change_state_dropdown.html.haml"
-      - "app/views/admin/cfps/_booths_cfp.html.haml"
-      - "app/views/admin/cfps/_events_cfp.html.haml"
-      - "app/views/admin/cfps/_form.html.haml"
-      - "app/views/admin/cfps/_tracks_cfp.html.haml"
       - "app/views/admin/conferences/_todo_list.html.haml"
       - "app/views/admin/difficulty_levels/_form.html.haml"
       - "app/views/admin/event_types/_form.html.haml"
@@ -319,9 +317,6 @@ linters:
       - "app/views/admin/booths/_change_state_dropdown.html.haml"
       - "app/views/admin/booths/index.html.haml"
       - "app/views/admin/booths/show.html.haml"
-      - "app/views/admin/cfps/_form.html.haml"
-      - "app/views/admin/cfps/index.html.haml"
-      - "app/views/admin/cfps/show.html.haml"
       - "app/views/admin/comments/_all_comments.html.haml"
       - "app/views/admin/comments/_posted_comments.html.haml"
       - "app/views/admin/comments/_unread_comments.html.haml"
@@ -483,8 +478,6 @@ linters:
   # Offense count: 34
   IdNames:
     exclude:
-      - "app/views/admin/cfps/_events_cfp.html.haml"
-      - "app/views/admin/cfps/_tracks_cfp.html.haml"
       - "app/views/admin/comments/index.html.haml"
       - "app/views/admin/conferences/index.html.haml"
       - "app/views/admin/conferences/show.html.haml"

--- a/app/controllers/admin/cfps_controller.rb
+++ b/app/controllers/admin/cfps_controller.rb
@@ -11,7 +11,7 @@ module Admin
     def show; end
 
     def new
-      @cfp = @program.cfps.new
+      @cfp = @program.cfps.new(cfp_params_or_first_remaining_type)
     end
 
     def edit; end
@@ -58,6 +58,12 @@ module Admin
 
     def cfp_params
       params.require(:cfp).permit(:start_date, :end_date, :description, :cfp_type)
+    end
+
+    def cfp_params_or_first_remaining_type
+      cfp_params
+    rescue ActionController::ParameterMissing
+      { 'cfp_type' => @program.remaining_cfp_types.first }
     end
   end
 end

--- a/app/controllers/admin/cfps_controller.rb
+++ b/app/controllers/admin/cfps_controller.rb
@@ -57,7 +57,11 @@ module Admin
     private
 
     def cfp_params
-      params.require(:cfp).permit(:start_date, :end_date, :description, :cfp_type)
+      params.require(:cfp).permit(
+        :start_date, :end_date,
+        :description, :cfp_type,
+        :enable_registrations
+      )
     end
 
     def cfp_params_or_first_remaining_type

--- a/app/helpers/admin/cfps_helper.rb
+++ b/app/helpers/admin/cfps_helper.rb
@@ -9,11 +9,5 @@ module Admin
         admin_conference_program_cfp_path(conference, cfp)
       end
     end
-
-    def select_cfp_types(cfp, program)
-      cfp_types = program.remaining_cfp_types
-      cfp_types.unshift(cfp.cfp_type) unless cfp.new_record?
-      cfp_types.map { |cfp_type| ["#{cfp_type.capitalize}", cfp_type] }
-    end
   end
 end

--- a/app/helpers/admin/cfps_helper.rb
+++ b/app/helpers/admin/cfps_helper.rb
@@ -1,0 +1,19 @@
+# frozen_string_literal: true
+
+module Admin
+  module CfpsHelper
+    def cfp_form_url(cfp, conference)
+      if cfp.new_record?
+        admin_conference_program_cfps_path
+      else
+        admin_conference_program_cfp_path(conference, cfp)
+      end
+    end
+
+    def select_cfp_types(cfp, program)
+      cfp_types = program.remaining_cfp_types
+      cfp_types.unshift(cfp.cfp_type) unless cfp.new_record?
+      cfp_types.map { |cfp_type| ["#{cfp_type.capitalize}", cfp_type] }
+    end
+  end
+end

--- a/app/views/admin/cfps/_booths_cfp.html.haml
+++ b/app/views/admin/cfps/_booths_cfp.html.haml
@@ -1,20 +1,20 @@
 %dt
   Type:
 %dd
-  = @cfp.cfp_type.capitalize
+  = cfp.cfp_type.capitalize
 %dt
   Start Date:
 %dd
-  = @cfp.start_date.strftime('%A, %B %e. %Y')
+  = cfp.start_date.strftime('%A, %B %e. %Y')
 %dt
   End Date:
 %dd
-  = @cfp.end_date.strftime('%A, %B %e. %Y')
+  = cfp.end_date.strftime('%A, %B %e. %Y')
 %dt
   Description
 %dd
-  = markdown(@cfp.description)
+  = markdown(cfp.description)
 %dt
   Days Left
 %dd
-  = pluralize(@cfp.remaining_days, 'day')
+  = pluralize(cfp.remaining_days, 'day')

--- a/app/views/admin/cfps/_events_cfp.html.haml
+++ b/app/views/admin/cfps/_events_cfp.html.haml
@@ -1,46 +1,46 @@
 %dt
   Type:
 %dd
-  = @cfp.cfp_type.capitalize
+  = cfp.cfp_type.capitalize
 %dt
   Start Date:
-%dd#start_date
-  = @cfp.start_date.strftime('%A, %B %-d. %Y')
+%dd#start-date
+  = cfp.start_date.strftime('%A, %B %-d. %Y')
 %dt
   End Date:
-%dd#end_date
-  = @cfp.end_date.strftime('%A, %B %-d. %Y')
+%dd#end-date
+  = cfp.end_date.strftime('%A, %B %-d. %Y')
 %dt
   Description:
 %dd#description
-  = markdown(@cfp.description)
+  = markdown(cfp.description)
 %dt
   Days Left:
 %dd
-  = pluralize(@cfp.remaining_days, 'day')
+  = pluralize(cfp.remaining_days, 'day')
 %dt
   Event types:
 %dd
-  = event_types_sentence(@conference)
+  = event_types_sentence(conference)
 %dt
   Tracks:
 %dd
-  = tracks(@conference)
+  = tracks(conference)
 %dt
   Public Schedule:
-%dd#schedule_public
-  - if @program.schedule_public
+%dd#schedule-public
+  - if conference.program.schedule_public
     Yes
   - else
     No
 %dt
   Schedule changeable?
-%dd#schedule_changes
-  - if @program.schedule_fluid
+%dd#schedule-changes
+  - if conference.program.schedule_fluid
     Yes
   - else
     No
 %dt
   Rating Levels:
 %dd#rating
-  = @program.rating
+  = conference.program.rating

--- a/app/views/admin/cfps/_form.html.haml
+++ b/app/views/admin/cfps/_form.html.haml
@@ -4,10 +4,20 @@
       %h1 Call for Papers
 .row
   .col-md-8
-    = semantic_form_for(@cfp, url: (@cfp.new_record? ? admin_conference_program_cfps_path : admin_conference_program_cfp_path(@conference.short_title, @cfp)), html: {multipart: true}) do |f|
-      = f.input :start_date, as: :string, input_html: { id: 'registration-period-start-datepicker', start_date: @conference.start_date, end_date: @conference.end_date, readonly: 'readonly' }
-      = f.input :end_date, as: :string, input_html: { id: 'registration-period-end-datepicker', readonly: 'readonly' }
-      = f.input :cfp_type, as: :select, collection: (@cfp.new_record? ? @program.remaining_cfp_types : [@cfp.cfp_type] + @program.remaining_cfp_types).map {|type| ["#{type.capitalize}", type]}, include_blank: false, label: 'Type', input_html: { class: 'select-help-toggle' }
-      = f.input :description, input_html: {rows: 2, data: { provide: 'markdown-editable' } }, hint: markdown_hint
+    = semantic_form_for(cfp, url: cfp_form_url(cfp, conference),
+      html: { multipart: true }) do |f|
+      = f.input :start_date, as: :string,
+        input_html: { id: 'registration-period-start-datepicker',
+          start_date: conference.start_date,
+          end_date: conference.end_date, readonly: 'readonly' }
+      = f.input :end_date, as: :string,
+        input_html: { id: 'registration-period-end-datepicker',
+          readonly: 'readonly' }
+      = f.input :cfp_type, as: :select, include_blank: false,
+        collection: select_cfp_types(cfp, conference.program),
+        label: 'Type', input_html: { class: 'select-help-toggle' }
+      = f.input :description, hint: markdown_hint,
+        input_html: { rows: 2, data: { provide: 'markdown-editable' } }
       %p.text-right
-        = f.action :submit, as: :button, button_html: { class: 'btn btn-primary' }
+        = f.action :submit, as: :button,
+          button_html: { class: 'btn btn-primary' }

--- a/app/views/admin/cfps/_form.html.haml
+++ b/app/views/admin/cfps/_form.html.haml
@@ -18,6 +18,11 @@
           readonly: 'readonly' }
       = f.input :description, hint: markdown_hint,
         input_html: { rows: 2, data: { provide: 'markdown-editable' } }
+      - if cfp.cfp_type == 'events'
+        = f.input :enable_registrations, as: :boolean,
+          hint: 'Allow submitters to request registration?'
+      - else
+        = f.input :enable_registrations, as: :hidden
       %p.text-right
         = f.action :submit, as: :button,
           button_html: { class: 'btn btn-primary' }

--- a/app/views/admin/cfps/_form.html.haml
+++ b/app/views/admin/cfps/_form.html.haml
@@ -1,11 +1,14 @@
 .row
   .col-md-12
     .page-header
-      %h1 Call for Papers
+      %h1
+        Call for
+        = cfp.cfp_type.capitalize
 .row
   .col-md-8
     = semantic_form_for(cfp, url: cfp_form_url(cfp, conference),
       html: { multipart: true }) do |f|
+      = f.input :cfp_type, as: :hidden
       = f.input :start_date, as: :string,
         input_html: { id: 'registration-period-start-datepicker',
           start_date: conference.start_date,
@@ -13,9 +16,6 @@
       = f.input :end_date, as: :string,
         input_html: { id: 'registration-period-end-datepicker',
           readonly: 'readonly' }
-      = f.input :cfp_type, as: :select, include_blank: false,
-        collection: select_cfp_types(cfp, conference.program),
-        label: 'Type', input_html: { class: 'select-help-toggle' }
       = f.input :description, hint: markdown_hint,
         input_html: { rows: 2, data: { provide: 'markdown-editable' } }
       %p.text-right

--- a/app/views/admin/cfps/_tracks_cfp.html.haml
+++ b/app/views/admin/cfps/_tracks_cfp.html.haml
@@ -1,20 +1,20 @@
 %dt
   Type:
 %dd
-  = @cfp.cfp_type.capitalize
+  = cfp.cfp_type.capitalize
 %dt
   Start Date:
-%dd#start_date
-  = @cfp.start_date.strftime('%A, %B %-d. %Y')
+%dd#start-date
+  = cfp.start_date.strftime('%A, %B %-d. %Y')
 %dt
   End Date:
-%dd#end_date
-  = @cfp.end_date.strftime('%A, %B %-d. %Y')
+%dd#end-date
+  = cfp.end_date.strftime('%A, %B %-d. %Y')
 %dt
   Description:
 %dd#description
-  = markdown(@cfp.description)
+  = markdown(cfp.description)
 %dt
   Days Left:
 %dd
-  = pluralize(@cfp.remaining_days, 'day')
+  = pluralize(cfp.remaining_days, 'day')

--- a/app/views/admin/cfps/edit.haml
+++ b/app/views/admin/cfps/edit.haml
@@ -1,0 +1,1 @@
+= render 'form', cfp: @cfp, conference: @conference

--- a/app/views/admin/cfps/index.html.haml
+++ b/app/views/admin/cfps/index.html.haml
@@ -19,8 +19,8 @@
           - @program.cfps.each do |cfp|
             %tr
               %td
-                = link_to(admin_conference_program_cfp_path(@conference.short_title, cfp.id)) do
-                  = cfp.cfp_type.capitalize
+                = link_to cfp.cfp_type.capitalize,
+                  admin_conference_program_cfp_path(@conference, cfp)
               %td
                 = cfp.start_date.strftime('%A, %B %-d. %Y')
               %td
@@ -32,9 +32,16 @@
                 = pluralize(cfp.remaining_days, 'day')
               %td
                 .btn-group
-                  = link_to 'Edit', edit_admin_conference_program_cfp_path(@conference.short_title, cfp.id), method: :get, class: 'btn btn-primary'
-                  = link_to 'Delete', admin_conference_program_cfp_path(@conference.short_title, cfp.id), method: 'delete', class: 'btn btn-danger', data: { confirm: 'Are you sure you want to delete the CfP?' }
+                  = link_to 'Edit',
+                    edit_admin_conference_program_cfp_path(@conference, cfp),
+                    method: :get, class: 'btn btn-primary'
+                  = link_to 'Delete',
+                    admin_conference_program_cfp_path(@conference, cfp),
+                    method: 'delete', class: 'btn btn-danger',
+                    data: { confirm: 'Are you sure?' }
 - if can? :new, @program.cfps.new
   .row
     .col-md-12.text-right
-      = link_to 'Create Call for Papers', new_admin_conference_program_cfp_path(@conference.short_title), class: 'btn btn-primary'
+      = link_to 'Create Call for Papers',
+        new_admin_conference_program_cfp_path(@conference),
+        class: 'btn btn-primary'

--- a/app/views/admin/cfps/index.html.haml
+++ b/app/views/admin/cfps/index.html.haml
@@ -1,9 +1,10 @@
 .row
   .col-md-12
     .page-header
-      %h1 Call for Papers
+      %h1 Calls for Content
       %p.text-muted
-        Call for people to submit events to your conference
+        Ask people to submit content to your conference,
+        within defined timeframes.
 - if @program.cfps
   .row
     .col-md-12

--- a/app/views/admin/cfps/index.html.haml
+++ b/app/views/admin/cfps/index.html.haml
@@ -43,6 +43,14 @@
 - if can? :new, @program.cfps.new
   .row
     .col-md-12.text-right
-      = link_to 'Create Call for Papers',
-        new_admin_conference_program_cfp_path(@conference),
-        class: 'btn btn-primary'
+      .btn-group
+        %button.btn.btn-primary.dropdown-toggle{ type: 'button',
+          data: { toggle: 'dropdown' } }
+          Add Call for...
+          %span.caret
+        %ul.dropdown-menu
+          - @program.remaining_cfp_types.each do |cfp_type|
+            %li
+              = link_to cfp_type.capitalize,
+                new_admin_conference_program_cfp_path(@conference,
+                  cfp: { cfp_type: cfp_type })

--- a/app/views/admin/cfps/new.haml
+++ b/app/views/admin/cfps/new.haml
@@ -1,0 +1,1 @@
+= render 'form', cfp: @cfp, conference: @conference

--- a/app/views/admin/cfps/show.html.haml
+++ b/app/views/admin/cfps/show.html.haml
@@ -7,10 +7,13 @@
 .row
   .col-md-8
     %dl.dl-horizontal
-      = render "#{@cfp.cfp_type}_cfp"
+      = render "#{@cfp.cfp_type}_cfp", cfp: @cfp, conference: @conference
 .row
   .col-md-12.text-right
-    = link_to(edit_admin_conference_program_cfp_path(@conference.short_title, @cfp.id), class: 'btn btn-primary') do
-      Edit
-    = link_to(admin_conference_program_cfp_path(@conference.short_title, @cfp.id), method: 'delete', class: 'btn btn-danger', data: { confirm: 'Are you sure you want to delete the CfP?' }) do
-      Delete
+    = link_to 'Edit',
+      edit_admin_conference_program_cfp_path(@conference, @cfp),
+      class: 'btn btn-primary'
+    = link_to 'Delete',
+      admin_conference_program_cfp_path(@conference, @cfp),
+      method: 'delete', class: 'btn btn-danger',
+      data: { confirm: 'Are you sure you want to delete the CfP?' }

--- a/app/views/layouts/_admin_sidebar.html.haml
+++ b/app/views/layouts/_admin_sidebar.html.haml
@@ -68,7 +68,7 @@
         %ul
           - if can? :update, Cfp.new(program_id: @conference.program.id)
             %li{class: active_nav_li(admin_conference_program_cfps_path(@conference.short_title))}
-              = link_to 'Call for Papers', admin_conference_program_cfps_path(@conference.short_title)
+              = link_to 'Calls for Content', admin_conference_program_cfps_path(@conference.short_title)
           - if can? :update, @conference.program.events.build
             %li{class: active_nav_li(admin_conference_program_events_path(@conference.short_title))}
               = link_to 'Events', admin_conference_program_events_path(@conference.short_title)

--- a/app/views/proposals/_proposal_form.html.haml
+++ b/app/views/proposals/_proposal_form.html.haml
@@ -43,10 +43,11 @@
         250
       words.
 
-    = f.inputs 'Enable pre-registration' do
-      = f.input :require_registration, label: 'Require participants to register to your event'
-      - message = @event.room ? "Value must be between 1 and #{@event.room.size}" : 'Check room capacity after scheduling.'
-      = f.input :max_attendees, hint: 'The maximum number of participants. ' + message
+    - if @program.cfp.enable_registrations?
+      = f.inputs 'Enable pre-registration' do
+        = f.input :require_registration, label: 'Require participants to register to your event'
+        - message = @event.room ? "Value must be between 1 and #{@event.room.size}" : 'Check room capacity after scheduling.'
+        = f.input :max_attendees, hint: 'The maximum number of participants. ' + message
 
     - if current_user.has_any_role? :admin, { name: :organizer, resource: @conference }, { name: :cfp, resource: @conference }
       = f.input :is_highlight

--- a/app/views/proposals/new.html.haml
+++ b/app/views/proposals/new.html.haml
@@ -59,7 +59,8 @@
                   250
                 words.
 
-              = f.input :require_registration, label: 'Require participants to register to your event'
+              - if @program.cfp.enable_registrations?
+                = f.input :require_registration, label: 'Require participants to register to your event'
 
               %p.text-right
                 = link_to '#description',  'data-toggle' => 'collapse', id: 'description_link' do

--- a/db/migrate/20181017183243_add_allow_reservations_on_cfps.rb
+++ b/db/migrate/20181017183243_add_allow_reservations_on_cfps.rb
@@ -1,0 +1,5 @@
+class AddAllowReservationsOnCfps < ActiveRecord::Migration[5.0]
+  def change
+    add_column 'cfps', 'enable_registrations', :boolean, default: false
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -42,13 +42,14 @@ ActiveRecord::Schema.define(version: 20181113195810) do
   end
 
   create_table "cfps", force: :cascade do |t|
-    t.date     "start_date",  null: false
-    t.date     "end_date",    null: false
+    t.date     "start_date",                           null: false
+    t.date     "end_date",                             null: false
     t.datetime "created_at"
     t.datetime "updated_at"
     t.integer  "program_id"
     t.string   "cfp_type"
     t.text     "description"
+    t.boolean  "enable_registrations", default: false
   end
 
   create_table "comments", force: :cascade do |t|
@@ -434,6 +435,7 @@ ActiveRecord::Schema.define(version: 20181113195810) do
     t.datetime "updated_at"
     t.boolean  "include_cfp",               default: false
     t.boolean  "include_booths"
+    t.boolean  "shuffle_highlights",        default: false, null: false
   end
 
   create_table "sponsors", force: :cascade do |t|

--- a/spec/factories/cfps.rb
+++ b/spec/factories/cfps.rb
@@ -8,6 +8,7 @@ FactoryBot.define do
     end_date { 2.days.from_now }
     cfp_type { 'events' }
     description { 'This is a test description' }
+    enable_registrations { true }
     program
   end
 end

--- a/spec/features/cfp_ability_spec.rb
+++ b/spec/features/cfp_ability_spec.rb
@@ -27,7 +27,7 @@ feature 'Has correct abilities' do
       expect(page).to have_link('Venue', href: "/admin/conferences/#{conference.short_title}/venue")
       expect(page).to have_link('Rooms', href: "/admin/conferences/#{conference.short_title}/venue/rooms")
       expect(page).to have_link('Program', href: "/admin/conferences/#{conference.short_title}/program")
-      expect(page).to have_link('Call for Papers', href: "/admin/conferences/#{conference.short_title}/program/cfps")
+      expect(page).to have_link('Calls for Content', href: "/admin/conferences/#{conference.short_title}/program/cfps")
       expect(page).to have_link('Events', href: "/admin/conferences/#{conference.short_title}/program/events")
       expect(page).to have_link('Tracks', href: "/admin/conferences/#{conference.short_title}/program/tracks")
       expect(page).to have_link('Event Types', href: "/admin/conferences/#{conference.short_title}/program/event_types")

--- a/spec/features/cfp_spec.rb
+++ b/spec/features/cfp_spec.rb
@@ -36,8 +36,8 @@ feature Conference do
           .to eq('Call for papers successfully created.')
 
       visit admin_conference_program_cfp_path(conference.short_title, conference.program.cfp)
-      expect(find('#start_date').text).to eq(today.strftime('%A, %B %-d. %Y'))
-      expect(find('#end_date').text).to eq((today + 6).strftime('%A, %B %-d. %Y'))
+      expect(find('#start-date').text).to eq(today.strftime('%A, %B %-d. %Y'))
+      expect(find('#end-date').text).to eq((today + 6).strftime('%A, %B %-d. %Y'))
 
       expect(Cfp.count).to eq(expected_count)
     end
@@ -74,8 +74,8 @@ feature Conference do
           .to eq('Call for papers successfully updated.')
 
       visit admin_conference_program_cfp_path(conference.short_title, conference.program.cfp)
-      expect(find('#start_date').text).to eq(today.strftime('%A, %B %-d. %Y'))
-      expect(find('#end_date').text).to eq((today + 14).strftime('%A, %B %-d. %Y'))
+      expect(find('#start-date').text).to eq(today.strftime('%A, %B %-d. %Y'))
+      expect(find('#end-date').text).to eq((today + 14).strftime('%A, %B %-d. %Y'))
       expect(Cfp.count).to eq(expected_count)
     end
   end

--- a/spec/features/commercials_spec.rb
+++ b/spec/features/commercials_spec.rb
@@ -5,6 +5,7 @@ require 'spec_helper'
 feature Commercial do
   # It is necessary to use bang version of let to build roles before user
   let!(:conference) { create(:conference) }
+  let!(:cfp) { create(:cfp, program: conference.program) }
   let!(:organizer_role) { Role.find_by(name: 'organizer', resource: conference) }
   let!(:organizer) { create(:user, role_ids: [organizer_role.id]) }
   let!(:participant) { create(:user) }

--- a/spec/features/organization_admin_ability_spec.rb
+++ b/spec/features/organization_admin_ability_spec.rb
@@ -38,7 +38,7 @@ feature 'Has correct abilities' do
       expect(page).to have_link('Rooms', href: "/admin/conferences/#{conference.short_title}/venue/rooms")
       expect(page).to have_link('Lodgings', href: "/admin/conferences/#{conference.short_title}/lodgings")
       expect(page).to have_link('Program', href: "/admin/conferences/#{conference.short_title}/program")
-      expect(page).to have_link('Call for Papers', href: "/admin/conferences/#{conference.short_title}/program/cfps")
+      expect(page).to have_link('Calls for Content', href: "/admin/conferences/#{conference.short_title}/program/cfps")
       expect(page).to have_link('Events', href: "/admin/conferences/#{conference.short_title}/program/events")
       expect(page).to have_link('Tracks', href: "/admin/conferences/#{conference.short_title}/program/tracks")
       expect(page).to have_link('Event Types', href: "/admin/conferences/#{conference.short_title}/program/event_types")

--- a/spec/features/organizer_ability_spec.rb
+++ b/spec/features/organizer_ability_spec.rb
@@ -41,7 +41,7 @@ feature 'Has correct abilities' do
       expect(page).to have_link('Rooms', href: "/admin/conferences/#{conference.short_title}/venue/rooms")
       expect(page).to have_link('Lodgings', href: "/admin/conferences/#{conference.short_title}/lodgings")
       expect(page).to have_link('Program', href: "/admin/conferences/#{conference.short_title}/program")
-      expect(page).to have_link('Call for Papers', href: "/admin/conferences/#{conference.short_title}/program/cfps")
+      expect(page).to have_link('Calls for Content', href: "/admin/conferences/#{conference.short_title}/program/cfps")
       expect(page).to have_link('Events', href: "/admin/conferences/#{conference.short_title}/program/events")
       expect(page).to have_link('Tracks', href: "/admin/conferences/#{conference.short_title}/program/tracks")
       expect(page).to have_link('Event Types', href: "/admin/conferences/#{conference.short_title}/program/event_types")

--- a/spec/features/proposals_spec.rb
+++ b/spec/features/proposals_spec.rb
@@ -94,6 +94,7 @@ feature Event do
 
     scenario 'update a proposal' do
       conference = create(:conference)
+      create(:cfp, program: conference.program)
       proposal = create(:event, program: conference.program)
 
       sign_in proposal.submitter

--- a/spec/features/versions_spec.rb
+++ b/spec/features/versions_spec.rb
@@ -4,6 +4,7 @@ require 'spec_helper'
 
 feature 'Version' do
   let!(:conference) { create(:conference) }
+  let!(:cfp) { create(:cfp, program: conference.program) }
   let!(:organizer_role) { Role.find_by(name: 'organizer', resource: conference) }
   let!(:organizer) { create(:user, role_ids: [organizer_role.id]) }
   let(:event_with_commercial) { create(:event, program: conference.program) }
@@ -35,7 +36,6 @@ feature 'Version' do
   end
 
   scenario 'display changes in cfp', feature: true, versioning: true, js: true do
-    cfp = create(:cfp, program: conference.program)
     cfp.update_attributes(start_date: (Time.zone.today + 1).strftime('%d/%m/%Y'), end_date: (Time.zone.today + 3).strftime('%d/%m/%Y'))
     cfp_id = cfp.id
     cfp.destroy


### PR DESCRIPTION
So... for LFNW we don't want people submitting proposals to be able to set event registration. It just doesn't work for _our_ event... so I added a switch.

In backporting this to upstream OSEM, I couldn't help fixing a few other nitpicks... like having the "Call for Booths" under the heading "Call for Papers". *sigh*.
