### PR TITLE
Store screenshot when feature test fails

### DIFF
--- a/spec/support/save_feature_failures.rb
+++ b/spec/support/save_feature_failures.rb
@@ -4,13 +4,16 @@ RSpec.configure do |config|
   config.after(:each, type: :feature) do
     example_filename = RSpec.current_example.full_description
     example_filename = example_filename.tr(' ', '_')
-    example_filename += '.html'
     example_filename = File.expand_path(example_filename, Capybara.save_path)
+    example_screenshotname = "#{example_filename}.png"
+    example_filename += '.html'
     if RSpec.current_example.exception.present?
       save_page(example_filename)
+      save_page(example_screenshotname)
     # remove the file if the test starts working again
-    elsif File.exist?(example_filename)
-      File.unlink(example_filename)
+    else
+      File.unlink(example_filename) if File.exist?(example_filename)
+      File.unlink(example_screenshotname) if File.exist?(example_screenshotname)
     end
   end
 end


### PR DESCRIPTION
This is useful when debugging a failing test.

Co-authored-by: Stephan Kulow <stephan@kulow.org>