### PR TITLE
Fixes typo in app/views/devise/registrations/edit.html.haml

### DIFF
--- a/app/views/devise/registrations/edit.html.haml
+++ b/app/views/devise/registrations/edit.html.haml
@@ -9,7 +9,7 @@
         = f.input :username, required: false, input_html: { autocomplete: 'off' }
         = f.input :email, required: false, input_html: { autocomplete: 'off' }
         = f.input :email_public,
-          hint: "Do you want to your email address publicly? (On sessions, registration lists, etc.)"
+          hint: "Do you want your email address to appear publicly? (e.g. on sessions, registration lists, etc.)"
         = f.input :password, hint: "(Leave blank if you don't want to change it)", input_html: { autocomplete: 'off' }
         = f.input :password_confirmation, input_html: { autocomplete: 'off' }
         = f.inputs name: 'OpenID' do


### PR DESCRIPTION
fixes typo in registration view

**Checklist**

- [x] I have read the [Contribution & Best practices Guide](https://github.com/openSUSE/osem/blob/master/CONTRIBUTING.md).
- [x] My branch is up-to-date with the upstream `master` branch.
- [ ] The tests pass locally with my changes.
- [ ] I have added tests that prove my fix is effective or that my feature works(if appropriate).
- [x] I have added necessary documentation (if appropriate).

**Short description of what this resolves/which [issues](https://github.com/openSUSE/osem/issues) does this fix?:**

There was a typo on the registration view.
-

**Changes proposed in this pull request:**

Correct from:

`Do you want to your email address publicly? (On sessions, registration lists, etc.)`

to:

`Do you want your email address to appear publicly? (e.g. on sessions, registration lists, etc.)`


- This is my first pull request ever to a public repo. Mentoring is appreciated. :)
