### PR TITLE
Fix flickering submit valid proposal test

### DIFF
--- a/spec/features/proposals_spec.rb
+++ b/spec/features/proposals_spec.rb
@@ -121,8 +121,7 @@ feature Event do
       fill_in 'event_abstract', with: 'Lorem ipsum abstract'
       click_link 'Do you require something special?'
 
-      page.find('#event_description')
-      fill_in 'event_description', with: 'Lorem ipsum description'
+      fill_in 'event_description', with: 'Lorem ipsum description', wait: 60
       click_button 'Create Proposal'
 
       page.find('#flash')


### PR DESCRIPTION
The `find` was added to try to fix the flickering test: https://github.com/openSUSE/osem/commit/ac3337bd1ed93462ee6d8cae5651fe8d633305d8

The reason why this fail is that the Javascript is not loaded yet.
`find` and `fill_in` have the same `default_max_wait_time`. Because of
that adding `find` doesn't solve the problem. Increase wait time
instead.

Fixes https://github.com/openSUSE/osem/issues/2356
