### PR TITLE
Use helpers instead of URLs in switch checkboxes

### DIFF
--- a/app/views/admin/conferences/_recent_users.html.haml
+++ b/app/views/admin/conferences/_recent_users.html.haml
@@ -14,10 +14,7 @@
             %td= link_to user.email, admin_user_path(user.id)
             %td= user.created_at.strftime('%m/%d/%Y')
             %td
-              = check_box_tag user.id, user.id, user.confirmed?,
-                url: "/admin/users/#{user.id}/toggle_confirmation?user[to_confirm]=",
-                class: 'switch-checkbox',
-                readonly: true
+              = user.confirmed? ? 'Yes' : 'No'
 - else
   %h5.text-warning.text-center
     No sign ups!

--- a/app/views/admin/events/registrations.html.haml
+++ b/app/views/admin/events/registrations.html.haml
@@ -32,7 +32,7 @@
               %td= event_registration.email
               %td= event_registration.created_at
               %td
-                = check_box_tag @conference.short_title, @event.id, event_registration.attended, class: 'switch-checkbox', url: "/admin/conferences/#{@conference.short_title}/program/events/#{@event.id}/toggle_attendance?events_registration_id=#{event_registration.id}&&event_registration[attended]="
+                = check_box_tag @conference.short_title, @event.id, event_registration.attended, class: 'switch-checkbox', url: "#{toggle_attendance_admin_conference_program_event_path(@conference, @event, events_registration_id: event_registration)}&&event_registration[attended]="
               %td
                 - if event_registration.registration.attended
                   %i.fa.fa-check.text-success

--- a/app/views/admin/users/_form.html.haml
+++ b/app/views/admin/users/_form.html.haml
@@ -6,12 +6,12 @@
           Confirmed?
         - if can? :toggle_confirmation, @user
           = check_box_tag @user.id, @user.id, @user.confirmed?,
-            url: "/admin/users/#{@user.id}/toggle_confirmation?user[to_confirm]=",
+            url: "#{toggle_confirmation_admin_user_path(@user.id)}?user[to_confirm]=",
             class: 'switch-checkbox',
             readonly: false
         - else
           = check_box_tag @user.id, @user.id, @user.confirmed?,
-            url: "/admin/users/#{@user.id}/toggle_confirmation?user[to_confirm]=",
+            url: "#{toggle_confirmation_admin_user_path(@user.id)}?user[to_confirm]=",
             class: 'switch-checkbox',
             readonly: true
     = f.input :is_admin, hint: 'An admin can create a new conference, manage users and make other users admins.'

--- a/app/views/admin/users/show.html.haml
+++ b/app/views/admin/users/show.html.haml
@@ -36,12 +36,12 @@
                     %td
                       - if can? :toggle_confirmation, @user
                         = check_box_tag @user.id, @user.id, @user.confirmed?,
-                          url: "/admin/users/#{@user.id}/toggle_confirmation?user[to_confirm]=",
+                          url: "#{toggle_confirmation_admin_user_path(@user)}?user[to_confirm]=",
                           class: 'switch-checkbox',
                           readonly: false
                       - else
                         = check_box_tag @user.id, @user.id, @user.confirmed?,
-                          url: "/admin/users/#{@user.id}/toggle_confirmation?user[to_confirm]=",
+                          url: "#{toggle_confirmation_admin_user_path(@user)}?user[to_confirm]=",
                           class: 'switch-checkbox',
                           readonly: true
                 - else


### PR DESCRIPTION
**Checklist**

- [ ] I have read the [Contribution & Best practices Guide](https://github.com/openSUSE/osem/blob/master/CONTRIBUTING.md).
- [ ] My branch is up-to-date with the upstream `master` branch.
- [ ] The tests pass locally with my changes.
- [ ] I have added tests that prove my fix is effective or that my feature works(if appropriate).
- [ ] I have added necessary documentation (if appropriate).

**Short description of what this resolves/which [issues](https://github.com/openSUSE/osem/issues) does this fix?:**

- https://github.com/openSUSE/osem/issues/2472

**Changes proposed in this pull request:**

**Pending** 
- https://github.com/openSUSE/osem/blob/master/app/views/admin/users/index.html.haml#L42 
- registrations toggle attendance (which seems to be removed, but shouldn't?)