### PR TITLE
Add the files we use for production deployments

### DIFF
--- a/config/deploy.rb
+++ b/config/deploy.rb
@@ -38,6 +38,7 @@ task :deploy do
       in_path(fetch(:current_path)) do
         command %{mkdir -p tmp/}
         command %{touch tmp/restart.txt}
+        command %{sudo systemctl restart osem-dj}
       end
     end
   end

--- a/dist/apache-vhost.conf
+++ b/dist/apache-vhost.conf
@@ -1,0 +1,45 @@
+<VirtualHost *:80>
+  ServerAdmin admin@opensuse.org
+  ServerName events.opensuse.org
+  ServerAlias conference.opensuse.org
+  ServerAlias summit.opensuse.org
+
+  DocumentRoot /home/osem/events/current/public
+
+  CustomLog /home/osem/events/current/log/access.log combined
+  ErrorLog /home/osem/events/current/log/error.log
+
+  RewriteEngine on
+  RewriteRule   "^/conference/(.+)"  "https://events.opensuse.org/conferences/$1"  [R,L]
+
+  # Serve assets and uploads directly
+  <location /assets>
+    ProxyPass !
+  </location>
+  <location /system>
+    ProxyPass !
+  </location>
+
+  # Pass the rest on to puma
+  ProxyPass / http://127.0.0.1:3000/
+  ProxyPassReverse / http://127.0.0.1:3000/
+
+  # don't loose time with IP address lookups
+  HostnameLookups Off
+  UseCanonicalName Off
+
+  # enable the footer on server-generated documents
+  ServerSignature On
+
+  <Directory "/home/osem/events">
+    Options FollowSymLinks
+  </Directory>
+
+  <Directory "/home/osem/events/current/public">
+    Options FollowSymLinks
+    AllowOverride All
+    Options -MultiViews
+    Require all granted
+  </Directory>
+
+</VirtualHost>

--- a/dist/osem-dj.service
+++ b/dist/osem-dj.service
@@ -1,0 +1,17 @@
+[Unit]
+Description=Open Source Event Manager Delayed Jobs
+Wants=osem.service
+Before=osem.service
+
+[Service]
+User=osem
+EnvironmentFile=/home/osem/events/current/.env.production
+WorkingDirectory=/home/osem/events/current
+ExecStart = /usr/bin/bundle exec bin/delayed_job -e production start
+ExecStop = /usr/bin/bundle exec bin/delayed_job -e production stop
+Type = forking
+PIDFile = /home/osem/events/current/tmp/pids/delayed_job.pid
+
+[Install]
+WantedBy=multi-user.target
+

--- a/dist/osem.service
+++ b/dist/osem.service
@@ -1,0 +1,13 @@
+[Unit]
+Description=Open Source Event Manager
+Wants=apache2.service
+Before=apache2.service
+
+[Service]
+User=osem
+EnvironmentFile=/home/osem/events/current/.env.production
+WorkingDirectory=/home/osem/events/current
+ExecStart=/usr/bin/bundle exec puma -e production
+
+[Install]
+WantedBy=multi-user.target

--- a/dotenv.example
+++ b/dotenv.example
@@ -44,7 +44,7 @@
 # OSEM_EMAIL_ADDRESS="no-reply@example.com"
 
 # The api key for transifex.com.
-# See TRANSLATION.md for details
+# See https://github.com/openSUSE/osem/wiki/Translation
 # OSEM_TRANSIFEX_APIKEY=1234
 
 # The errbit host to post exceptions to


### PR DESCRIPTION
We are using apache as reverse proxy and two systemd units (puma & delayed job) for events.opensuse.org. Track them also in this project, might be useful for others.