### PR TITLE
Disable capybara animation

### DIFF
--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -60,6 +60,8 @@ RSpec.configure do |config|
   #     --seed 1234
   config.order = 'random'
 
+  Capybara.disable_animation = true
+
   Capybara.register_driver :firefox do |app|
     Capybara::Selenium::Driver.new(app, browser: :firefox)
   end


### PR DESCRIPTION
Turn off jquery animation to speed up the Capybara JS specs.

Co-authored-by: Stephan Kulow stephan@kulow.org
