### PR TITLE
Disable links for tickets on splashpage

### DIFF
--- a/app/views/conferences/_tickets.haml
+++ b/app/views/conferences/_tickets.haml
@@ -13,13 +13,25 @@
       .row.row-centered
         - tickets.each do |ticket|
           .col-md-3.col-sm-3.col-centered.col-top
-            = link_to(conference_tickets_path(conference.short_title),
-              class: 'thumbnail') do
-              .caption
-                %h3.text-center.word_break
-                  = ticket.title
-                .word_break
-                  = markdown(ticket.description)
-                %button.btn-block.btn.btn-lg.btn-success
-                  %i.fa.fa-ticket.fa-fw
-                  = humanized_money_with_symbol(ticket.price)
+            - if conference.registration_open?
+              = link_to(conference_tickets_path(conference.short_title),
+                class: 'thumbnail') do
+                .caption
+                  %h3.text-center.word_break
+                    = ticket.title
+                  .word_break
+                    = markdown(ticket.description)
+                  %button.btn-block.btn.btn-lg.btn-success
+                    %i.fa.fa-ticket.fa-fw
+                    = humanized_money_with_symbol(ticket.price)
+            - else
+              .thumbnail
+                .caption
+                  %h3.text-center.word_break
+                    = ticket.title
+                  .word_break
+                    = markdown(ticket.description)
+                  %button.btn-block.btn.btn-lg.btn-success.disabled
+                    %i.fa.fa-ticket.fa-fw
+                    = humanized_money_with_symbol(ticket.price)
+


### PR DESCRIPTION
* Conditional rendering to disable links for tickets on splash screen
* Only enable links when registration is open

**Checklist**

- [x] I have read the [Contribution & Best practices Guide](https://github.com/openSUSE/osem/blob/master/CONTRIBUTING.md).
- [x] My branch is up-to-date with the upstream `master` branch.
- [ ] The tests pass locally with my changes.
- [ ] I have added tests that prove my fix is effective or that my feature works(if appropriate).
- [ ] I have added necessary documentation (if appropriate).

**Short description of what this resolves/which [issues](https://github.com/openSUSE/osem/issues) does this fix?:**

<!-- List the issue number resolved with this change; if there is no open issue, describe the problem this request solves -->

-

**Changes proposed in this pull request:**

<!-- Summarize the changes, using declarative language. -->

-
