### PR TITLE
Add condition for missing_speakers in a track.

### DIFF
--- a/app/controllers/admin/reports_controller.rb
+++ b/app/controllers/admin/reports_controller.rb
@@ -15,8 +15,9 @@ module Admin
 
       attended_registrants_ids = @conference.registrations.where(attended: true).pluck(:user_id)
       @missing_event_speakers = EventUser.joins(:event)
-                                .where('event_role = ? and program_id = ?', 'submitter', @program.id)
+                                .where('event_role = ? and program_id = ?', 'speaker', @program.id)
                                 .where.not(user_id: attended_registrants_ids)
+                                .where(event_id: @events.pluck(:id))
                                 .includes(:user, :event)
     end
   end

--- a/spec/controllers/admin/reports_controller_spec.rb
+++ b/spec/controllers/admin/reports_controller_spec.rb
@@ -1,0 +1,38 @@
+# frozen_string_literal: true
+
+require 'spec_helper'
+
+describe Admin::ReportsController do
+
+  let(:conference) { create(:conference, start_date: Date.current - 1.day) }
+  let!(:admin) { create(:admin) }
+  let!(:user1) { create(:user) }
+  let!(:user2) { create(:user) }
+  let!(:venue) { create(:venue, conference: conference) }
+  let!(:room) { create(:room, venue: venue) }
+  let!(:track_submitter) { create(:user) }
+  let!(:self_organized_track) { create(:track, :self_organized, submitter_id: track_submitter.id, program: conference.program, name: 'My awesome track', start_date: Date.current, end_date: Date.current, room: room, state: 'confirmed') }
+  let!(:track) { create(:track, program: conference.program, color: '#800080') }
+
+  let!(:event1) { create(:event, id: 1, program: conference.program, track: self_organized_track, speakers: [user1], state: 'confirmed') }
+  let!(:event2) { create(:event, id: 2, program: conference.program, track: track, speakers: [user2], state: 'confirmed') }
+
+  context 'track organizer is signed in' do
+    before :each do
+      sign_in(track_submitter)
+      self_organized_track.assign_role_to_submitter
+    end
+
+    describe 'GET #index' do
+      it 'renders the index template' do
+        get :index, conference_id: conference.short_title
+        expect(response).to render_template :index
+      end
+
+      it 'initialises missing speakers' do
+        get :index, conference_id: conference.short_title
+        expect(assigns(:missing_event_speakers).pluck(:user_id)).to eq [user1.id]
+      end
+    end
+  end
+end


### PR DESCRIPTION

Fixes #1942

**Checklist**

- [x] I have read the [Contribution & Best practices Guide](https://github.com/openSUSE/osem/blob/master/CONTRIBUTING.md).
- [x] My branch is up-to-date with the upstream `master` branch.
- [x] The tests pass locally with my changes.
- [x] I have added tests that prove my fix is effective or that my feature works(if appropriate).
- [ ] I have added necessary documentation (if appropriate).

**Short description of what this resolves/which [issues](https://github.com/openSUSE/osem/issues) does this fix?:**

A user could see missing speakers of events which not accessible by him ( not under his track) in the reports option.
