### PR TITLE
Remove from splash page edit subtitle, if splashpage is not created.

### DIFF
--- a/app/views/admin/splashpages/show.html.haml
+++ b/app/views/admin/splashpages/show.html.haml
@@ -3,9 +3,13 @@
     .page-header
       %h1 Splashpage
       %p.text-muted
-        Build a
-        = link_to "splash page", conference_path(@conference.short_title)
-        with all the information for your conference
+        - if @splashpage
+          View the
+          = link_to "splash page", conference_path(@conference.short_title)
+
+        - else
+          Build a splashpage with all the information for your conference
+
 - if @splashpage
   .row
     .col-md-12


### PR DESCRIPTION
**Checklist**

- [x] I have read the [Contribution & Best practices Guide](https://github.com/openSUSE/osem/blob/master/CONTRIBUTING.md).
- [x] My branch is up-to-date with the upstream `master` branch.
- [x] The tests pass locally with my changes.
- [ ] I have added tests that prove my fix is effective or that my feature works(if appropriate).
- [ ] I have added necessary documentation (if appropriate).

**Short description of what this resolves/which [issues](https://github.com/openSUSE/osem/issues) does this fix?:**

<!-- List the issue number resolved with this change; if there is no open issue, describe the problem this request solves -->
- Fix #1962 

**Changes proposed in this pull request:**

<!-- Summarize the changes, using declarative language. -->
The link at the splash page edit subtitle is targeting the expected spashpage url.

The text prompts the creation of the splash page, so there is no reason for the link to exist before the creation of the splashpage. 

Similarly there is no reason to prompt the creation of the splash page after it is already created.
