### PR TITLE
Fix overlay of carousel controls

### DIFF
--- a/app/assets/stylesheets/osem-schedule.scss
+++ b/app/assets/stylesheets/osem-schedule.scss
@@ -1,3 +1,12 @@
+#schedule-content .carousel-control{
+  width: 12%;
+}
+
+@media (min-width: 768px){
+  #schedule-content .carousel-control{
+    width: 5%;
+  }
+}
 
 .room-name{
   font-weight: bold;


### PR DESCRIPTION
Events on the last column where not clickable because the carousel controls where render on top. Make them narrower to solve it.

Fixes https://github.com/openSUSE/osem/issues/2434

This is how it looks like in different screen sizes:

![image](https://user-images.githubusercontent.com/16052290/54998107-93519c80-4fcd-11e9-992f-09ab8886bbd2.png)
![image](https://user-images.githubusercontent.com/16052290/54998144-abc1b700-4fcd-11e9-95a9-4988a9c740c1.png)
![image](https://user-images.githubusercontent.com/16052290/54998162-ba0fd300-4fcd-11e9-9f04-3d9e84fda1c2.png)


This bug was a side effect of using a carousel for rendering the schedule. There are strong arguments to think this is not the best design and a better solution is being discussed: https://github.com/openSUSE/osem/issues/2421

Co-authored-by: @sncarnera
