### PR TITLE
Ed1001 ticket currency select patch

### DIFF
--- a/app/views/admin/tickets/_form.html.haml
+++ b/app/views/admin/tickets/_form.html.haml
@@ -12,7 +12,10 @@
       = f.input :title, input_html: { autofocus: true }
       = f.input :description, input_html: { rows: 5, data: { provide: 'markdown-editable' } }
       = f.input :price
-      = f.input :price_currency, as: :select, class: 'form-control', collection: ['USD', 'EUR', 'GBP', 'INR', 'CNY', 'CHF'], include_blank: false
+      - if (@conference.tickets.count >= 1 && @ticket.new_record?) || @conference.tickets.count > 1
+        = f.input :price_currency, as: :select, class: 'form-control', collection: [@conference.tickets.first.price_currency], include_blank: false
+      - else
+        = f.input :price_currency, as: :select, class: 'form-control', collection: ['USD', 'EUR', 'GBP', 'INR', 'CNY', 'CHF'], include_blank: false
       = f.input :registration_ticket, hint: 'A registration ticket is with which user register for the conference.'
       %p.text-right
         = f.action :submit, as: :button, button_html: { class: 'btn btn-primary' }

--- a/docker-compose.override.yml.example
+++ b/docker-compose.override.yml.example
@@ -3,4 +3,4 @@ services:
   osem:
     build:
       args:
-        CONTAINER_USERID: 501
+        CONTAINER_USERID: 13042

--- a/docker-compose.override.yml.example
+++ b/docker-compose.override.yml.example
@@ -3,4 +3,4 @@ services:
   osem:
     build:
       args:
-        CONTAINER_USERID: 13042
+        CONTAINER_USERID: 501


### PR DESCRIPTION
**Checklist**

- [x] I have read the [Contribution & Best practices Guide](https://github.com/openSUSE/osem/blob/master/CONTRIBUTING.md).
- [x] My branch is up-to-date with the upstream `master` branch.
- [ ] The tests pass locally with my changes. (I'm not sure about this as even the untouched project has failures, so I assume 100% pass is not expected? I may need guidance on this one)

**Short description of what this resolves/which [issues](https://github.com/openSUSE/osem/issues) does this fix?:**

- Ticket currencies - #2086

**Changes proposed in this pull request:**

- Ticket price currency select will behave such that if there is already a ticket created, any new tickets will no longer have the option to select a different currency. If there is only one ticket created I have left the option to edit the currency for that ticket (not sure if this is desired, perhaps could disable if sold tickets > 0). I feel like this part of the code could be 'DRYer' but I couldn't seem to make it so, apologies but I have no experience with haml and couldn't find something suitable by googling, if there's a better way I'd be glad to know. Thanks


