### PR TITLE
show invited users in invite responsible field

### DIFF
--- a/app/controllers/admin/booths_controller.rb
+++ b/app/controllers/admin/booths_controller.rb
@@ -50,6 +50,7 @@ module Admin
 
     def edit
       @url = admin_conference_booth_path(@conference.short_title, @booth.id)
+      @invitation_pending_emails = @booth.invited_responsibles.pluck(:email).join(',')
     end
 
     def update

--- a/app/controllers/booths_controller.rb
+++ b/app/controllers/booths_controller.rb
@@ -34,6 +34,7 @@ class BoothsController < ApplicationController
 
   def edit
     @url = conference_booth_path(@conference.short_title, @booth.id)
+    @invitation_pending_emails = @booth.invited_responsibles.pluck(:email).join(',')
   end
 
   def update

--- a/app/models/booth.rb
+++ b/app/models/booth.rb
@@ -84,4 +84,8 @@ class Booth < ApplicationRecord
     end
     alert
   end
+
+  def invited_responsibles
+    responsibles.where(last_sign_in_at: nil)
+  end
 end

--- a/app/views/admin/booths/edit.html.haml
+++ b/app/views/admin/booths/edit.html.haml
@@ -2,4 +2,4 @@
   Editing
   = @booth.title
 
-= render 'booths/form'
+= render 'booths/form', invitation_pending_emails: @invitation_pending_emails

--- a/app/views/admin/booths/new.html.haml
+++ b/app/views/admin/booths/new.html.haml
@@ -1,3 +1,3 @@
 %h1 New #{t'booth'}
 
-= render 'booths/form'
+= render 'booths/form', invitation_pending_emails: ''

--- a/app/views/admin/booths/show.html.haml
+++ b/app/views/admin/booths/show.html.haml
@@ -49,6 +49,17 @@
               = " , " unless i == @booth.responsibles.length - 1
       %tr
         %td.col-md-2
+          %b Invited Responsibles
+        %td
+          - @booth.invited_responsibles.each_with_index do |responsibles, i|
+            .responsibles
+              = link_to responsibles.name, admin_user_path(responsibles)
+              (
+              = responsibles.email
+              )
+              = " , " unless i == @booth.invited_responsibles.length - 1
+      %tr
+        %td.col-md-2
           %b Submitted on
         %td
           = @booth.created_at

--- a/app/views/booths/_form.html.haml
+++ b/app/views/booths/_form.html.haml
@@ -12,7 +12,7 @@
           hint: 'e.g. employee, comunity manager, etc'
         = f.input :website_url
         = responsibles_selector_input f
-        = f.input :invite_responsible,
+        = f.input :invite_responsible, input_html: { value: invitation_pending_emails },
           hint: "This field is to invite unregistered users using their email to become #{(t'booth_responsible').pluralize}."
         = image_tag f.object.picture.thumb.url if f.object.picture?
         = f.input :picture

--- a/app/views/booths/edit.html.haml
+++ b/app/views/booths/edit.html.haml
@@ -3,4 +3,4 @@
     Editing
     = @booth.title
 
-  = render 'form'
+  = render 'form', invitation_pending_emails: @invitation_pending_emails

--- a/app/views/booths/new.html.haml
+++ b/app/views/booths/new.html.haml
@@ -1,4 +1,4 @@
 .container
   %h1 Request a #{t'booth'}
 
-  = render 'form'
+  = render 'form', invitation_pending_emails: ''

--- a/app/views/booths/show.html.haml
+++ b/app/views/booths/show.html.haml
@@ -51,6 +51,18 @@
                 = ", " unless i == @booth.responsibles.length - 1
         %tr
           %td.col-md-2
+            %b Invited Responsibles
+          %td
+            - @booth.invited_responsibles.each_with_index do |responsibles, i|
+              .responsibles
+                = link_to responsibles.name, user_path(responsibles)
+                - if responsibles.email_public
+                  (
+                  = responsibles.email
+                  )
+                = ", " unless i == @booth.invited_responsibles.length - 1
+        %tr
+          %td.col-md-2
             %b Submitted on
           %td
             = @booth.created_at


### PR DESCRIPTION
This PR adds the following features -
1. Invited users who have not joined the app will be shown in invite responsible field.
2. The submitter will be able to remove the invited user from the edit page.

**Showing invited users in invite responsible field**
![showinvited](https://user-images.githubusercontent.com/25618739/62428317-f7bffd80-b71d-11e9-8fd4-f21be3ff1f77.png)
