### PR TITLE
Add price currency to conferences

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -4,6 +4,13 @@ Not release yet...
 
 ## Update from 1.0
 
+### Set Conference Price Currency
+Price currency is now set when creating a new conference, for all conferences created before this change the price currency must be set.
+
+```
+bundle exec rake data:set_conference_price_currency RAILS_ENV=production
+```
+
 ### Multiple Schedules
 A conference can have multiple schedules now so it's easier for organizers to
 test schedules and collaborate on different versions.

--- a/app/controllers/admin/conferences_controller.rb
+++ b/app/controllers/admin/conferences_controller.rb
@@ -182,7 +182,7 @@ module Admin
                                          :vpositions_attributes, :use_volunteers, :color,
                                          :sponsorship_levels_attributes, :sponsors_attributes,
                                          :registration_limit, :organization_id, :ticket_layout,
-                                         :booth_limit)
+                                         :booth_limit, :price_currency)
     end
   end
 end

--- a/app/models/ticket.rb
+++ b/app/models/ticket.rb
@@ -75,10 +75,6 @@ class Ticket < ApplicationRecord
 
   private
 
-  def get_price_currency
-    'GBP'
-  end
-
   def tickets_of_conference_have_same_currency
     tickets = Ticket.where(conference_id: conference_id)
     return if tickets.count.zero? || (tickets.count == 1 && self == tickets.first)

--- a/app/models/ticket.rb
+++ b/app/models/ticket.rb
@@ -8,13 +8,9 @@ class Ticket < ApplicationRecord
   has_paper_trail meta:   { conference_id: :conference_id },
                   ignore: %i[updated_at]
 
-  monetize :price_cents, with_model_currency: :price_currency
+  monetize :price_cents, with_currency: ->(ticket) { ticket.conference.price_currency }
 
   scope :for_registration, -> { where(registration_ticket: true) }
-
-  # This validation is for the sake of simplicity.
-  # If we would allow different currencies per conference we also have to handle convertions between currencies!
-  validate :tickets_of_conference_have_same_currency
 
   validates :price_cents, :price_currency, :title, presence: true
 
@@ -78,6 +74,10 @@ class Ticket < ApplicationRecord
   end
 
   private
+
+  def get_price_currency
+    'GBP'
+  end
 
   def tickets_of_conference_have_same_currency
     tickets = Ticket.where(conference_id: conference_id)

--- a/app/views/admin/conferences/new.html.haml
+++ b/app/views/admin/conferences/new.html.haml
@@ -7,6 +7,7 @@
                           input_html: { required: 'required' }
         = f.input :short_title, hint: "A short and unique handle for your conference, using only letters, numbers, underscores, and dashes. This will be used to identify your conference in URLs etc. Example: 'froscon2011'",
                                 input_html: { required: 'required', pattern: '[a-zA-Z0-9_-]+', title: 'Only letters, numbers, underscores, and dashes.' }, prepend: conferences_url + '/'
+      = f.input :price_currency, as: :select, class: 'form-control', collection: ['USD', 'EUR', 'GBP', 'INR', 'CNY', 'CHF'], include_blank: false, hint: "Please select the currency in which the tickets for this conference will be sold"
       = f.inputs 'Scheduling' do
         = f.input :timezone, as: :time_zone, default: Time.zone.name, hint: 'Please select in what time zone your conference will take place.'
         = f.input :start_date, as: :string, input_html: { id: 'conference-start-datepicker', required: 'required' }

--- a/app/views/admin/conferences/new.html.haml
+++ b/app/views/admin/conferences/new.html.haml
@@ -7,7 +7,7 @@
                           input_html: { required: 'required' }
         = f.input :short_title, hint: "A short and unique handle for your conference, using only letters, numbers, underscores, and dashes. This will be used to identify your conference in URLs etc. Example: 'froscon2011'",
                                 input_html: { required: 'required', pattern: '[a-zA-Z0-9_-]+', title: 'Only letters, numbers, underscores, and dashes.' }, prepend: conferences_url + '/'
-      = f.input :price_currency, as: :select, class: 'form-control', collection: ['USD', 'EUR', 'GBP', 'INR', 'CNY', 'CHF'], include_blank: false, hint: "Please select the currency in which the tickets for this conference will be sold"
+        = f.input :price_currency, as: :select, class: 'form-control', collection: ['USD', 'EUR', 'GBP', 'INR', 'CNY', 'CHF'], include_blank: false, hint: "Please select the currency in which the tickets for this conference will be sold"
       = f.inputs 'Scheduling' do
         = f.input :timezone, as: :time_zone, default: Time.zone.name, hint: 'Please select in what time zone your conference will take place.'
         = f.input :start_date, as: :string, input_html: { id: 'conference-start-datepicker', required: 'required' }

--- a/app/views/admin/tickets/_form.html.haml
+++ b/app/views/admin/tickets/_form.html.haml
@@ -12,7 +12,10 @@
       = f.input :title, input_html: { autofocus: true }
       = f.input :description, input_html: { rows: 5, data: { provide: 'markdown-editable' } }
       = f.input :price
-      = f.input :price_currency, as: :select, class: 'form-control', collection: ['USD', 'EUR', 'GBP', 'INR', 'CNY', 'CHF'], include_blank: false
+      %label
+        Currency
+      %p
+        = @conference.price_currency
       = f.input :registration_ticket, hint: 'A registration ticket is with which user register for the conference.'
       %p.text-right
         = f.action :submit, as: :button, button_html: { class: 'btn btn-primary' }

--- a/config/initializers/devise.rb
+++ b/config/initializers/devise.rb
@@ -5,7 +5,6 @@ Devise.setup do |config|
   # ==> openIDs configuration
   # Define the available openID providers that can be used to log in
   # Pass each provider to User model in :omniauth_providers (for open_id providers use their name)
-
   config.omniauth :open_id, name: 'suse', identifier: 'http://www.opensuse.org/openid/user'
   config.omniauth :google_oauth2, (ENV['OSEM_GOOGLE_KEY'] || Rails.application.secrets.google_key), (ENV['OSEM_GOOGLE_SECRET'] || Rails.application.secrets.google_secret),
                   name:  'google',

--- a/db/migrate/20190713163405_add_price_currency_to_conferences.rb
+++ b/db/migrate/20190713163405_add_price_currency_to_conferences.rb
@@ -1,0 +1,5 @@
+class AddPriceCurrencyToConferences < ActiveRecord::Migration[5.1]
+  def change
+    add_column :conferences, :price_currency, :string, default: "USD"
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,18 +10,21 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 20181113195810) do
+ActiveRecord::Schema.define(version: 20190713163405) do
+
+  # These are extensions that must be enabled in order to support this database
+  enable_extension "plpgsql"
 
   create_table "answers", force: :cascade do |t|
-    t.string   "title"
+    t.string "title"
     t.datetime "created_at"
     t.datetime "updated_at"
   end
 
   create_table "booth_requests", force: :cascade do |t|
-    t.integer  "booth_id"
-    t.integer  "user_id"
-    t.string   "role"
+    t.integer "booth_id"
+    t.integer "user_id"
+    t.string "role"
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
     t.index ["booth_id"], name: "index_booth_requests_on_booth_id"
@@ -29,81 +32,82 @@ ActiveRecord::Schema.define(version: 20181113195810) do
   end
 
   create_table "booths", force: :cascade do |t|
-    t.string   "title"
-    t.text     "description"
-    t.text     "reasoning"
-    t.string   "state"
-    t.string   "logo_link"
-    t.string   "website_url"
-    t.text     "submitter_relationship"
-    t.integer  "conference_id"
-    t.datetime "created_at",             null: false
-    t.datetime "updated_at",             null: false
+    t.string "title"
+    t.text "description"
+    t.text "reasoning"
+    t.string "state"
+    t.string "logo_link"
+    t.string "website_url"
+    t.text "submitter_relationship"
+    t.integer "conference_id"
+    t.datetime "created_at", null: false
+    t.datetime "updated_at", null: false
   end
 
   create_table "cfps", force: :cascade do |t|
-    t.date     "start_date",                           null: false
-    t.date     "end_date",                             null: false
+    t.date "start_date", null: false
+    t.date "end_date", null: false
     t.datetime "created_at"
     t.datetime "updated_at"
-    t.integer  "program_id"
-    t.string   "cfp_type"
-    t.text     "description"
-    t.boolean  "enable_registrations", default: false
+    t.integer "program_id"
+    t.string "cfp_type"
+    t.text "description"
+    t.boolean "enable_registrations", default: false
   end
 
   create_table "comments", force: :cascade do |t|
-    t.string   "title",            limit: 50, default: ""
-    t.text     "body"
-    t.integer  "commentable_id"
-    t.string   "commentable_type"
-    t.integer  "user_id"
+    t.string "title", limit: 50, default: ""
+    t.text "body"
+    t.integer "commentable_id"
+    t.string "commentable_type"
+    t.integer "user_id"
     t.datetime "created_at"
     t.datetime "updated_at"
-    t.string   "subject"
-    t.integer  "parent_id"
-    t.integer  "lft"
-    t.integer  "rgt"
+    t.string "subject"
+    t.integer "parent_id"
+    t.integer "lft"
+    t.integer "rgt"
     t.index ["commentable_id"], name: "index_comments_on_commentable_id"
     t.index ["commentable_type"], name: "index_comments_on_commentable_type"
     t.index ["user_id"], name: "index_comments_on_user_id"
   end
 
   create_table "commercials", force: :cascade do |t|
-    t.string   "commercial_id"
-    t.string   "commercial_type"
-    t.integer  "commercialable_id"
-    t.string   "commercialable_type"
+    t.string "commercial_id"
+    t.string "commercial_type"
+    t.integer "commercialable_id"
+    t.string "commercialable_type"
     t.datetime "created_at"
     t.datetime "updated_at"
-    t.string   "url"
+    t.string "url"
   end
 
   create_table "conferences", force: :cascade do |t|
-    t.string   "guid",                               null: false
-    t.string   "title",                              null: false
-    t.string   "short_title",                        null: false
-    t.string   "timezone",                           null: false
-    t.date     "start_date",                         null: false
-    t.date     "end_date",                           null: false
+    t.string "guid", null: false
+    t.string "title", null: false
+    t.string "short_title", null: false
+    t.string "timezone", null: false
+    t.date "start_date", null: false
+    t.date "end_date", null: false
     t.datetime "created_at"
     t.datetime "updated_at"
-    t.string   "logo_file_name"
-    t.integer  "revision",           default: 0,     null: false
-    t.boolean  "use_vpositions",     default: false
-    t.boolean  "use_vdays",          default: false
-    t.boolean  "use_volunteers"
-    t.string   "color"
-    t.text     "events_per_week"
-    t.text     "description"
-    t.integer  "registration_limit", default: 0
-    t.string   "picture"
-    t.integer  "start_hour",         default: 9
-    t.integer  "end_hour",           default: 20
-    t.integer  "organization_id"
-    t.integer  "ticket_layout",      default: 0
-    t.string   "custom_domain"
-    t.integer  "booth_limit",        default: 0
+    t.string "logo_file_name"
+    t.integer "revision", default: 0, null: false
+    t.boolean "use_vpositions", default: false
+    t.boolean "use_vdays", default: false
+    t.boolean "use_volunteers"
+    t.string "color"
+    t.text "events_per_week"
+    t.text "description"
+    t.integer "registration_limit", default: 0
+    t.string "picture"
+    t.integer "start_hour", default: 9
+    t.integer "end_hour", default: 20
+    t.integer "organization_id"
+    t.integer "ticket_layout", default: 0
+    t.string "custom_domain"
+    t.integer "booth_limit", default: 0
+    t.string "price_currency", default: "USD"
     t.index ["organization_id"], name: "index_conferences_on_organization_id"
   end
 
@@ -113,95 +117,95 @@ ActiveRecord::Schema.define(version: 20181113195810) do
   end
 
   create_table "contacts", force: :cascade do |t|
-    t.string   "social_tag"
-    t.string   "email"
-    t.string   "facebook"
-    t.string   "googleplus"
-    t.string   "twitter"
-    t.string   "instagram"
-    t.integer  "conference_id"
+    t.string "social_tag"
+    t.string "email"
+    t.string "facebook"
+    t.string "googleplus"
+    t.string "twitter"
+    t.string "instagram"
+    t.integer "conference_id"
     t.datetime "created_at"
     t.datetime "updated_at"
-    t.string   "sponsor_email"
-    t.string   "mastodon"
-    t.string   "youtube"
-    t.string   "blog"
+    t.string "sponsor_email"
+    t.string "mastodon"
+    t.string "youtube"
+    t.string "blog"
   end
 
   create_table "delayed_jobs", force: :cascade do |t|
-    t.integer  "priority",   default: 0, null: false
-    t.integer  "attempts",   default: 0, null: false
-    t.text     "handler",                null: false
-    t.text     "last_error"
+    t.integer "priority", default: 0, null: false
+    t.integer "attempts", default: 0, null: false
+    t.text "handler", null: false
+    t.text "last_error"
     t.datetime "run_at"
     t.datetime "locked_at"
     t.datetime "failed_at"
-    t.string   "locked_by"
-    t.string   "queue"
+    t.string "locked_by"
+    t.string "queue"
     t.datetime "created_at"
     t.datetime "updated_at"
     t.index ["priority", "run_at"], name: "delayed_jobs_priority"
   end
 
   create_table "difficulty_levels", force: :cascade do |t|
-    t.string   "title"
-    t.text     "description"
-    t.string   "color"
+    t.string "title"
+    t.text "description"
+    t.string "color"
     t.datetime "created_at"
     t.datetime "updated_at"
-    t.integer  "program_id"
+    t.integer "program_id"
   end
 
   create_table "email_settings", force: :cascade do |t|
-    t.integer  "conference_id"
-    t.boolean  "send_on_registration",                          default: false
-    t.boolean  "send_on_accepted",                              default: false
-    t.boolean  "send_on_rejected",                              default: false
-    t.boolean  "send_on_confirmed_without_registration",        default: false
-    t.text     "registration_body"
-    t.text     "accepted_body"
-    t.text     "rejected_body"
-    t.text     "confirmed_without_registration_body"
+    t.integer "conference_id"
+    t.boolean "send_on_registration", default: false
+    t.boolean "send_on_accepted", default: false
+    t.boolean "send_on_rejected", default: false
+    t.boolean "send_on_confirmed_without_registration", default: false
+    t.text "registration_body"
+    t.text "accepted_body"
+    t.text "rejected_body"
+    t.text "confirmed_without_registration_body"
     t.datetime "created_at"
     t.datetime "updated_at"
-    t.string   "registration_subject"
-    t.string   "accepted_subject"
-    t.string   "rejected_subject"
-    t.string   "confirmed_without_registration_subject"
-    t.boolean  "send_on_conference_dates_updated",              default: false
-    t.string   "conference_dates_updated_subject"
-    t.text     "conference_dates_updated_body"
-    t.boolean  "send_on_conference_registration_dates_updated", default: false
-    t.string   "conference_registration_dates_updated_subject"
-    t.text     "conference_registration_dates_updated_body"
-    t.boolean  "send_on_venue_updated",                         default: false
-    t.string   "venue_updated_subject"
-    t.text     "venue_updated_body"
-    t.boolean  "send_on_cfp_dates_updated",                     default: false
-    t.boolean  "send_on_program_schedule_public",               default: false
-    t.string   "program_schedule_public_subject"
-    t.string   "cfp_dates_updated_subject"
-    t.text     "program_schedule_public_body"
-    t.text     "cfp_dates_updated_body"
-    t.boolean  "send_on_booths_acceptance",                     default: false
-    t.string   "booths_acceptance_subject"
-    t.text     "booths_acceptance_body"
-    t.boolean  "send_on_booths_rejection",                      default: false
-    t.string   "booths_rejection_subject"
-    t.text     "booths_rejection_body"
-    t.boolean  "send_on_submitted_proposal",                    default: false
-    t.string   "submitted_proposal_subject"
-    t.text     "submitted_proposal_body"
+    t.string "registration_subject"
+    t.string "accepted_subject"
+    t.string "rejected_subject"
+    t.string "confirmed_without_registration_subject"
+    t.boolean "send_on_conference_dates_updated", default: false
+    t.string "conference_dates_updated_subject"
+    t.text "conference_dates_updated_body"
+    t.boolean "send_on_conference_registration_dates_updated", default: false
+    t.string "conference_registration_dates_updated_subject"
+    t.text "conference_registration_dates_updated_body"
+    t.boolean "send_on_venue_updated", default: false
+    t.string "venue_updated_subject"
+    t.text "venue_updated_body"
+    t.boolean "send_on_cfp_dates_updated", default: false
+    t.boolean "send_on_program_schedule_public", default: false
+    t.string "program_schedule_public_subject"
+    t.string "cfp_dates_updated_subject"
+    t.text "program_schedule_public_body"
+    t.text "cfp_dates_updated_body"
+    t.boolean "send_on_booths_acceptance", default: false
+    t.string "booths_acceptance_subject"
+    t.text "booths_acceptance_body"
+    t.boolean "send_on_booths_rejection", default: false
+    t.string "booths_rejection_subject"
+    t.text "booths_rejection_body"
+    t.boolean "send_on_submitted_proposal", default: false
+    t.string "submitted_proposal_subject"
+    t.text "submitted_proposal_body"
   end
 
   create_table "event_schedules", force: :cascade do |t|
-    t.integer  "event_id"
-    t.integer  "schedule_id"
-    t.integer  "room_id"
+    t.integer "event_id"
+    t.integer "schedule_id"
+    t.integer "room_id"
     t.datetime "start_time"
-    t.datetime "created_at",                 null: false
-    t.datetime "updated_at",                 null: false
-    t.boolean  "enabled",     default: true
+    t.datetime "created_at", null: false
+    t.datetime "updated_at", null: false
+    t.boolean "enabled", default: true
     t.index ["event_id", "schedule_id"], name: "index_event_schedules_on_event_id_and_schedule_id", unique: true
     t.index ["event_id"], name: "index_event_schedules_on_event_id"
     t.index ["room_id"], name: "index_event_schedules_on_room_id"
@@ -209,171 +213,171 @@ ActiveRecord::Schema.define(version: 20181113195810) do
   end
 
   create_table "event_types", force: :cascade do |t|
-    t.string   "title",                                 null: false
-    t.integer  "length",                  default: 30
-    t.integer  "minimum_abstract_length", default: 0
-    t.integer  "maximum_abstract_length", default: 500
-    t.string   "color"
-    t.string   "description"
-    t.integer  "program_id"
+    t.string "title", null: false
+    t.integer "length", default: 30
+    t.integer "minimum_abstract_length", default: 0
+    t.integer "maximum_abstract_length", default: 500
+    t.string "color"
+    t.string "description"
+    t.integer "program_id"
     t.datetime "created_at"
     t.datetime "updated_at"
   end
 
   create_table "event_users", force: :cascade do |t|
-    t.integer  "user_id"
-    t.integer  "event_id"
-    t.string   "event_role", default: "participant", null: false
-    t.string   "comment"
+    t.integer "user_id"
+    t.integer "event_id"
+    t.string "event_role", default: "participant", null: false
+    t.string "comment"
     t.datetime "created_at"
     t.datetime "updated_at"
   end
 
   create_table "events", force: :cascade do |t|
-    t.string   "guid",                                         null: false
-    t.integer  "event_type_id"
-    t.string   "title",                                        null: false
-    t.string   "subtitle"
-    t.string   "state",                        default: "new", null: false
-    t.string   "progress",                     default: "new", null: false
-    t.string   "language"
+    t.string "guid", null: false
+    t.integer "event_type_id"
+    t.string "title", null: false
+    t.string "subtitle"
+    t.string "state", default: "new", null: false
+    t.string "progress", default: "new", null: false
+    t.string "language"
     t.datetime "start_time"
-    t.text     "abstract"
-    t.text     "description"
-    t.boolean  "public",                       default: true
-    t.text     "proposal_additional_speakers"
-    t.integer  "track_id"
-    t.integer  "room_id"
+    t.text "abstract"
+    t.text "description"
+    t.boolean "public", default: true
+    t.text "proposal_additional_speakers"
+    t.integer "track_id"
+    t.integer "room_id"
     t.datetime "created_at"
     t.datetime "updated_at"
-    t.boolean  "require_registration"
-    t.integer  "difficulty_level_id"
-    t.integer  "week"
-    t.boolean  "is_highlight",                 default: false
-    t.integer  "program_id"
-    t.integer  "max_attendees"
-    t.integer  "comments_count",               default: 0,     null: false
+    t.boolean "require_registration"
+    t.integer "difficulty_level_id"
+    t.integer "week"
+    t.boolean "is_highlight", default: false
+    t.integer "program_id"
+    t.integer "max_attendees"
+    t.integer "comments_count", default: 0, null: false
   end
 
   create_table "events_registrations", force: :cascade do |t|
-    t.integer  "registration_id"
-    t.integer  "event_id"
-    t.boolean  "attended",        default: false, null: false
+    t.integer "registration_id"
+    t.integer "event_id"
+    t.boolean "attended", default: false, null: false
     t.datetime "created_at"
   end
 
   create_table "lodgings", force: :cascade do |t|
-    t.string   "name"
-    t.text     "description"
-    t.string   "photo_file_name"
-    t.string   "photo_content_type"
-    t.integer  "photo_file_size"
+    t.string "name"
+    t.text "description"
+    t.string "photo_file_name"
+    t.string "photo_content_type"
+    t.integer "photo_file_size"
     t.datetime "photo_updated_at"
     t.datetime "created_at"
     t.datetime "updated_at"
-    t.string   "website_link"
-    t.integer  "conference_id"
-    t.string   "picture"
+    t.string "website_link"
+    t.integer "conference_id"
+    t.string "picture"
   end
 
   create_table "openids", force: :cascade do |t|
-    t.string   "provider"
-    t.string   "email"
-    t.string   "uid"
-    t.integer  "user_id"
+    t.string "provider"
+    t.string "email"
+    t.string "uid"
+    t.integer "user_id"
     t.datetime "created_at"
     t.datetime "updated_at"
   end
 
   create_table "organizations", force: :cascade do |t|
-    t.string "name",            null: false
-    t.text   "description"
+    t.string "name", null: false
+    t.text "description"
     t.string "picture"
-    t.text   "code_of_conduct"
+    t.text "code_of_conduct"
   end
 
   create_table "payments", force: :cascade do |t|
-    t.string   "last4"
-    t.integer  "amount"
-    t.string   "authorization_code"
-    t.integer  "status",             default: 0, null: false
-    t.integer  "user_id",                        null: false
-    t.integer  "conference_id",                  null: false
-    t.datetime "created_at",                     null: false
-    t.datetime "updated_at",                     null: false
+    t.string "last4"
+    t.integer "amount"
+    t.string "authorization_code"
+    t.integer "status", default: 0, null: false
+    t.integer "user_id", null: false
+    t.integer "conference_id", null: false
+    t.datetime "created_at", null: false
+    t.datetime "updated_at", null: false
   end
 
   create_table "physical_tickets", force: :cascade do |t|
-    t.integer  "ticket_purchase_id", null: false
-    t.datetime "created_at",         null: false
-    t.datetime "updated_at",         null: false
-    t.string   "token"
+    t.integer "ticket_purchase_id", null: false
+    t.datetime "created_at", null: false
+    t.datetime "updated_at", null: false
+    t.string "token"
     t.index ["token"], name: "index_physical_tickets_on_token", unique: true
   end
 
   create_table "programs", force: :cascade do |t|
-    t.integer  "conference_id"
-    t.integer  "rating",               default: 0
-    t.boolean  "schedule_public",      default: false
-    t.boolean  "schedule_fluid",       default: false
+    t.integer "conference_id"
+    t.integer "rating", default: 0
+    t.boolean "schedule_public", default: false
+    t.boolean "schedule_fluid", default: false
     t.datetime "created_at"
     t.datetime "updated_at"
-    t.string   "languages"
-    t.boolean  "blind_voting",         default: false
+    t.string "languages"
+    t.boolean "blind_voting", default: false
     t.datetime "voting_start_date"
     t.datetime "voting_end_date"
-    t.integer  "selected_schedule_id"
-    t.integer  "schedule_interval",    default: 15,    null: false
+    t.integer "selected_schedule_id"
+    t.integer "schedule_interval", default: 15, null: false
     t.index ["selected_schedule_id"], name: "index_programs_on_selected_schedule_id"
   end
 
   create_table "qanswers", force: :cascade do |t|
-    t.integer  "question_id"
-    t.integer  "answer_id"
+    t.integer "question_id"
+    t.integer "answer_id"
     t.datetime "created_at"
     t.datetime "updated_at"
   end
 
   create_table "qanswers_registrations", id: false, force: :cascade do |t|
     t.integer "registration_id", null: false
-    t.integer "qanswer_id",      null: false
+    t.integer "qanswer_id", null: false
   end
 
   create_table "question_types", force: :cascade do |t|
-    t.string   "title"
+    t.string "title"
     t.datetime "created_at"
     t.datetime "updated_at"
   end
 
   create_table "questions", force: :cascade do |t|
-    t.string   "title"
-    t.integer  "question_type_id"
-    t.integer  "conference_id"
-    t.boolean  "global"
+    t.string "title"
+    t.integer "question_type_id"
+    t.integer "conference_id"
+    t.boolean "global"
     t.datetime "created_at"
     t.datetime "updated_at"
   end
 
   create_table "registration_periods", force: :cascade do |t|
-    t.integer  "conference_id"
-    t.date     "start_date"
-    t.date     "end_date"
+    t.integer "conference_id"
+    t.date "start_date"
+    t.date "end_date"
     t.datetime "created_at"
     t.datetime "updated_at"
   end
 
   create_table "registrations", force: :cascade do |t|
-    t.integer  "conference_id"
+    t.integer "conference_id"
     t.datetime "arrival"
     t.datetime "departure"
     t.datetime "created_at"
     t.datetime "updated_at"
-    t.text     "other_special_needs"
-    t.boolean  "attended",                 default: false
-    t.boolean  "volunteer"
-    t.integer  "user_id"
-    t.integer  "week"
-    t.boolean  "accepted_code_of_conduct"
+    t.text "other_special_needs"
+    t.boolean "attended", default: false
+    t.boolean "volunteer"
+    t.integer "user_id"
+    t.integer "week"
+    t.boolean "accepted_code_of_conduct"
   end
 
   create_table "registrations_vchoices", id: false, force: :cascade do |t|
@@ -382,110 +386,110 @@ ActiveRecord::Schema.define(version: 20181113195810) do
   end
 
   create_table "resources", force: :cascade do |t|
-    t.string  "name"
-    t.text    "description"
+    t.string "name"
+    t.text "description"
     t.integer "quantity"
-    t.integer "used",          default: 0
+    t.integer "used", default: 0
     t.integer "conference_id"
   end
 
   create_table "roles", force: :cascade do |t|
-    t.string   "name"
+    t.string "name"
     t.datetime "created_at"
     t.datetime "updated_at"
-    t.string   "description"
-    t.integer  "resource_id"
-    t.string   "resource_type"
+    t.string "description"
+    t.integer "resource_id"
+    t.string "resource_type"
     t.index ["name", "resource_type", "resource_id"], name: "index_roles_on_name_and_resource_type_and_resource_id"
     t.index ["name"], name: "index_roles_on_name"
   end
 
   create_table "rooms", force: :cascade do |t|
-    t.string  "guid",     null: false
-    t.string  "name",     null: false
+    t.string "guid", null: false
+    t.string "name", null: false
     t.integer "size"
     t.integer "venue_id", null: false
   end
 
   create_table "schedules", force: :cascade do |t|
-    t.integer  "program_id"
+    t.integer "program_id"
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
-    t.integer  "track_id"
+    t.integer "track_id"
     t.index ["program_id"], name: "index_schedules_on_program_id"
     t.index ["track_id"], name: "index_schedules_on_track_id"
   end
 
   create_table "splashpages", force: :cascade do |t|
-    t.integer  "conference_id"
-    t.boolean  "public"
-    t.boolean  "include_tracks"
-    t.boolean  "include_program"
-    t.boolean  "include_social_media"
-    t.boolean  "include_venue"
-    t.boolean  "include_tickets"
-    t.boolean  "include_registrations"
-    t.boolean  "include_sponsors"
-    t.boolean  "include_lodgings"
-    t.string   "banner_photo_file_name"
-    t.string   "banner_photo_content_type"
-    t.integer  "banner_photo_file_size"
+    t.integer "conference_id"
+    t.boolean "public"
+    t.boolean "include_tracks"
+    t.boolean "include_program"
+    t.boolean "include_social_media"
+    t.boolean "include_venue"
+    t.boolean "include_tickets"
+    t.boolean "include_registrations"
+    t.boolean "include_sponsors"
+    t.boolean "include_lodgings"
+    t.string "banner_photo_file_name"
+    t.string "banner_photo_content_type"
+    t.integer "banner_photo_file_size"
     t.datetime "banner_photo_updated_at"
     t.datetime "created_at"
     t.datetime "updated_at"
-    t.boolean  "include_cfp",               default: false
-    t.boolean  "include_booths"
-    t.boolean  "shuffle_highlights",        default: false, null: false
+    t.boolean "include_cfp", default: false
+    t.boolean "include_booths"
+    t.boolean "shuffle_highlights", default: false, null: false
   end
 
   create_table "sponsors", force: :cascade do |t|
-    t.string   "name"
-    t.text     "description"
-    t.string   "website_url"
-    t.string   "logo_file_name"
-    t.integer  "sponsorship_level_id"
-    t.integer  "conference_id"
+    t.string "name"
+    t.text "description"
+    t.string "website_url"
+    t.string "logo_file_name"
+    t.integer "sponsorship_level_id"
+    t.integer "conference_id"
     t.datetime "created_at"
     t.datetime "updated_at"
-    t.string   "picture"
+    t.string "picture"
   end
 
   create_table "sponsorship_levels", force: :cascade do |t|
-    t.string   "title"
-    t.integer  "conference_id"
+    t.string "title"
+    t.integer "conference_id"
     t.datetime "created_at"
     t.datetime "updated_at"
-    t.integer  "position"
+    t.integer "position"
   end
 
   create_table "subscriptions", force: :cascade do |t|
-    t.integer  "user_id"
-    t.integer  "conference_id"
+    t.integer "user_id"
+    t.integer "conference_id"
     t.datetime "created_at"
     t.datetime "updated_at"
   end
 
   create_table "survey_questions", force: :cascade do |t|
     t.integer "survey_id"
-    t.string  "title"
-    t.integer "kind",             default: 0
+    t.string "title"
+    t.integer "kind", default: 0
     t.integer "min_choices"
     t.integer "max_choices"
-    t.text    "possible_answers"
-    t.boolean "mandatory",        default: false
+    t.text "possible_answers"
+    t.boolean "mandatory", default: false
   end
 
   create_table "survey_replies", force: :cascade do |t|
-    t.integer  "survey_question_id"
-    t.integer  "user_id"
-    t.text     "text"
-    t.datetime "created_at",         null: false
-    t.datetime "updated_at",         null: false
+    t.integer "survey_question_id"
+    t.integer "user_id"
+    t.text "text"
+    t.datetime "created_at", null: false
+    t.datetime "updated_at", null: false
   end
 
   create_table "survey_submissions", force: :cascade do |t|
-    t.integer  "user_id"
-    t.integer  "survey_id"
+    t.integer "user_id"
+    t.integer "survey_id"
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
   end
@@ -493,100 +497,100 @@ ActiveRecord::Schema.define(version: 20181113195810) do
   create_table "surveys", force: :cascade do |t|
     t.datetime "start_date"
     t.datetime "end_date"
-    t.string   "title"
-    t.text     "description"
-    t.integer  "surveyable_id"
-    t.string   "surveyable_type"
-    t.datetime "created_at",                  null: false
-    t.datetime "updated_at",                  null: false
-    t.integer  "target",          default: 0
+    t.string "title"
+    t.text "description"
+    t.integer "surveyable_id"
+    t.string "surveyable_type"
+    t.datetime "created_at", null: false
+    t.datetime "updated_at", null: false
+    t.integer "target", default: 0
     t.index ["surveyable_type", "surveyable_id"], name: "index_surveys_on_surveyable_type_and_surveyable_id"
   end
 
   create_table "ticket_purchases", force: :cascade do |t|
-    t.integer  "ticket_id"
-    t.integer  "conference_id"
-    t.boolean  "paid",          default: false
+    t.integer "ticket_id"
+    t.integer "conference_id"
+    t.boolean "paid", default: false
     t.datetime "created_at"
-    t.integer  "quantity",      default: 1
-    t.integer  "user_id"
-    t.integer  "payment_id"
-    t.integer  "week"
-    t.float    "amount_paid",   default: 0.0
+    t.integer "quantity", default: 1
+    t.integer "user_id"
+    t.integer "payment_id"
+    t.integer "week"
+    t.float "amount_paid", default: 0.0
   end
 
   create_table "ticket_scannings", force: :cascade do |t|
-    t.integer  "physical_ticket_id", null: false
-    t.datetime "created_at",         null: false
-    t.datetime "updated_at",         null: false
+    t.integer "physical_ticket_id", null: false
+    t.datetime "created_at", null: false
+    t.datetime "updated_at", null: false
   end
 
   create_table "tickets", force: :cascade do |t|
-    t.integer  "conference_id"
-    t.string   "title",                               null: false
-    t.text     "description"
-    t.integer  "price_cents",         default: 0,     null: false
-    t.string   "price_currency",      default: "USD", null: false
-    t.boolean  "registration_ticket", default: false
+    t.integer "conference_id"
+    t.string "title", null: false
+    t.text "description"
+    t.integer "price_cents", default: 0, null: false
+    t.string "price_currency", default: "USD", null: false
+    t.boolean "registration_ticket", default: false
     t.datetime "created_at"
     t.datetime "updated_at"
   end
 
   create_table "tracks", force: :cascade do |t|
-    t.string   "guid",                                 null: false
-    t.string   "name",                                 null: false
-    t.text     "description"
-    t.string   "color"
+    t.string "guid", null: false
+    t.string "name", null: false
+    t.text "description"
+    t.string "color"
     t.datetime "created_at"
     t.datetime "updated_at"
-    t.integer  "program_id"
-    t.string   "short_name",                           null: false
-    t.string   "state",                default: "new", null: false
-    t.boolean  "cfp_active",                           null: false
-    t.integer  "submitter_id"
-    t.integer  "room_id"
-    t.date     "start_date"
-    t.date     "end_date"
-    t.text     "relevance"
-    t.integer  "selected_schedule_id"
+    t.integer "program_id"
+    t.string "short_name", null: false
+    t.string "state", default: "new", null: false
+    t.boolean "cfp_active", null: false
+    t.integer "submitter_id"
+    t.integer "room_id"
+    t.date "start_date"
+    t.date "end_date"
+    t.text "relevance"
+    t.integer "selected_schedule_id"
     t.index ["room_id"], name: "index_tracks_on_room_id"
     t.index ["selected_schedule_id"], name: "index_tracks_on_selected_schedule_id"
     t.index ["submitter_id"], name: "index_tracks_on_submitter_id"
   end
 
   create_table "users", force: :cascade do |t|
-    t.string   "email",                  default: "",    null: false
-    t.string   "encrypted_password",     default: "",    null: false
-    t.string   "reset_password_token"
+    t.string "email", default: "", null: false
+    t.string "encrypted_password", default: "", null: false
+    t.string "reset_password_token"
     t.datetime "reset_password_sent_at"
     t.datetime "remember_created_at"
-    t.integer  "sign_in_count",          default: 0
+    t.integer "sign_in_count", default: 0
     t.datetime "current_sign_in_at"
     t.datetime "last_sign_in_at"
-    t.string   "current_sign_in_ip"
-    t.string   "last_sign_in_ip"
-    t.string   "confirmation_token"
+    t.string "current_sign_in_ip"
+    t.string "last_sign_in_ip"
+    t.string "confirmation_token"
     t.datetime "confirmed_at"
     t.datetime "confirmation_sent_at"
-    t.string   "unconfirmed_email"
+    t.string "unconfirmed_email"
     t.datetime "created_at"
     t.datetime "updated_at"
-    t.string   "name"
-    t.boolean  "email_public",           default: false
-    t.text     "biography"
-    t.string   "nickname"
-    t.string   "affiliation"
-    t.string   "avatar_file_name"
-    t.string   "avatar_content_type"
-    t.integer  "avatar_file_size"
+    t.string "name"
+    t.boolean "email_public", default: false
+    t.text "biography"
+    t.string "nickname"
+    t.string "affiliation"
+    t.string "avatar_file_name"
+    t.string "avatar_content_type"
+    t.integer "avatar_file_size"
     t.datetime "avatar_updated_at"
-    t.string   "mobile"
-    t.string   "tshirt"
-    t.string   "languages"
-    t.text     "volunteer_experience"
-    t.boolean  "is_admin",               default: false
-    t.string   "username"
-    t.boolean  "is_disabled",            default: false
+    t.string "mobile"
+    t.string "tshirt"
+    t.string "languages"
+    t.text "volunteer_experience"
+    t.boolean "is_admin", default: false
+    t.string "username"
+    t.boolean "is_disabled", default: false
     t.index ["confirmation_token"], name: "index_users_on_confirmation_token", unique: true
     t.index ["email"], name: "index_users_on_email", unique: true
     t.index ["reset_password_token"], name: "index_users_on_reset_password_token", unique: true
@@ -605,55 +609,55 @@ ActiveRecord::Schema.define(version: 20181113195810) do
   end
 
   create_table "vdays", force: :cascade do |t|
-    t.integer  "conference_id"
-    t.date     "day"
-    t.text     "description"
+    t.integer "conference_id"
+    t.date "day"
+    t.text "description"
     t.datetime "created_at"
     t.datetime "updated_at"
   end
 
   create_table "venues", force: :cascade do |t|
-    t.string   "guid"
-    t.string   "name"
-    t.string   "website"
-    t.text     "description"
+    t.string "guid"
+    t.string "name"
+    t.string "website"
+    t.text "description"
     t.datetime "created_at"
     t.datetime "updated_at"
-    t.string   "photo_file_name"
-    t.string   "street"
-    t.string   "postalcode"
-    t.string   "city"
-    t.string   "country"
-    t.string   "latitude"
-    t.string   "longitude"
-    t.integer  "conference_id"
-    t.string   "picture"
+    t.string "photo_file_name"
+    t.string "street"
+    t.string "postalcode"
+    t.string "city"
+    t.string "country"
+    t.string "latitude"
+    t.string "longitude"
+    t.integer "conference_id"
+    t.string "picture"
   end
 
   create_table "versions", force: :cascade do |t|
-    t.string   "item_type",      null: false
-    t.integer  "item_id",        null: false
-    t.string   "event",          null: false
-    t.string   "whodunnit"
-    t.text     "object"
-    t.text     "object_changes"
+    t.string "item_type", null: false
+    t.integer "item_id", null: false
+    t.string "event", null: false
+    t.string "whodunnit"
+    t.text "object"
+    t.text "object_changes"
     t.datetime "created_at"
-    t.integer  "conference_id"
+    t.integer "conference_id"
     t.index ["item_type", "item_id"], name: "index_versions_on_item_type_and_item_id"
   end
 
   create_table "votes", force: :cascade do |t|
-    t.integer  "event_id"
-    t.integer  "rating"
+    t.integer "event_id"
+    t.integer "rating"
     t.datetime "created_at"
     t.datetime "updated_at"
-    t.integer  "user_id"
+    t.integer "user_id"
   end
 
   create_table "vpositions", force: :cascade do |t|
-    t.integer  "conference_id"
-    t.string   "title",         null: false
-    t.text     "description"
+    t.integer "conference_id"
+    t.string "title", null: false
+    t.text "description"
     t.datetime "created_at"
     t.datetime "updated_at"
   end

--- a/lib/tasks/set_conference_currency.rake
+++ b/lib/tasks/set_conference_currency.rake
@@ -1,0 +1,24 @@
+# frozen_string_literal: true
+
+namespace :data do
+  desc 'Sets price_currency in all pre-existing Conference records'
+  task set_conference_price_currency: :environment do
+    Conference.all.each do |conference|
+      # if ticket has price_currency it is old and needs to be updated
+      if conference.tickets.first.price_currency
+        # check all tickets have same price currency
+        ticket_pc = conference.tickets.first.price_currency
+        make_change = true
+        conference.tickets.each do |ticket|
+          make_change = false unless ticket.price_currency == ticket_pc
+        end
+      end
+      if make_change
+        conference.update(price_currency: ticket_pc)
+        puts "price currency of #{ticket_pc} set for conference: #{conference.title}."
+      else
+        puts "price currency discrepancy between tickets for conference: #{conference.title}, please check and try again."
+      end
+    end
+  end
+end


### PR DESCRIPTION
**Checklist**

- [x] I have read the [Contribution & Best practices Guide](https://github.com/openSUSE/osem/blob/master/CONTRIBUTING.md).
- [x] My branch is up-to-date with the upstream `master` branch.
- [ ] The tests pass locally with my changes.
- [x] I have added necessary documentation (if appropriate).

N.B. As I mentioned last pull request, I'm unclear how the test can be passed. The untouched master branch fails the test also so not sure what's wrong there. 

Ticket currencies - #2086

Declare the price currency of ticket when creating a conference

Add price currency to conferences and make amendments to pertinent functionality and views

- Added migration to add price_currency to conferences table
- Added select currency in form for new conference under basic info
- Changed with_model_currency: to with_currency: with a lambda that returns parent conference's currency
- Added price_currency to strong params of conference
- Created data rake task for setting existing conferences' price currency

Pull request one of two - as suggested I will hold off the removal of the price_currency from the tickets table until this is approved. Also will amend all price currency references in the various methods it's used in.