### PR TITLE
Fix several problems with permissions

### DIFF
--- a/app/models/ability.rb
+++ b/app/models/ability.rb
@@ -56,10 +56,6 @@ class Ability
         conference = registration.conference
         conference.registration_open? && registration.new_record? && !conference.registration_limit_exceeded?
       end
-
-      can [:new, :create], Event do |event|
-        event.program.cfp_open? && event.new_record?
-      end
     end
   end
 

--- a/app/models/ability.rb
+++ b/app/models/ability.rb
@@ -57,10 +57,6 @@ class Ability
         conference.registration_open? && registration.new_record? && !conference.registration_limit_exceeded?
       end
 
-      can :show, Event do |event|
-        event.new_record?
-      end
-
       can [:new, :create], Event do |event|
         event.program.cfp_open? && event.new_record?
       end


### PR DESCRIPTION
This fixes an important issue affecting events.opensuse.org:
- Allow to see the schedule without login #2365


There are many things weird in the permissions. I will take a closer look, but I wanted to fix the priority bug first.