### PR TITLE
Fix incorrect format in xml dates

### DIFF
--- a/app/views/schedules/show.xml.haml
+++ b/app/views/schedules/show.xml.haml
@@ -16,7 +16,7 @@
           %room{ name: room.name }
             - events_in_rooms[room].each do |event|
               %event{ guid: event.guid, id: event.id }
-                %date= time_with_timezone(event.time)
+                %date= event.time.in_time_zone(@conference.timezone).iso8601
                 %start= event.time.strftime('%H:%M')
                 %duration= length_timestamp(event.event_type.length)
                 %room= event.room.name


### PR DESCRIPTION
Dates where using (some years ago) iso8601 without taking the timezone into account, as reported in: https://github.com/openSUSE/osem/issues/1188

When trying to fix the issue, the date was converted to an incorrect format which took timezone into account in: https://github.com/openSUSE/osem/commit/73a6e06fd3db5397a5869f8d269728063631dfae

Come back to use iso8601 but taking the timezone into account.

Really fixes https://github.com/openSUSE/osem/issues/1188
Fixes https://github.com/openSUSE/osem/issues/2510

This is needed by the video team for the openSUSE conference in few week. A fast review would be appreciated. :pray: 
