### PR TITLE
Add /conferences/:conference_id/program/proposal/:id

### DIFF
--- a/config/routes.rb
+++ b/config/routes.rb
@@ -170,6 +170,7 @@ Osem::Application.routes.draw do
       end
     end
     resource :program, only: [] do
+      get 'proposal/:id', to: 'proposals#show' # For backward compatibility
       resources :proposals, except: :destroy do
         get 'commercials/render_commercial' => 'commercials#render_commercial'
         resources :commercials, only: [:create, :update, :destroy]


### PR DESCRIPTION
We changed this route (because of renaming proposal to proposals in):
https://github.com/openSUSE/osem/commit/daf1f805bd16fbf22fbe25f5224dd022b5e082cc

Keep the old route for compatibility. We may need to add more routes for the same reason.

Fixes https://github.com/openSUSE/osem/issues/2330
