### PR TITLE
Use New Install within their own template

### DIFF
--- a/app/controllers/conferences_controller.rb
+++ b/app/controllers/conferences_controller.rb
@@ -8,6 +8,9 @@ class ConferencesController < ApplicationController
   def index
     @current    = Conference.where('end_date >= ?', Date.current).reorder(start_date: :asc)
     @antiquated = Conference.where('end_date < ?', Date.current)
+    if @antiquated.empty? && @current.empty? && User.empty?
+      render :new_install
+    end
   end
 
   def show

--- a/app/views/conferences/index.html.haml
+++ b/app/views/conferences/index.html.haml
@@ -18,8 +18,6 @@
     #antiquated.collapse
       - @antiquated.each do |conference|
         = render '/conferences/conference_details', conference: conference
-  - if @antiquated.empty? && @current.empty? && User.empty?
-    = render partial: 'new_install'
 
 -content_for :script_body do
   :javascript

--- a/app/views/conferences/new_install.html.haml
+++ b/app/views/conferences/new_install.html.haml
@@ -17,5 +17,5 @@
         will the be administrator of it.
       %p
         We hope you enjoy using OSEM, if you have any question don't hesitate to
-        = link_to('http://osem.io/#contact') do
+        = link_to('https://osem.io/#contact') do
           contact us!


### PR DESCRIPTION
It used to be a partial inside #index, but having their own page
yields some extra benefits:

- Performance: Move logic from the view to the controller
  - Theres' no need to go extra steps inside the :index view
- UI: Remove the extra 'Upcoming Conferences' when the system needs
  to start the flow of the creation of the first user

**Checklist**

- [X] I have read the [Contribution & Best practices Guide](https://github.com/openSUSE/osem/blob/master/CONTRIBUTING.md).
- [x] My branch is up-to-date with the upstream `master` branch.
- [x] The tests pass locally with my changes.
- [x] I have added tests that prove my fix is effective or that my feature works(if appropriate).
- [x] I have added necessary documentation (if appropriate).

**Short description of what this resolves/which [issues](https://github.com/openSUSE/osem/issues) does this fix?:**

Part of the issue #2555 "Streamline Conference public page"

**Changes proposed in this pull request:**

If accepted, the UI will change from this:

![20190718_osem_before](https://user-images.githubusercontent.com/1037088/61446671-0eeda580-a93f-11e9-8b08-e0e414606616.png)

To this:

![20190718_osem_after](https://user-images.githubusercontent.com/1037088/61446877-70157900-a93f-11e9-81d6-9a68632aa1ae.png)

