### PR TITLE
Document roles:add rake task in update from 1.0

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -35,6 +35,18 @@ data.
 bundle exec rake data:set_conference_in_versions RAILS_ENV=production
 ```
 
+### Organization admins
+
+We have a new role `organization admins` which allow a user to manage his the
+organization and create and manage conference within the organization. This
+needs the role to exist in the database, otherwise the application crashes
+as it is assumed to exist. For that, run the following rake task:
+
+```
+bundle exec rake roles:add RAILS_ENV=production
+```
+
+
 # Changes in OSEM 1.0
 
 [Released May 24, 2016](https://osem.io/1.0)


### PR DESCRIPTION
It is needed to run `rake roles:add` due to the addition of organization
admins when updating from 1.0. This needs to be documented as it makes
the application crashing.

Fixes https://github.com/openSUSE/osem/issues/2496