### PR TITLE
Update binding_of_caller

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -82,7 +82,7 @@ GEM
       actionpack (>= 3.1)
       axlsx (>= 2.0.1)
     bcrypt (3.1.12)
-    binding_of_caller (0.7.2)
+    binding_of_caller (0.8.0)
       debug_inspector (>= 0.0.1)
     bootstrap-sass (3.4.0)
       autoprefixer-rails (>= 5.2.1)
@@ -731,7 +731,7 @@ DEPENDENCIES
   whenever
 
 RUBY VERSION
-   ruby 2.5.3p105
+   ruby 2.5.0p0
 
 BUNDLED WITH
    1.17.1


### PR DESCRIPTION
There is a bug for the old version which affectes some Ruby versions.
Generate Gemfile with our current Ruby version 2.5.0.
