### PR TITLE
Fix event registatrion for rooms without size

### DIFF
--- a/app/views/admin/events/registrations.html.haml
+++ b/app/views/admin/events/registrations.html.haml
@@ -11,7 +11,7 @@
         for
         = @event.title
 
-    - if @event.room && (@event_registrations.length > @event.room.size)
+    - if @event.room.try(:size) && (@event_registrations.length > @event.room.size)
       %b Attention:
       You have more registrations than the capacity of the room!
 


### PR DESCRIPTION
If the room size is not set (which is possible as the size is not mandatory), the events registrations page breaks because of a comparison of nil with Integer.
