### PR TITLE
Added select-all checkbox in splashpages form

### DIFF
--- a/app/views/admin/splashpages/_form.html.haml
+++ b/app/views/admin/splashpages/_form.html.haml
@@ -9,6 +9,13 @@
       = f.inputs name: 'Components' do
         %ul.fa-ul
           %li
+            %th
+              %button.btn.btn-default#select-all{ type: "button" }
+                Select All
+            %th
+              %button.btn.btn-default#unselect-all{ type: "button" }
+                Unselect All
+          %li
             = f.input :include_cfp, label: 'Display call for papers and call for tracks, while open', input_html: { checked: params[:action] == 'new' || @splashpage.try(:include_cfp) }
           %li
             = f.input :include_program, label: 'Display the program', input_html: { checked: params[:action] == 'new' || @splashpage.try(:include_program) }
@@ -45,3 +52,15 @@
     .col-md-12
       %p.text-right
         = f.submit 'Save Changes', class: 'btn btn-primary'
+
+:javascript
+  $(document).ready(function(){
+    $('#select-all').click(function(event) {
+      var parent = $(this).parents('.inputs:last');
+      parent.find('.input.checkbox input[type=checkbox]').prop('checked',true);
+      });
+    $('#unselect-all').click(function(event) {
+      var parent = $(this).parents('.inputs:last');
+      parent.find('.input.checkbox input[type=checkbox]').prop('checked',false);
+      });
+  });


### PR DESCRIPTION
**Checklist**

- [x] I have read the [Contribution & Best practices Guide](https://github.com/openSUSE/osem/blob/master/CONTRIBUTING.md).
- [x] My branch is up-to-date with the upstream `master` branch.
- [ ] The tests pass locally with my changes.
- [ ] I have added tests that prove my fix is effective or that my feature works(if appropriate).
- [ ] I have added necessary documentation (if appropriate).

The "select all" checkbox is added for the quick
selection or deselection of the checkboxes in
admin/splashpages#new.

closes issue #2022

![Screenshot from 2019-03-09 09-32-48](https://user-images.githubusercontent.com/32434989/54066135-28743780-4251-11e9-9f59-b4dedc408135.png)


-
