### PR TITLE
Raise handled error when conference not found

### DIFF
--- a/app/controllers/conferences_controller.rb
+++ b/app/controllers/conferences_controller.rb
@@ -19,7 +19,7 @@ class ConferencesController < ApplicationController
       :registration_period,
       :contact,
       venue: :commercial
-    ).find_by(conference_finder_conditions)
+    ).find_by!(conference_finder_conditions)
     authorize! :show, @conference # TODO: reduce the 10 queries performed here
 
     splashpage = @conference.splashpage


### PR DESCRIPTION
The current codebase will end in a 500 APPLICATION ERROR if Conference#short_title isn't found... this should be a 404 NOT FOUND INSTEAD, which will be handled if we raise ActiveRecord::RecordNotFound.
