### PR TITLE
Allow late booth/track submission

### DIFF
--- a/app/assets/javascripts/osem-datepickers.js
+++ b/app/assets/javascripts/osem-datepickers.js
@@ -32,6 +32,12 @@ $(function () {
       minDate : $("#registration-arrival-datepicker").attr('start_date')
   });
 
+  $('#invitation-end-date').datetimepicker({
+      format: 'YYYY-MM-DD',
+      maxDate : $("#invitation-end-date").attr('end_date'),
+      minDate : today
+   });
+   
   $("#registration-arrival-datepicker").on("dp.change",function (e) {
       // departure_date > start_date,arrival_date
       if ((new Date(e.date).getTime()) > (new Date($("#registration-arrival-datepicker").attr('start_date')).getTime())){

--- a/app/assets/javascripts/osem-datepickers.js
+++ b/app/assets/javascripts/osem-datepickers.js
@@ -36,8 +36,8 @@ $(function () {
       format: 'YYYY-MM-DD',
       maxDate : $("#invitation-end-date").attr('end_date'),
       minDate : today
-   });
-   
+   }).keypress(function(event) {event.preventDefault();});
+
   $("#registration-arrival-datepicker").on("dp.change",function (e) {
       // departure_date > start_date,arrival_date
       if ((new Date(e.date).getTime()) > (new Date($("#registration-arrival-datepicker").attr('start_date')).getTime())){

--- a/app/controllers/admin/invites_controller.rb
+++ b/app/controllers/admin/invites_controller.rb
@@ -1,0 +1,11 @@
+module Admin
+  class InvitesController < Admin::BaseController
+    load_and_authorize_resource :conference, find_by: :short_title
+
+    def new
+      @invite = @conference.invites.new
+    end
+
+    def create; end
+  end
+end

--- a/app/controllers/admin/invites_controller.rb
+++ b/app/controllers/admin/invites_controller.rb
@@ -2,10 +2,69 @@ module Admin
   class InvitesController < Admin::BaseController
     load_and_authorize_resource :conference, find_by: :short_title
 
+    def index
+      @invites = Invite.where(conference_id: @conference.id)
+      @invites.each do |invite|
+        invite.emails = User.find(invite.user_id).email
+      end
+    end
+
     def new
       @invite = @conference.invites.new
     end
 
-    def create; end
+    def create
+      emails_array = invite_params[:emails].split(',')
+      invite_count = 0
+      flag = 0
+      emails_array.each do |email|
+        @invite = @conference.invites.new(invite_params)
+        new_user = User.find_by(email: email)
+        new_user = User.invite!({ email: email }, current_user) if new_user.nil?
+        @invite.user_id = new_user.id
+        invite_count += 1
+        unless @invite.save
+          flash.now[:error] = "#{(invite_count - 1)} invitations created. Creating invitation failed. #{@invite.errors.full_messages.to_sentence}."
+          flag = 1
+          break
+        end
+      end
+      if flag.zero?
+        redirect_to admin_conference_invites_path, notice: "#{invite_count.to_s + ' invitation'.pluralize(invite_count)} successfully created."
+      else
+        render 'new'
+      end
+    end
+
+    def edit
+      @invite = Invite.find(params[:id])
+    end
+
+    def update
+      @invite = Invite.find(params[:id])
+      if @invite.update_attributes(invite_params)
+        redirect_to admin_conference_invites_path,
+                    notice: 'Invitation successfully updated.'
+      else
+        flash.now[:error] = "Creating invitation failed. #{@invite.errors.full_messages.to_sentence}."
+        render 'edit'
+      end
+    end
+
+    def destroy
+      if Invite.find(params[:id]).destroy
+        redirect_to admin_conference_invites_path,
+                    notice: 'Invitation deleted.'
+      else
+        redirect_to admin_conference_invites_path,
+                    notice: 'Unable to delete the invitation.'
+      end
+    end
+
+    private
+
+    def invite_params
+      params.require(:invite).permit(:emails, :end_date, :invite_for)
+    end
   end
 end

--- a/app/models/conference.rb
+++ b/app/models/conference.rb
@@ -33,6 +33,7 @@ class Conference < ApplicationRecord
   has_many :resources, dependent: :destroy
   has_many :booths, dependent: :destroy
   has_many :confirmed_booths, -> { where(state: 'confirmed') }, class_name: 'Booth'
+  has_many :invites, dependent: :destroy
 
   has_many :lodgings, dependent: :destroy
   has_many :registrations, dependent: :destroy

--- a/app/models/invite.rb
+++ b/app/models/invite.rb
@@ -1,0 +1,8 @@
+class Invite < ApplicationRecord
+  attr_accessor :emails
+  belongs_to :conference
+
+  validates :end_date, presence: true
+  validates :invite_for, presence: true
+  validates :user_id, presence: true, uniqueness: { scope: [:invite_for, :conference_id] }
+end

--- a/app/views/admin/booths/index.html.haml
+++ b/app/views/admin/booths/index.html.haml
@@ -100,3 +100,4 @@
   .col-md-12.text-right
     - if can? :create, Booth
       = link_to 'New Booth', new_admin_conference_booth_path(@conference.short_title), class: 'button btn btn-primary'
+      = link_to 'Late Submission Invite', new_admin_conference_invite_path(@conference.short_title), class: 'button btn btn-success'

--- a/app/views/admin/invites/edit.html.haml
+++ b/app/views/admin/invites/edit.html.haml
@@ -1,0 +1,11 @@
+.row
+  .col-md-12
+    .page-header
+      %h1 Edit Invitation
+
+.row
+  .col-md-8
+    = semantic_form_for(@invite, url: admin_conference_invite_path(@conference.short_title), html: { multipart: true }) do |f|
+      = f.input :invite_for, as: :select, collection: ['Track', (t 'booth').capitalize]
+      = f.input :end_date, as: :string, input_html: { id: 'invitation-end-date', end_date: @conference.end_date }
+      = f.action :submit, as: :button, button_html: { class: 'btn btn-primary' }

--- a/app/views/admin/invites/index.html.haml
+++ b/app/views/admin/invites/index.html.haml
@@ -1,0 +1,42 @@
+.row
+  .col-md-12
+    .page-header
+      %h1
+        Invitations
+
+.row
+  .col-md-12
+    - if @invites.present?
+      %table.datatable
+        %thead
+          %th
+            %b ID
+          %th
+            %b User
+          %th
+            %b Invited for
+          %th
+            %b Invitation validity
+          %th
+            %b Action
+
+        - @invites.each do |invite|
+          %tr
+            %td
+              = invite.id
+            %td
+              = invite.emails
+            %td
+              = invite.invite_for
+            %td
+              = invite.end_date
+            %td
+              = link_to 'Edit', edit_admin_conference_invite_path(@conference.short_title, invite.id),
+              class: 'btn btn-primary'
+              = link_to 'Delete', admin_conference_invite_path(@conference.short_title, invite.id), method: :delete,
+                data: { confirm: 'Are you sure?' }, class: 'btn btn-danger'
+
+.row
+  .col-md-12.text-right
+    - if can? :create, Invite
+      = link_to 'Late Submission Invite', new_admin_conference_invite_path(@conference.short_title), class: 'button btn btn-success'

--- a/app/views/admin/invites/new.html.haml
+++ b/app/views/admin/invites/new.html.haml
@@ -1,0 +1,28 @@
+.row
+  .col-md-offset-1.col-md-8
+    %h1.text-center Late Submission Invitation
+    = semantic_form_for(@invite, url: admin_conference_invites_path, html: { multipart: true }) do |f|
+      = f.input :emails, class: 'form-control', required: true,
+        hint: 'Add emails to invite people to join the app and submit requests after the cfps deadline.'
+      = f.input :invite_for, as: :select, collection: ['Track', (t 'booth').capitalize]
+      = f.input :end_date, as: :string, input_html: { id: 'invitation-end-date', end_date: @conference.end_date }
+      %p.text-right
+        = f.submit 'Submit', class: 'btn btn-success'
+
+  :javascript
+    $(document).ready(function() {
+      $('#invite_emails').selectize({
+        plugins: ['remove_button'],
+        delimiter: ',',
+        persist: false,
+        create: function(input) {
+          if (!/^\w+([\.-]?\w+)*@\w+([\.-]?\w+)*(\.\w{2,3})+$/.test(input)){
+            return {}
+          }
+          return {
+              value: input,
+              text: input
+          }
+        }
+      } )
+    });

--- a/app/views/admin/invites/new.html.haml
+++ b/app/views/admin/invites/new.html.haml
@@ -8,6 +8,7 @@
       = f.input :end_date, as: :string, input_html: { id: 'invitation-end-date', end_date: @conference.end_date }
       %p.text-right
         = f.submit 'Submit', class: 'btn btn-success'
+    = link_to 'View Invitations', admin_conference_invites_path, class: 'btn btn-primary'
 
   :javascript
     $(document).ready(function() {

--- a/app/views/admin/tracks/index.html.haml
+++ b/app/views/admin/tracks/index.html.haml
@@ -100,3 +100,4 @@
 .row
   .col-md-12.text-right
     = link_to 'New Track', new_admin_conference_program_track_path(@conference.short_title), class: 'btn btn-primary'
+    = link_to 'Late Submission Invite', new_admin_conference_invite_path(@conference.short_title), class: 'button btn btn-success'

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -45,7 +45,7 @@ Osem::Application.routes.draw do
       get '/volunteers_list' => 'volunteers#show'
       get '/volunteers' => 'volunteers#index', as: 'volunteers_info'
       patch '/volunteers' => 'volunteers#update', as: 'volunteers_update'
-
+      resources :invites
       resources :booths do
         member do
           patch :accept

--- a/db/migrate/20190810082925_create_invites.rb
+++ b/db/migrate/20190810082925_create_invites.rb
@@ -1,0 +1,12 @@
+class CreateInvites < ActiveRecord::Migration[5.2]
+  def change
+    create_table :invites do |t|
+      t.integer :conference_id
+      t.integer :user_id
+      t.date :end_date
+      t.text :invite_for
+
+      t.timestamps
+    end
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2019_06_12_161235) do
+ActiveRecord::Schema.define(version: 2019_08_10_082925) do
 
   create_table "answers", force: :cascade do |t|
     t.string "title"
@@ -262,6 +262,15 @@ ActiveRecord::Schema.define(version: 2019_06_12_161235) do
     t.integer "event_id"
     t.boolean "attended", default: false, null: false
     t.datetime "created_at"
+  end
+
+  create_table "invites", force: :cascade do |t|
+    t.integer "conference_id"
+    t.integer "user_id"
+    t.date "end_date"
+    t.text "invite_for"
+    t.datetime "created_at", null: false
+    t.datetime "updated_at", null: false
   end
 
   create_table "lodgings", force: :cascade do |t|

--- a/spec/ability/ability_spec.rb
+++ b/spec/ability/ability_spec.rb
@@ -94,7 +94,52 @@ describe 'User' do
       it{ should be_able_to(:manage, registration_public) }
       it{ should be_able_to(:manage, registration_not_public) }
 
+      context 'when user wants to submit a booth' do
+        let(:conference) { create(:conference) }
+
+        context 'when booth submission is open' do
+          before :each do
+            create(:cfp, program: conference.program, cfp_type: 'booths')
+          end
+
+          it{ should be_able_to(:new, Booth.new(conference: conference)) }
+          it{ should be_able_to(:create, Booth.new(conference: conference)) }
+        end
+
+        context 'when booth submission is closed' do
+
+          context 'when user is not invited for late booth submssion' do
+            before :each do
+              create(:cfp, program: conference.program, cfp_type: 'booths', start_date: Date.current - 6.days, end_date: Date.current - 6.days)
+            end
+
+            it{ should_not be_able_to(:new, Booth.new(conference: conference)) }
+            it{ should_not be_able_to(:create, Booth.new(conference: conference)) }
+          end
+
+          context 'when user is invited for late booth submssion' do
+            before :each do
+              create(:cfp, program: conference.program, cfp_type: 'booths', start_date: Date.current - 6.days, end_date: Date.current - 6.days)
+              create(:invite, conference_id: conference.id, invite_for: (t 'booth').capitalize.to_s, user_id: user.id, end_date: Date.current + 6.days)
+            end
+
+            it{ should be_able_to(:new, Booth.new(conference: conference)) }
+            it{ should be_able_to(:create, Booth.new(conference: conference)) }
+          end
+
+          context 'when user is invited for late booth submssion but invitation expires' do
+            before :each do
+              create(:cfp, program: conference.program, cfp_type: 'booths', start_date: Date.current - 6.days, end_date: Date.current - 6.days)
+              create(:invite, conference_id: conference.id, invite_for: (t 'booth').capitalize.to_s, user_id: user.id, end_date: Date.current - 2.days)
+            end
+
+            it{ should_not be_able_to(:new, Booth.new(conference: conference)) }
+            it{ should_not be_able_to(:create, Booth.new(conference: conference)) }
+          end
+        end
+      end
       # Test for user can register or not
+
       context 'when user is not a speaker with event confirmed' do
         let(:conference) { create(:conference) }
 

--- a/spec/controllers/admin/invites_controller_spec.rb
+++ b/spec/controllers/admin/invites_controller_spec.rb
@@ -1,0 +1,152 @@
+# frozen_string_literal: true
+
+require 'spec_helper'
+
+describe Admin::InvitesController do
+
+  let(:admin) { create(:admin) }
+  let(:conference) { create(:conference) }
+  let(:invite) { create(:invite, user_id: 1, end_date: '2019-08-12', invite_for: (t 'booth').capitalize, conference: conference) }
+
+  context 'not logged in user' do
+
+    describe 'GET index' do
+      it 'does not render admin/invites#index' do
+        get :index, params: { conference_id: conference.short_title }
+        expect(response).to redirect_to(user_session_path)
+      end
+    end
+
+    describe 'GET new' do
+      it 'does not render admin/invites#new' do
+        get :new, params: { conference_id: conference.short_title }
+        expect(response).to redirect_to(user_session_path)
+      end
+    end
+  end
+
+  context 'user is admin' do
+    before :each do
+      sign_in admin
+    end
+
+    describe 'GET index' do
+      before { get :index, params: { conference_id: conference.short_title } }
+
+      it 'renders index template' do
+        expect(response).to render_template('index')
+      end
+    end
+
+    describe 'GET new' do
+      before { get :new, params: { conference_id: conference.short_title } }
+
+      it 'assigns attributes for invite' do
+        expect(assigns(:invite)).to be_a_new(Invite)
+      end
+
+      it 'renders new template' do
+        expect(response).to render_template('new')
+      end
+    end
+
+    describe 'POST #create' do
+      context 'successfully created' do
+        before { post :create, params: { invite: attributes_for(:invite), conference_id: conference.short_title } }
+
+        it 'creates a new invite' do
+          expected = expect do
+            post :create, params: { invite: { emails: 'user1@example.com', end_date: Date.today, invite_for: (t 'booth').pluralize.to_s }, conference_id: conference.short_title }
+          end
+          expected.to change(Invite, :count).by(1)
+        end
+
+        it 'redirects to admin booth index' do
+          expect(response).to redirect_to(admin_conference_invites_path)
+        end
+
+        it 'creates a new user on inviting for late submission' do
+          expect(User.where(email: 'user@example.com')).to exist
+        end
+
+        it 'does not create a user with invalid email on inviting booth responsible' do
+          expect(User.where(email: 'example')).not_to exist
+        end
+
+        it 'invited user should be a part of invites' do
+          expect(Invite.pluck(:user_id)).to include(User.find_by(email: 'user@example.com').id)
+        end
+      end
+
+      context 'create action fails' do
+        before { post :create, params: { invite: attributes_for(:invite, emails: 'example'), conference_id: conference.short_title } }
+
+        it 'does not create any invite on invalid email' do
+          expected = expect do
+            post :create, params: { invite: attributes_for(:invite, emails: 'example'), conference_id: conference.short_title }
+          end
+          expected.to_not change(Invite, :count)
+        end
+
+        it 'does not create a duplicate invite' do
+          post :create, params: { invite: attributes_for(:invite), conference_id: conference.short_title }
+          expected = expect do
+            post :create, params: { invite: attributes_for(:invite), conference_id: conference.short_title }
+          end
+          expected.to change(Invite, :count).by(0)
+        end
+
+        it 'redirects to new' do
+          expect(response).to render_template('new')
+        end
+      end
+    end
+
+    describe 'GET #edit' do
+      before { get :edit, params: { id: invite.id, conference_id: conference.short_title } }
+
+      it 'renders edit template' do
+        expect(response).to render_template('edit')
+      end
+
+      it 'assigns booth variable' do
+        expect(assigns(:invite)).to eq invite
+      end
+    end
+
+    describe 'PATCH #update' do
+      context 'updates suchessfully' do
+        before { patch :update, params: { id: invite.id, invite: attributes_for(:invite, end_date: '2019-08-13'), conference_id: conference.short_title } }
+
+        it 'redirects to admin invite index path' do
+          expect(response).to redirect_to admin_conference_invites_path
+        end
+
+        it 'shows success message' do
+          expect(flash[:notice]).to match 'Invitation successfully updated.'
+        end
+
+        it 'updates invite' do
+          invite.reload
+          expect(invite.end_date).to eq(Date.parse('2019-08-13'))
+        end
+      end
+    end
+
+    describe 'DELETE #destroy' do
+      before { delete :destroy, params: { conference_id: conference.short_title, id: invite.id } }
+
+      it 'redirects to admin room index path' do
+        expect(response).to redirect_to admin_conference_invites_path(conference_id: conference.short_title)
+      end
+
+      it 'shows success message in flash notice' do
+        expect(flash[:notice]).to match('Invitation deleted.')
+      end
+
+      it 'deletes the room' do
+        expect(Invite.count).to eq 0
+      end
+    end
+  end
+end

--- a/spec/factories/invites.rb
+++ b/spec/factories/invites.rb
@@ -1,0 +1,9 @@
+FactoryBot.define do
+  factory :invite do
+    conference
+    emails { 'user@example.com' }
+    end_date { '2019-08-12' }
+    invite_for { (I18n.t 'booth').capitalize.to_s }
+    user_id { 1 }
+  end
+end


### PR DESCRIPTION
closes #2534 

**Checklist**

- [x] I have read the [Contribution & Best practices Guide](https://github.com/openSUSE/osem/blob/master/CONTRIBUTING.md).
- [x] My branch is up-to-date with the upstream `master` branch.
- [x] The tests pass locally with my changes.
- [x] I have added tests that prove my fix is effective or that my feature works(if appropriate).
- [x] I have added necessary documentation (if appropriate).

**Procedure**
  1. Admin will click on late submission link available on sidebar.
  2. Late submission form will be rendered.
  3. Admin enter emails of user, select type (booth/track), select date before which invited users can submit request.
  4. All the users with emails mentioned will be invited.
  5. If user already exist then no invitation will be generated but user will be able to submit booth.
  6. If user doesn't exist then invitation mail will be sent to the user.
  7. If invited user joins within the time period of late submission then request booth option will be available to the user otherwise it will not be visible.
   
**Button in booths**
![invite](https://user-images.githubusercontent.com/25618739/62809719-61bf1500-bb19-11e9-8c7c-c0126c364573.png)

**Late submission invitation form**
![form](https://user-images.githubusercontent.com/25618739/62809736-684d8c80-bb19-11e9-8543-76eb260617ee.png)

**All Invitations**
![indexinvite](https://user-images.githubusercontent.com/25618739/62822631-ca52d400-bba3-11e9-83ce-1c37eeb3f7da.png)

**Booth Request option not available to uninvited user**
![late_not_available](https://user-images.githubusercontent.com/25618739/61661253-436bb380-ace9-11e9-8fd6-fe4bb9b28b71.png)

**Booth request option available to invited user**
![late_available](https://user-images.githubusercontent.com/25618739/61661300-5a120a80-ace9-11e9-89bc-a4e9b9ed6ff1.png)

**Migration**
![late_migration](https://user-images.githubusercontent.com/25618739/61661810-a578e880-acea-11e9-9728-824cb59ccf4d.png)
