### PR TITLE
Added contactable to tracks

### DIFF
--- a/app/controllers/tracks_controller.rb
+++ b/app/controllers/tracks_controller.rb
@@ -13,12 +13,15 @@ class TracksController < ApplicationController
 
   def new
     @track = @program.tracks.new(color: @conference.next_color_for_collection(:tracks))
+    @track.build_contact
   end
 
   def edit; end
 
   def create
     @track = @program.tracks.new(track_params)
+    @contact = @track.build_contact(track_params[:contact_attributes])
+    @contact.conference = @conference
     @track.submitter = current_user
     @track.cfp_active = false
     if @track.save
@@ -35,7 +38,8 @@ class TracksController < ApplicationController
       redirect_to conference_program_tracks_path(conference_id: @conference.short_title),
                   notice: 'Track request successfully updated.'
     else
-      flash.now[:error] = "Track request update failed: #{@track.errors.full_messages.join('. ')}."
+      flash.now[:error] = "Track request update failed: #{@track.errors.full_messages.join('. ')}" \
+                          "#{@track.contact.errors.full_messages.join('. ')}."
       render :edit
     end
   end
@@ -55,7 +59,8 @@ class TracksController < ApplicationController
   private
 
   def track_params
-    params.require(:track).permit(:name, :description, :color, :short_name, :start_date, :end_date, :relevance)
+    params.require(:track).permit(:name, :description, :color, :short_name, :start_date, :end_date, :relevance,
+                                  contact_attributes: [:id, :social_tag, :facebook, :googleplus, :twitter, :instagram, :mastodon, :youtube])
   end
 
   def update_state(transition, notice)

--- a/app/models/contact.rb
+++ b/app/models/contact.rb
@@ -4,6 +4,7 @@ class Contact < ApplicationRecord
   has_paper_trail on: [:update], ignore: [:updated_at], meta: { conference_id: :conference_id }
 
   belongs_to :conference
+  belongs_to :contactable, polymorphic: true
 
   validates :conference, presence: true
   # Conferences only have one contact

--- a/app/models/track.rb
+++ b/app/models/track.rb
@@ -12,6 +12,8 @@ class Track < ApplicationRecord
   belongs_to :selected_schedule, class_name: 'Schedule'
   has_many :events, dependent: :nullify
   has_many :schedules
+  has_one :contact, as: :contactable
+  accepts_nested_attributes_for :contact
 
   has_paper_trail ignore: [:updated_at], meta: { conference_id: :conference_id }
 

--- a/app/views/tracks/_form.html.haml
+++ b/app/views/tracks/_form.html.haml
@@ -17,4 +17,15 @@
         = f.input :end_date, as: :string, input_html: { id: 'registration-period-end-datepicker', readonly: 'readonly' }
         = f.input :description, input_html: {rows: 2, data: { provide: 'markdown-editable' } }, required: true, hint: "This will be public #{markdown_hint}".html_safe
         = f.input :relevance, input_html: {rows: 5, data: { provide: 'markdown-editable' } }, required: true, hint: "Please explain here how this track relates to the conference, how you are related to its content and why we should accept it. #{markdown_hint}".html_safe
+
+        = f.inputs name:'Social Media' do
+          = f.semantic_fields_for :contact, @track.contact do |c|
+            = c.input :social_tag, hint: "The hashtag you'll use on Twitter and Google+. Don't include the '#' sign!'", required: false
+            = c.input :facebook, hint: 'This will appear in the social media section as a link to the Facebook.', required: false
+            = c.input :googleplus, label: 'Google+ Url', hint: 'This will appear in the social media section as a link to the Google+ Page of your Track', required: false
+            = c.input :twitter, hint: 'This will appear in the social media section as a link to the Twitter Page of your Track', required: false
+            = c.input :instagram, hint: 'This will appear in the social media section as a link to the Instagram Page of your Track', required: false
+            = c.input :mastodon, hint: 'This will appear in the social media section as a link to the Mastodon Page of your Track', required: false
+            = c.input :youtube, hint: 'This will appear in the social media section as a link to the YouTube channel for your Track.', required: false
+
         = f.action :submit, as: :button, button_html: { class: 'btn btn-primary' }

--- a/db/migrate/20190612161235_add_polymorphic_to_contact.rb
+++ b/db/migrate/20190612161235_add_polymorphic_to_contact.rb
@@ -1,0 +1,6 @@
+class AddPolymorphicToContact < ActiveRecord::Migration[5.1]
+  def change
+    add_column :contacts, :contactable_type, :string
+    add_column :contacts, :contactable_id, :integer
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2019_06_03_143107) do
+ActiveRecord::Schema.define(version: 2019_06_12_161235) do
 
   create_table "answers", force: :cascade do |t|
     t.string "title"
@@ -126,6 +126,8 @@ ActiveRecord::Schema.define(version: 2019_06_03_143107) do
     t.string "mastodon"
     t.string "youtube"
     t.string "blog"
+    t.string "contactable_type"
+    t.integer "contactable_id"
   end
 
   create_table "delayed_jobs", force: :cascade do |t|

--- a/spec/controllers/tracks_controller_spec.rb
+++ b/spec/controllers/tracks_controller_spec.rb
@@ -8,6 +8,7 @@ describe TracksController do
   let(:conference) { create(:conference) }
   let!(:regular_track) { create(:track, program: conference.program) }
   let!(:self_organized_track) { create(:track, :self_organized, program: conference.program, submitter: user, name: 'My awesome track', color: '#800080') }
+  let!(:contact) { create(:contact, contactable_type: 'Track', contactable_id: self_organized_track.id) }
 
   before :each do
     sign_in(user)


### PR DESCRIPTION
Related to #2528 

I have tried couple of different ways to use the contact model for social media fields. I have chosem this approach so as to enable for the user to add all fields at the same time in a single form while creating the track using nested attributes.

Also, as `contact` model has a `has_one` relationship with `conference` model I need to pass the `conference_id` as it is mandatory but I believe this will break the previous mechanism where a conference had one contact which could be fetched to show on the splashpage. _**So we would need to modify this relationship as well.**_

At this point I need to decide if I should use this model or just add the social fields in the main Track/Booth model itself.

![image](https://user-images.githubusercontent.com/26951824/63634038-afd22d80-c66e-11e9-9095-39a3ac8d7506.png)

Apart from this other fields like :code_of_conduct_accepted, :additional_requirements etc are pretty straightforward and after this I can work on the different views related to these details.