### PR TITLE
Update devise_ichain_authenticatable to 0.3.2

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -158,7 +158,7 @@ GEM
       railties (>= 4.1.0, < 6.0)
       responders
       warden (~> 1.2.3)
-    devise_ichain_authenticatable (0.3.1)
+    devise_ichain_authenticatable (0.3.2)
       devise (>= 2.2)
     diff-lcs (1.3)
     docile (1.3.1)


### PR DESCRIPTION
Otherwise instances using ichain authentication (such as events.opensuse.org) break after the Rails 5.1 update.
