### PR TITLE
Fix flickering submit valid proposal test

### DIFF
--- a/spec/features/proposals_spec.rb
+++ b/spec/features/proposals_spec.rb
@@ -119,10 +119,11 @@ feature Event do
       fill_in 'event_title', with: 'Example Proposal'
       select('Example Event Type', from: 'event[event_type_id]')
       fill_in 'event_abstract', with: 'Lorem ipsum abstract'
-      click_link 'Do you require something special?'
+      expect(page).to have_text('You have used 3 words')
 
-      page.find('#event_description')
+      click_link 'Do you require something special?'
       fill_in 'event_description', with: 'Lorem ipsum description'
+
       click_button 'Create Proposal'
 
       page.find('#flash')


### PR DESCRIPTION
The `find` was added to try to fix the flickering test: ac3337b

`find` and `fill_in` have the same `default_max_wait_time`, so didn't
change the problem.

The reason why this fails sometimes is that the Javascript for the
description (for the text editor) moves the 'Do you require something
special?' link a bit down. This causes that the link is not actually
clicked if capybara found it before it moved. Ensuring that the link is
searched after the description has been introduced solves the problem.

Finally fixes https://github.com/openSUSE/osem/issues/2356 :tada: :dancer: :champagne: :fireworks:  :tada: :cake: 

Co-authored-by: @coolo 