### PR TITLE
Goodbye PhantomJS

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -12,6 +12,7 @@ before_install:
   - "echo `phantomjs -v`"
 addons:
   mariadb: '10.2'
+  chrome: stable
 notifications:
   email:
     on_success: change

--- a/.travis.yml
+++ b/.travis.yml
@@ -11,7 +11,6 @@ before_install:
   - "echo 'gem: --no-ri --no-rdoc' > ~/.gemrc"
   - "echo `phantomjs -v`"
 addons:
-  mariadb: '10.2'
   chrome: stable
 notifications:
   email:
@@ -23,15 +22,12 @@ notifications:
     on_success: change
     on_failure: change
 before_script:
-  - mysql -u root -e 'create database osem_test;'
   - RAILS_ENV=test bundle exec rake db:bootstrap --trace
 script:
   - "./travis_script.sh $TEST_SUITE"
 env:
   global:
-    - OSEM_DB_ADAPTER=mysql2
-    - OSEM_DB_USER=root
-    - OSEM_DB_PASSWORD=''
+    - OSEM_DB_ADAPTER=sqlite3
     - OSEM_DB_HOST=''
     - OSEM_DB_PORT=''
     - OSEM_DB_NAME='osem_test'

--- a/Gemfile
+++ b/Gemfile
@@ -252,10 +252,11 @@ end
 group :test do
   # as test framework
   gem 'capybara'
+  gem 'chromedriver-helper'
   gem 'database_cleaner'
-  gem 'phantomjs', :require => 'phantomjs/poltergeist'
-  gem 'poltergeist'
+  gem 'geckodriver-helper'
   gem 'rspec-rails', '~> 3.5', '>= 3.5.2'
+  gem 'selenium-webdriver'
   # for measuring test coverage
   gem 'codecov', require: false
   # for describing models

--- a/Gemfile
+++ b/Gemfile
@@ -257,6 +257,7 @@ group :test do
   gem 'geckodriver-helper'
   gem 'rspec-rails', '~> 3.5', '>= 3.5.2'
   gem 'selenium-webdriver'
+  gem 'transactional_capybara'
   # for measuring test coverage
   gem 'codecov', require: false
   # for describing models

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -548,6 +548,8 @@ GEM
     thread_safe (0.3.6)
     tilt (2.0.8)
     timecop (0.9.1)
+    transactional_capybara (0.2.0)
+      capybara
     transitions (0.1.12)
     ttfunk (1.1.1)
     turbolinks (5.2.0)
@@ -696,6 +698,7 @@ DEPENDENCIES
   stripe-ruby-mock
   thor (~> 0.19)
   timecop
+  transactional_capybara
   transitions
   turbolinks
   uglifier (>= 1.3.0)

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -64,6 +64,8 @@ GEM
     airbrake-ruby (2.12.0)
     ajax-datatables-rails (0.4.3)
       railties (>= 4.0)
+    archive-zip (0.11.0)
+      io-like (~> 0.3.0)
     arel (7.1.4)
     ast (2.4.0)
     autoprefixer-rails (9.3.1)
@@ -104,10 +106,14 @@ GEM
     chart-js-rails (0.1.6)
       railties (> 3.1)
     chartkick (3.0.1)
+    childprocess (0.9.0)
+      ffi (~> 1.0, >= 1.0.11)
+    chromedriver-helper (2.1.0)
+      archive-zip (~> 0.10)
+      nokogiri (~> 1.8)
     chronic (0.10.2)
     chunky_png (1.3.8)
     climate_control (0.2.0)
-    cliver (0.3.2)
     cloudinary (1.9.1)
       aws_cf_signer
       rest-client
@@ -179,6 +185,8 @@ GEM
       actionpack (>= 3.2.13)
     formtastic-bootstrap (3.1.1)
       formtastic (>= 3.0)
+    geckodriver-helper (0.21.0)
+      archive-zip (~> 0.7)
     globalid (0.4.1)
       activesupport (>= 4.2.0)
     gravtastic (3.2.6)
@@ -225,6 +233,7 @@ GEM
     i18n_data (0.8.0)
     inversion (1.1.1)
       loggability (~> 0.12)
+    io-like (0.3.0)
     iso-639 (0.2.8)
     jaro_winkler (1.5.1)
     jquery-datatables-rails (3.4.0)
@@ -334,16 +343,10 @@ GEM
       ast (~> 2.4.0)
     pdf-core (0.2.5)
     pg (1.1.2)
-    phantomjs (2.1.1.0)
     piwik_analytics (1.0.2)
       actionpack
       activesupport
       rails (>= 3.0.0)
-    poltergeist (1.9.0)
-      capybara (~> 2.1)
-      cliver (~> 0.3.1)
-      multi_json (~> 1.0)
-      websocket-driver (>= 0.2.0)
     powerpack (0.1.2)
     prawn (1.0.0)
       pdf-core (~> 0.2.2)
@@ -502,6 +505,9 @@ GEM
       sprockets-rails (>= 2.0, < 4.0)
       tilt (>= 1.1, < 3)
     selectize-rails (0.12.6)
+    selenium-webdriver (3.14.1)
+      childprocess (~> 0.5)
+      rubyzip (~> 1.2, >= 1.2.2)
     sexp_processor (4.11.0)
     shellany (0.0.1)
     shoulda-matchers (2.8.0)
@@ -602,6 +608,7 @@ DEPENDENCIES
   carrierwave-bombshelter
   chart-js-rails
   chartkick
+  chromedriver-helper
   climate_control
   cloudinary
   cocoon
@@ -621,6 +628,7 @@ DEPENDENCIES
   font-awesome-rails
   formtastic (~> 3.1.5)
   formtastic-bootstrap
+  geckodriver-helper
   gravtastic
   guard-rspec
   haml-rails
@@ -645,9 +653,7 @@ DEPENDENCIES
   omniauth-openid
   paper_trail
   pg
-  phantomjs
   piwik_analytics (~> 1.0.1)
-  poltergeist
   prawn-qrcode (~> 0.2.2.1)
   prawn_rails
   puma (~> 3.0)
@@ -680,6 +686,7 @@ DEPENDENCIES
   ruby-oembed (~> 0.12.0)
   sass-rails (>= 4.0.2)
   selectize-rails
+  selenium-webdriver
   shoulda-matchers
   skylight
   spring-commands-rspec

--- a/dotenv.example
+++ b/dotenv.example
@@ -115,3 +115,12 @@
 # Speeds up turn around times of tests
 # OSEM_FACTORY_LINT=false
 
+# How should browser tests be performed?
+# For headless Chrome (default):
+# OSEM_TEST_DRIVER=chrome_headless
+# For Chrome:
+# OSEM_TEST_DRIVER=chrome
+# For headless Firefox:
+# OSEM_TEST_DRIVER=firefox_headless
+# For Firefox:
+# OSEM_TEST_DRIVER=firefox

--- a/spec/features/cfp_spec.rb
+++ b/spec/features/cfp_spec.rb
@@ -18,6 +18,7 @@ feature Conference do
 
       click_button 'Create Cfp'
 
+      page.find('#flash')
       expect(flash)
           .to eq('Creating the call for papers failed. ' +
           "Start date can't be blank. End date can't be blank.")
@@ -53,6 +54,7 @@ feature Conference do
       page.execute_script(
           "$('#registration-period-start-datepicker').val('')")
       click_button 'Update Cfp'
+      page.find('#flash')
       expect(flash)
           .to eq('Updating call for papers failed. ' +
                     "Start date can't be blank.")
@@ -67,6 +69,7 @@ feature Conference do
       click_button 'Update Cfp'
 
       # Validations
+      page.find('#flash')
       expect(flash)
           .to eq('Call for papers successfully updated.')
 

--- a/spec/features/code_of_conduct_spec.rb
+++ b/spec/features/code_of_conduct_spec.rb
@@ -68,25 +68,33 @@ feature 'Code of Conduct:' do
       let!(:organization) { create(:organization, code_of_conduct: sample_text) }
       let!(:participant) { create(:user) }
 
-      before { sign_in participant }
-
-      it 'must be accepted', js: true do
+      before do
+        sign_in participant
         visit conferences_path
         within "#conference-#{conference.id}" do
           click_on 'Register'
         end
+      end
+
+      it 'can be viewed', js: true do
+        page.find('input#registration_accepted_code_of_conduct')
         expect(page).to have_text('I have read and accept the Code of Conduct')
         expect(page).not_to have_text(sample_text)
         within 'form' do
           click_on 'Code of Conduct'
         end
+        page.find('.modal-dialog')
         expect(page).to have_content(sample_text)
-        find('button.close').click
-        click_on 'Register'
+      end
+
+      it 'must be accepted', js: true do
+        find("input[type='submit']").click
+        page.find('#flash')
         expect(conference.user_registered?(participant)).to be_falsey
-        expect(page).to have_content('Accepted code of conduct must be accepted')
+        expect(flash).to match('Accepted code of conduct must be accepted')
         check 'registration[accepted_code_of_conduct]'
         click_on 'Register'
+        page.find('#flash')
         expect(conference.user_registered?(participant)).to be_truthy
         visit conference_conference_registration_path(conference)
         expect(page).to have_content('You have accepted the Code of Conduct')

--- a/spec/features/conference_registration_spec.rb
+++ b/spec/features/conference_registration_spec.rb
@@ -35,7 +35,11 @@ feature Registration do
         click_link 'My Registration'
         expect(current_path).to eq(conference_conference_registration_path(conference.short_title))
 
-        click_link 'Unregister'
+        page.accept_alert do
+          click_link 'Unregister'
+        end
+        page.find('#flash')
+        expect(page).to have_content('not registered')
         expect(conference.user_registered?(participant)).to be(false)
       end
     end

--- a/spec/features/conference_spec.rb
+++ b/spec/features/conference_spec.rb
@@ -28,6 +28,7 @@ feature Conference do
 
       click_button 'Create Conference'
 
+      page.find('#flash')
       expect(flash)
           .to eq('Conference was successfully created.')
       expect(Conference.count).to eq(expected_count)
@@ -49,9 +50,14 @@ feature Conference do
       fill_in 'conference_title', with: 'New Con'
       fill_in 'conference_short_title', with: ''
 
-      click_button 'Update Conference'
+      page.accept_alert do
+        click_button 'Update Conference'
+      end
+
+      page.find('#flash')
       expect(flash)
           .to eq("Updating conference failed. Short title can't be blank.")
+      page.find('#flash .close').click
 
       fill_in 'conference_title', with: 'New Con'
       fill_in 'conference_short_title', with: 'NewCon'
@@ -64,9 +70,12 @@ feature Conference do
           .execute_script("$('#conference-end-datepicker').val('" +
                              "#{(day + 7).strftime('%d/%m/%Y')}')")
 
-      click_button 'Update Conference'
-      expect(flash)
-          .to eq('Conference was successfully updated.')
+      page.accept_alert do
+        click_button 'Update Conference'
+      end
+
+      page.find('#flash')
+      expect(flash).to eq('Conference was successfully updated.')
 
       conference.reload
       expect(conference.title).to eq('New Con')

--- a/spec/features/contact_spec.rb
+++ b/spec/features/contact_spec.rb
@@ -16,7 +16,7 @@ feature Contact do
       visit edit_admin_conference_contact_path(conference.short_title)
       fill_in 'contact_' + field_name, with: field_value
       click_button 'Update Contact'
-
+      page.find('#flash')
       expect(flash)
           .to eq('Contact details were successfully updated.')
       contact.reload

--- a/spec/features/difficulty_levels_spec.rb
+++ b/spec/features/difficulty_levels_spec.rb
@@ -22,7 +22,7 @@ feature DifficultyLevel do
       page.find('#difficulty_level_color').set('#ff0000')
 
       click_button 'Create Difficulty level'
-
+      page.find('#flash')
       # Validations
       expect(flash).to eq('Difficulty level successfully created.')
       within('table#difficulty_levels') do
@@ -40,9 +40,12 @@ feature DifficultyLevel do
                 conference_id: conference.short_title)
 
       # Remove difficulty level
-      within('table tr:nth-of-type(4)') do
-        click_link 'Delete'
+      page.accept_alert do
+        within('table tr:nth-of-type(4)') do
+          click_link 'Delete'
+        end
       end
+      page.find('#flash')
 
       # Validations
       expect(flash).to eq('Difficulty level successfully deleted.')

--- a/spec/features/email_spec.rb
+++ b/spec/features/email_spec.rb
@@ -37,6 +37,7 @@ feature EmailSettings do
       fill_in 'email_settings_confirmed_without_registration_body',
               with: 'Confirmed without registration email body'
 
+      page.execute_script 'window.scrollTo(0,0)'
       click_link 'Update Notifications'
       fill_in 'email_settings_conference_dates_updated_subject',
               with: 'Updated conference dates subject'
@@ -54,7 +55,7 @@ feature EmailSettings do
               with: 'Updated conference venue template'
 
       click_button 'Update Email settings'
-
+      page.find('#flash')
       expect(flash)
           .to eq('Email settings have been successfully updated.')
 

--- a/spec/features/event_types_spec.rb
+++ b/spec/features/event_types_spec.rb
@@ -28,7 +28,7 @@ feature EventType do
       page.find('#event_type_color').set('#e4e4e4')
 
       click_button 'Create Event type'
-
+      page.find('#flash')
       # Validations
       expect(flash).to eq('Event type successfully created.')
       within('table#event_types') do
@@ -42,6 +42,7 @@ feature EventType do
       within('tr', text: 'Party') do
         click_link 'Delete'
       end
+      page.find('#flash')
       expect(flash).to eq('Event type successfully deleted.')
 
       within('table#event_types') do

--- a/spec/features/lodgings_spec.rb
+++ b/spec/features/lodgings_spec.rb
@@ -21,7 +21,7 @@ feature Lodging do
     attach_file 'Picture', path
 
     click_button 'Create Lodging'
-
+    page.find('#flash')
     # Validations
     expect(flash).to eq('Lodging successfully created.')
     expect(page.has_content?('New lodging')).to be true
@@ -47,7 +47,7 @@ feature Lodging do
     attach_file 'Picture', path
 
     click_button 'Update Lodging'
-
+    page.find('#flash')
     # Validations
     expect(flash).to eq('Lodging successfully updated.')
     expect(page.has_content?('New lodging')).to be true
@@ -67,9 +67,10 @@ feature Lodging do
 
     expect(page.has_content?(lodging.name)).to be true
 
-    # Add lodging
-    click_link 'Delete'
-
+    page.accept_alert do
+      click_link 'Delete'
+    end
+    page.find('#flash')
     # Validations
     expect(flash).to eq('Lodging successfully deleted.')
     expect(page.has_content?(CGI.escapeHTML(lodging.name))).to be false

--- a/spec/features/omniauth_spec.rb
+++ b/spec/features/omniauth_spec.rb
@@ -20,6 +20,7 @@ feature Openid do
       within('#openidlinks') do
         click_link 'omniauth-google'
       end
+      page.find('#flash')
       expect(flash).to eq('test-1@example.com signed in successfully with google')
       expect(Openid.count).to eq(expected_count_openid)
       expect(User.count).to eq(expected_count_user)
@@ -35,6 +36,7 @@ feature Openid do
       within('#openidlinks') do
         click_link 'omniauth-google'
       end
+      page.find('#flash')
       expect(flash).to eq('test-participant-1@example.com signed in successfully with google')
       expect(Openid.count).to eq(expected_count_openid)
       expect(User.count).to eq(expected_count_user)
@@ -47,7 +49,7 @@ feature Openid do
       within('#openidlinks') do
         click_link 'omniauth-google'
       end
-
+      page.find('#flash')
       expect(flash).to eq('Could not authenticate you from Google because "Invalid credentials".')
     end
 
@@ -65,6 +67,7 @@ feature Openid do
       within('#openidlinks') do
         click_link 'omniauth-google'
       end
+      page.find('#flash')
       expect(flash).to eq('test-participant-1@example.com signed in successfully with google')
       expect(Openid.count).to eq(expected_count_openid)
       expect(User.count).to eq(expected_count_user)
@@ -82,7 +85,9 @@ feature Openid do
       within('#openidlinks') do
         click_link 'omniauth-google'
       end
+      page.find('#flash')
       expect(flash).to eq('test-participant-1@example.com signed in successfully with google')
+      page.find('#flash .close').click
       expect(Openid.count).to eq(expected_count_openid)
       expect(User.count).to eq(expected_count_user)
 
@@ -95,7 +100,9 @@ feature Openid do
       within('#openidlinks') do
         click_link 'omniauth-google'
       end
+      page.find('#flash')
       expect(flash).to eq('test-participant-1@example.com signed in successfully with google')
+      page.find('#flash .close').click
       expect(Openid.count).to eq(expected_count_openid)
       expect(User.count).to eq(expected_count_user)
       expect(Openid.where(email: 'test-participant-1@example.com').first.nil?).to eq(false)
@@ -111,6 +118,7 @@ feature Openid do
       within('#openidlinks') do
         click_link 'omniauth-facebook'
       end
+      page.find('#flash')
       expect(flash).to eq('test-participant-1@example.com signed in successfully with facebook')
       expect(Openid.count).to eq(expected_count_openid)
       expect(User.count).to eq(expected_count_user)
@@ -136,6 +144,7 @@ feature Openid do
       within('#openidlinks') do
         click_link "omniauth-#{provider}"
       end
+      page.find('#flash')
       expect(flash).to eq("user-#{provider}@example.com signed in successfully with #{provider}")
       expect(Openid.count).to eq(expected_count_openid)
       expect(User.count).to eq(expected_count_user)

--- a/spec/features/organization_spec.rb
+++ b/spec/features/organization_spec.rb
@@ -16,6 +16,7 @@ feature Organization do
       click_button 'Update Organization'
 
       organization.reload
+      page.find('#flash')
       expect(flash).to eq('Organization successfully updated')
       expect(organization.name).to eq('changed name')
     end
@@ -30,7 +31,7 @@ feature Organization do
       fill_in 'organization_name', with: 'Organization name'
 
       click_button 'Create Organization'
-
+      page.find('#flash')
       expect(flash).to eq('Organization successfully created')
       expect(Organization.last.name).to eq('Organization name')
     end
@@ -44,7 +45,7 @@ feature Organization do
     end
     scenario "can't create new organization", feature: true, js: true do
       visit new_admin_organization_path
-
+      page.find('#flash')
       expect(flash).to eq('You are not authorized to access this page.')
     end
 

--- a/spec/features/program_spec.rb
+++ b/spec/features/program_spec.rb
@@ -22,7 +22,7 @@ feature Program do
       fill_in 'program_rating', with: '4'
 
       click_button 'Update Program'
-
+      page.find('#flash')
       # Validations
       expect(flash)
           .to eq('The program was successfully updated.')

--- a/spec/features/proposals_spec.rb
+++ b/spec/features/proposals_spec.rb
@@ -85,6 +85,7 @@ feature Event do
       fill_in 'event_abstract', with: 'Lorem ipsum abstract'
 
       click_button 'Create Proposal'
+      page.find('#flash')
       expect(page).to have_content 'Proposal was successfully submitted.'
 
       expect(Event.count).to eq(expected_count_event)
@@ -103,6 +104,7 @@ feature Event do
       select('Easy', from: 'event[difficulty_level_id]')
 
       click_button 'Update Proposal'
+      page.find('#flash')
       expect(page).to have_content 'Proposal was successfully updated.'
     end
 
@@ -121,6 +123,7 @@ feature Event do
       fill_in 'event_description', with: 'Lorem ipsum description'
 
       click_button 'Create Proposal'
+      page.find('#flash')
       expect(page).to have_content 'Proposal was successfully submitted.'
 
       expect(current_path).to eq(conference_program_proposals_path(conference.short_title))
@@ -145,6 +148,8 @@ feature Event do
       visit conference_program_proposals_path(conference.short_title)
       expect(page).to have_content 'Example Proposal'
       click_link "delete_proposal_#{@event.id}"
+      page.accept_alert
+      page.find('#flash')
       expect(page).to have_content 'Proposal was successfully withdrawn.'
       @event.reload
       expect(@event.state).to eq('withdrawn')

--- a/spec/features/proposals_spec.rb
+++ b/spec/features/proposals_spec.rb
@@ -111,21 +111,19 @@ feature Event do
     scenario 'signed_in user submits a valid proposal', feature: true, js: true do
       sign_in participant_without_bio
       expected_count = Event.count + 1
+
       visit conference_program_proposals_path(conference.short_title)
       click_link 'New Proposal'
 
       fill_in 'event_title', with: 'Example Proposal'
-
       select('Example Event Type', from: 'event[event_type_id]')
-
       fill_in 'event_abstract', with: 'Lorem ipsum abstract'
       click_link 'description_link'
       fill_in 'event_description', with: 'Lorem ipsum description'
-
       click_button 'Create Proposal'
       page.find('#flash')
       expect(page).to have_content 'Proposal was successfully submitted.'
-
+      TransactionalCapybara::AjaxHelpers.wait_for_ajax(page)
       expect(current_path).to eq(conference_program_proposals_path(conference.short_title))
       expect(Event.count).to eq(expected_count)
     end

--- a/spec/features/registration_periods_spec.rb
+++ b/spec/features/registration_periods_spec.rb
@@ -19,10 +19,11 @@ feature RegistrationPeriod do
       click_link 'New Registration Period'
 
       click_button 'Save Registration Period'
+      page.find('#flash')
       expect(flash)
           .to eq('An error prohibited the Registration Period from being saved: ' \
           "Start date can't be blank. End date can't be blank.")
-
+      page.find('#flash .close').click
       page
           .execute_script("$('#registration-period-start-datepicker').val('" +
                              "#{Date.today.strftime('%d/%m/%Y')}')")
@@ -31,7 +32,7 @@ feature RegistrationPeriod do
                              "#{(Date.today + 5).strftime('%d/%m/%Y')}')")
 
       click_button 'Save Registration Period'
-
+      page.find('#flash')
       expect(flash).to eq('Registration Period successfully updated.')
       expect(current_path).to eq(admin_conference_registration_period_path(conference.short_title))
 

--- a/spec/features/resource_spec.rb
+++ b/spec/features/resource_spec.rb
@@ -23,6 +23,7 @@ feature Resource do
       click_button 'Create Resource'
 
       expect(Resource.count).to eq(2)
+      page.find('#flash')
       expect(flash).to eq('Resource successfully created.')
     end
 
@@ -34,7 +35,7 @@ feature Resource do
 
       click_button 'Update Resource'
       resource.reload
-
+      page.find('#flash')
       expect(flash).to eq('Resource successfully updated.')
       expect(resource.name).to eq('changed_name')
     end
@@ -43,6 +44,7 @@ feature Resource do
       visit admin_conference_resources_path(conference.short_title)
       click_link('Delete', href: admin_conference_resource_path(conference.short_title, resource.id))
 
+      page.find('#flash')
       expect(flash).to eq('Resource successfully destroyed.')
     end
   end

--- a/spec/features/roles_spec.rb
+++ b/spec/features/roles_spec.rb
@@ -21,7 +21,7 @@ feature Role do
       fill_in 'role_description', with: 'changed description'
       click_button 'Update Role'
       role.reload
-
+      page.find('#flash')
       expect(flash).to eq("Successfully updated role #{role_name}")
       expect(role.description).to eq('changed description')
     end
@@ -69,7 +69,7 @@ feature Role do
       bootstrap_switch = first('td').find('.bootstrap-switch-container')
       bootstrap_switch.click
 
-      expect(find('.alert').text).to eq "×Successfully removed role #{role_name} from user #{user_with_role.email}"
+      expect(find('.alert').text).to eq "× Successfully removed role #{role_name} from user #{user_with_role.email}"
       expect(by_role_name).to eq(role_name) | eq('organizer')
       user_with_role.reload
       expect(user_with_role.has_cached_role?(role_name, conference)).to eq false

--- a/spec/features/rooms_spec.rb
+++ b/spec/features/rooms_spec.rb
@@ -23,7 +23,7 @@ feature Room do
       fill_in 'room_size', with: '100'
 
       click_button 'Create Room'
-
+      page.find('#flash')
       # Validations
       expect(flash).to eq('Room successfully created.')
       within('table#rooms') do
@@ -42,7 +42,7 @@ feature Room do
       fill_in 'room_size', with: '100'
 
       click_button 'Update Room'
-
+      page.find('#flash')
       # Validations
       expect(flash).to eq('Room successfully updated.')
       within('table#rooms') do

--- a/spec/features/splashpage_spec.rb
+++ b/spec/features/splashpage_spec.rb
@@ -16,7 +16,7 @@ feature Splashpage do
 
     click_link 'Create Splashpage'
     click_button 'Save Changes'
-
+    page.find('#flash')
     expect(flash).to eq('Splashpage successfully created.')
     expect(current_path).to eq(admin_conference_splashpage_path(conference.short_title))
     expect(page.has_text?('Private')).to be true
@@ -32,7 +32,7 @@ feature Splashpage do
       click_link 'Edit'
       check('Make splash page public')
       click_button 'Save Changes'
-
+      page.find('#flash')
       expect(flash).to eq('Splashpage successfully updated.')
       expect(current_path).to eq(admin_conference_splashpage_path(conference.short_title))
       expect(page.has_text?('Public')).to be true
@@ -45,7 +45,8 @@ feature Splashpage do
       sign_in organizer
       visit admin_conference_splashpage_path(conference.short_title)
       click_link 'Delete'
-
+      page.accept_alert
+      page.find('#flash')
       expect(current_path).to eq(admin_conference_splashpage_path(conference.short_title))
       expect(flash).to eq('Splashpage was successfully destroyed.')
       expect(Splashpage.count).to eq(0)
@@ -60,7 +61,7 @@ feature Splashpage do
     scenario 'splashpage is not accessible for participants if it is not public' do
       sign_in participant
       visit conference_path(conference.short_title)
-
+      page.find('#flash')
       expect(flash).to eq('You are not authorized to access this page.')
       expect(current_path).to eq(root_path)
     end

--- a/spec/features/sponsor_spec.rb
+++ b/spec/features/sponsor_spec.rb
@@ -26,7 +26,7 @@ feature Sponsor do
       select(conference.sponsorship_levels.first.title, from: 'sponsor_sponsorship_level_id')
 
       click_button 'Create Sponsor'
-
+      page.find('#flash')
       expect(flash).to eq('Sponsor successfully created.')
       within('table#sponsors') do
         expect(page.has_content?('SUSE')).to be true
@@ -46,6 +46,7 @@ feature Sponsor do
           click_link 'Delete'
         end
       end
+      page.find('#flash')
       expect(flash).to eq('Sponsor successfully deleted.')
       expect(page).to_not have_selector('table#sponsors')
     end

--- a/spec/features/sponsorship_level_spec.rb
+++ b/spec/features/sponsorship_level_spec.rb
@@ -21,7 +21,7 @@ feature SponsorshipLevel do
       fill_in 'sponsorship_level_title', with: 'Platin'
 
       click_button 'Create Sponsorship level'
-
+      page.find('#flash')
       # Validations
       expect(flash).to eq('Sponsorship level successfully created.')
       within('table#sponsorship_levels') do
@@ -39,7 +39,7 @@ feature SponsorshipLevel do
       fill_in 'sponsorship_level_title', with: 'Gold'
 
       click_button 'Update Sponsorship level'
-
+      page.find('#flash')
       # Validations
       expect(flash).to eq('Sponsorship level successfully updated.')
       within('table#sponsorship_levels') do

--- a/spec/features/ticket_purchases_spec.rb
+++ b/spec/features/ticket_purchases_spec.rb
@@ -32,7 +32,7 @@ feature Registration do
         expect(current_path).to eq(conference_tickets_path(conference.short_title))
 
         click_button 'Continue'
-
+        page.find('#flash')
         expect(current_path).to eq(new_conference_payment_path(conference.short_title))
         expect(flash).to eq('Please pay here to get tickets.')
         purchase = TicketPurchase.where(user_id: participant.id, ticket_id: ticket.id).first
@@ -68,7 +68,7 @@ feature Registration do
         expect(current_path).to eq(conference_tickets_path(conference.short_title))
 
         click_button 'Continue'
-
+        page.find('#flash')
         expect(current_path).to eq(new_conference_payment_path(conference.short_title))
         expect(flash).to eq('Please pay here to get tickets.')
         purchase = TicketPurchase.where(user_id: participant.id, ticket_id: ticket.id).first
@@ -87,7 +87,7 @@ feature Registration do
             page.execute_script(%{ $('#submitButton').click(); })
             sleep(20)
           end
-
+          page.find('#flash')
           expect(current_path).to eq(conference_payments_path(conference.short_title))
           expect(flash).to eq('Your card was declined. Please try again with correct credentials.')
         end
@@ -138,7 +138,7 @@ feature Registration do
         expect(current_path).to eq(conference_tickets_path(conference.short_title))
 
         click_button 'Continue'
-
+        page.find('#flash')
         expect(flash).to eq('Oops, something went wrong with your purchase! You cannot buy more than one registration tickets.')
         expect(current_path).to eq(conference_tickets_path(conference.short_title))
       end
@@ -157,7 +157,7 @@ feature Registration do
         expect(current_path).to eq(conference_tickets_path(conference.short_title))
 
         click_button 'Continue'
-
+        page.find('#flash')
         expect(current_path).to eq(new_conference_payment_path(conference.short_title))
         expect(flash).to eq('Please pay here to get tickets.')
         purchase = TicketPurchase.where(user_id: participant.id, ticket_id: ticket.id).first

--- a/spec/features/tickets_spec.rb
+++ b/spec/features/tickets_spec.rb
@@ -25,6 +25,7 @@ feature Ticket do
       fill_in 'ticket_price', with: '100'
 
       click_button 'Create Ticket'
+      page.find('#flash')
       expect(flash).to eq('Ticket successfully created.')
       expect(Ticket.count).to eq(2)
     end
@@ -37,6 +38,7 @@ feature Ticket do
       fill_in 'ticket_price', with: '-1'
 
       click_button 'Create Ticket'
+      page.find('#flash')
       expect(flash).to eq("Creating Ticket failed: Title can't be blank. Price cents must be greater than or equal to 0.")
       expect(Ticket.count).to eq(1)
     end
@@ -55,9 +57,10 @@ feature Ticket do
 
         ticket.reload
         # It's necessary to multiply by 100 because the price is in cents
+        page.find('#flash')
+        expect(flash).to eq('Ticket successfully updated.')
         expect(ticket.price).to eq(Money.new(50 * 100, 'USD'))
         expect(ticket.title).to eq('Event Ticket')
-        expect(flash).to eq('Ticket successfully updated.')
         expect(Ticket.count).to eq(2)
       end
 
@@ -72,6 +75,7 @@ feature Ticket do
 
         ticket.reload
         # It's necessary to multiply by 100 because the price is in cents
+        page.find('#flash')
         expect(ticket.price).to eq(Money.new(100 * 100, 'USD'))
         expect(ticket.title).to eq('Business Ticket')
         expect(flash).to eq("Ticket update failed: Title can't be blank. Price cents must be greater than or equal to 0.")
@@ -81,7 +85,8 @@ feature Ticket do
       scenario 'delete ticket', feature: true, js: true do
         visit admin_conference_tickets_path(conference.short_title)
         click_link('Delete', href: admin_conference_ticket_path(conference.short_title, ticket.id))
-
+        page.accept_alert
+        page.find('#flash')
         expect(flash).to eq('Ticket successfully destroyed.')
         expect(Ticket.count).to eq(1)
       end

--- a/spec/features/tracks_spec.rb
+++ b/spec/features/tracks_spec.rb
@@ -22,6 +22,7 @@ feature Track do
         page.find('#track_color').set('#B94D4D')
         fill_in 'track_description', with: 'Events about our Linux distribution'
         click_button 'Create Track'
+        page.find('#flash')
       end
 
       expected.to change { Track.count }.by 1
@@ -36,20 +37,17 @@ feature Track do
       track = create(:track, program_id: conference.program.id)
       sign_in organizer
 
-      expected = expect do
-        visit admin_conference_program_tracks_path(conference_id: conference.short_title)
-        within('#tracks', visible: true) do
-          page.accept_confirm do
-            find_link('Delete').click
-          end
-        end
+      visit admin_conference_program_tracks_path(conference_id: conference.short_title)
+      within('#tracks', visible: true) do
+        click_link 'Delete'
       end
-
-      expected.to change { Track.count }.by(-1)
+      page.accept_alert
+      page.find('#flash')
       expect(flash).to eq('Track successfully deleted.')
       expect(page.has_css?('table#tracks')).to be false
       expect(page.has_content?(track.name)).to be false
       expect(page.has_content?(track.description)).to be false
+      expect(Track.count).to eq(0)
     end
 
     scenario 'updates a track', feature: true, js: true do
@@ -59,7 +57,7 @@ feature Track do
       expected = expect do
         visit admin_conference_program_tracks_path(conference_id: conference.short_title)
         within('#tracks', visible: true) do
-          find_link('Edit').trigger('click')
+          click_link 'Edit'
         end
 
         fill_in 'track_name', with: 'Distribution'
@@ -67,8 +65,8 @@ feature Track do
         page.find('#track_color').set('#B94D4D')
         fill_in 'track_description', with: 'Events about our Linux distribution'
         click_button 'Update Track'
+        page.find('#flash')
       end
-
       expected.to_not(change { Track.count })
       expect(flash).to eq('Track successfully updated.')
       within('table#tracks') do
@@ -93,6 +91,7 @@ feature Track do
         fill_in 'track_description', with: 'Events about our Linux distribution'
         fill_in 'track_relevance', with: 'Maintainer of super awesome distribution'
         click_button 'Create Track'
+        page.find('#flash')
       end
 
       expected.to change { Track.count }.by 1
@@ -113,6 +112,7 @@ feature Track do
         accept_confirm do
           click_link 'Withdraw'
         end
+        page.find('#flash')
       end
 
       expected.to_not(change { Track.count })
@@ -136,6 +136,7 @@ feature Track do
         page.find('#track_color').set('#B94D4D')
         fill_in 'track_description', with: 'Events about our Linux distribution'
         click_button 'Update Track'
+        page.find('#flash')
       end
 
       expected.to_not(change { Track.count })

--- a/spec/features/user_ability_spec.rb
+++ b/spec/features/user_ability_spec.rb
@@ -15,7 +15,7 @@ feature 'Has correct abilities' do
 
     scenario 'for administration views' do
       visit admin_conference_path(conference.short_title)
-
+      page.find('#flash')
       expect(current_path).to eq root_path
       expect(flash).to eq 'You are not authorized to access this page.'
     end

--- a/spec/features/venues_spec.rb
+++ b/spec/features/venues_spec.rb
@@ -26,6 +26,7 @@ feature Conference do
               with: 'Lorem ipsum dolor sit amet, consetetur' \
               'sadipscing elitr, sed diam nonumy eirmod tempor'
       click_button 'Create Venue'
+      page.find('#flash')
       expect(flash)
           .to eq('Venue was successfully created.')
       venue = Conference.find(conference.id).venue
@@ -43,6 +44,7 @@ feature Conference do
       fill_in 'venue_website', with: 'www.example.com new'
       fill_in 'venue_description', with: 'new'
       click_button 'Update Venue'
+      page.find('#flash')
       expect(flash)
           .to eq('Venue was successfully updated.')
       venue.reload

--- a/spec/features/versions_spec.rb
+++ b/spec/features/versions_spec.rb
@@ -250,6 +250,8 @@ feature 'Version' do
     splashpage_id = conference.splashpage.id
 
     click_link 'Delete'
+    page.accept_alert
+
     visit admin_revision_history_path
     expect(page).to have_text("#{organizer.name} created new splashpage with ID #{splashpage_id} in conference #{conference.short_title}")
     expect(page).to have_text("#{organizer.name} updated public, include program, include cfp, include venue, include tickets, include lodgings,

--- a/spec/features/volunteers_spec.rb
+++ b/spec/features/volunteers_spec.rb
@@ -29,6 +29,7 @@ feature Conference do
 #         find('div.nested-fields:nth-of-type(1) div:nth-of-type(1) textarea').
 #           set('Example Person')
       click_button 'Update Conference'
+      page.find('#flash')
       expect(flash)
       .to eq('Volunteering options were successfully updated.')
 
@@ -47,6 +48,7 @@ feature Conference do
 #       click_link 'Remove vday'
 #       expect(page.all('div.nested-fields').count == 0).to be true
       click_button 'Update Conference'
+      page.find('#flash')
       expect(flash).to eq('Volunteering options were successfully updated.')
       expect(page.all('div.nested-fields').count == 0).to be true
       sign_out
@@ -75,6 +77,7 @@ feature Conference do
 #         find('div.nested-fields:nth-of-type(1) div:nth-of-type(1) textarea').
 #         set('Example Person')
       click_button 'Update Conference'
+      page.find('#flash')
       expect(flash)
       .to eq('Volunteering options were successfully updated.')
 
@@ -92,6 +95,7 @@ feature Conference do
 #                  "[id$='_vday_ids']").
 #                       find(:option, "#{Date.today.strftime}").select_option
       click_button 'Update Conference'
+      page.find('#flash')
       expect(flash)
       .to eq('Volunteering options were successfully updated.')
 
@@ -111,6 +115,7 @@ feature Conference do
 #       click_link 'Remove vposition'
 #       expect(page.all('div.nested-fields').count == 1).to be true
 #       click_button 'Update Conference'
+      page.find('#flash')
       expect(flash).to eq('Volunteering options were successfully updated.')
 #       click_link 'Remove vday'
 #       expect(page.all('div.nested-fields').count == 0).to be true

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -74,7 +74,7 @@ RSpec.configure do |config|
 
   Capybara.register_driver :chrome_headless do |app|
     capabilities = Selenium::WebDriver::Remote::Capabilities.chrome(
-      chromeOptions: { args: %w(headless disable-gpu) }
+      chromeOptions: { args: %w(headless disable-gpu window-size=1920x1080) }
     )
     Capybara::Selenium::Driver.new(
       app, browser: :chrome, desired_capabilities: capabilities

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -18,6 +18,9 @@ require 'shoulda/matchers'
 # all migrations applied
 ActiveRecord::Migration.maintain_test_schema!
 
+# Keep capybara and the database on the same page
+require 'transactional_capybara/rspec'
+
 require 'selenium/webdriver'
 
 # Adds rspec helper provided by paper_trail

--- a/spec/support/database_cleaner.rb
+++ b/spec/support/database_cleaner.rb
@@ -2,17 +2,16 @@
 
 RSpec.configure do |config|
   config.before(:suite) do
-    DatabaseCleaner.clean_with(:truncation)
+    DatabaseCleaner.clean_with(:transaction)
     Rails.application.load_seed
   end
 
-  config.before(:each) do |example|
-    DatabaseCleaner.strategy = example.metadata[:js] == true ? :truncation : :transaction
+  config.before(:each) do
     DatabaseCleaner.start
   end
 
   config.after(:each) do |example|
+    TransactionalCapybara::AjaxHelpers.wait_for_ajax(page) if example.metadata[:js]
     DatabaseCleaner.clean
-    Rails.application.load_seed if example.metadata[:js] == true
   end
 end


### PR DESCRIPTION
* Drop phantomjs; use selenium to run Chrome or Firefox, visible or headless. (Headless Chrome by default - including features testing in Travis.) Resolves #2150 .
