### PR TITLE
Only define rubocop tasks in the dev env

### DIFF
--- a/lib/tasks/rubocop.rake
+++ b/lib/tasks/rubocop.rake
@@ -1,16 +1,17 @@
 # frozen_string_literal: true
 
-require 'rubocop/rake_task'
+unless Rails.env.production?
+  require 'rubocop/rake_task'
 
-namespace :rubocop do
-  desc 'Generate .rubocop_todo.yml'
-  task :auto_gen_config do
-    sh 'rubocop --display-cop-names --auto-gen-config --auto-gen-only-exclude'
+  RuboCop::RakeTask.new(:rubocop) do |task|
+    task.patterns = []
+    task.options = ['--display-cop-names']
   end
-end
 
-desc 'Run RuboCop on the whole project'
-RuboCop::RakeTask.new(:rubocop) do |task|
-  task.patterns = []
-  task.options = ['--display-cop-names']
+  namespace :rubocop do
+    desc 'Generate .rubocop_todo.yml'
+    task :auto_gen_config do
+      sh 'rubocop --display-cop-names --auto-gen-config --auto-gen-only-exclude'
+    end
+  end
 end


### PR DESCRIPTION
This broke loading the rake tasks in the production environemt as we only haverubocop in development.