### PR TITLE
Update condition to pluck users for booth responsibles

### DIFF
--- a/app/helpers/application_helper.rb
+++ b/app/helpers/application_helper.rb
@@ -132,7 +132,7 @@ module ApplicationHelper
   end
 
   def user_selector_input(field, form, hint = '', multiple = true)
-    users = User.active.pluck(:id, :name, :username, :email).map { |user| [user[0], user[1].blank? ? user[2] : user[1], user[2], user[3]] }.sort_by { |user| user[1].downcase }
+    users = User.where(is_disabled: false).pluck(:id, :name, :username, :email).map { |user| [user[0], user[1].blank? ? user[2] : user[1], user[2], user[3]] }.sort_by { |user| user[1].downcase }
     form.input(
       field,
       as:            :select,


### PR DESCRIPTION
Earlier we used active scope to pluck users for booth responsibles, that allows all users except those whose last sign in is 3 months or old as well as their is_disabled field is false but now we allow all users except those with is_disabled field false to be booth responsible.


