### PR TITLE
Booth states can be changed in bulk

### DIFF
--- a/app/controllers/admin/booths_controller.rb
+++ b/app/controllers/admin/booths_controller.rb
@@ -115,6 +115,10 @@ module Admin
       update_state(:confirm, "#{(t 'booth').capitalize} successfully confirmed")
     end
 
+    def booths_state
+      redirect_to admin_conference_booths_path
+    end
+
     private
 
     def update_state(transition, notice)
@@ -132,7 +136,7 @@ module Admin
     def booth_params
       params.require(:booth).permit(:title, :description, :reasoning, :state, :picture, :conference_id,
                                     :created_at, :updated_at, :submitter_relationship, :website_url, :invite_responsible,
-                                    responsible_ids: [])
+                                    :current_booth_state, :new_booth_state, responsible_ids: [])
     end
   end
 end

--- a/app/models/booth.rb
+++ b/app/models/booth.rb
@@ -4,7 +4,7 @@ class Booth < ApplicationRecord
   include ActiveRecord::Transitions
   has_paper_trail ignore: [:updated_at], meta: { conference_id: :conference_id }
 
-  attr_accessor :invite_responsible
+  attr_accessor :invite_responsible, :current_booth_state, :new_booth_state
 
   belongs_to :conference
   has_many :booth_requests, dependent: :destroy

--- a/app/views/admin/booths/_change_state_dropdown.html.haml
+++ b/app/views/admin/booths/_change_state_dropdown.html.haml
@@ -10,7 +10,7 @@
       - link = "Accept #{t'booth'}"
     %li= link_to link,
     accept_admin_conference_booth_path(@conference.short_title, booth),
-    method: :patch ,id: "accept_booth_#{booth.id}",
+    method: :patch ,id: "accept_booth_#{booth.id}", class: "common_booth_#{booth.id}",
     data: (confirm_message ? { confirm: confirm_message } : nil)
 
 - if booth.transition_possible? :reject
@@ -20,30 +20,30 @@
     - link = 'Reject'
   %li= link_to link,
   reject_admin_conference_booth_path(@conference.short_title, booth),
-  method: :patch, id: "reject_booth_#{booth.id}",
+  method: :patch, id: "reject_booth_#{booth.id}", class: "common_booth_#{booth.id}",
   data: (@conference.email_settings.send_on_booths_rejection ? { confirm: 'By rejecting this booth, an email will be sent informing the submitter about the rejection. You may change the state to \'To reject\' until you are completely sure.'} : nil)
 
 - if booth.transition_possible? :to_reject
   %li= link_to "To reject #{t'booth'}",
   to_reject_admin_conference_booth_path(@conference.short_title, booth),
-  method: :patch, id: "to_reject_booth_#{booth.id}"
+  method: :patch, id: "to_reject_booth_#{booth.id}", class: "common_booth_#{booth.id}"
 
 - if booth.transition_possible? :restart
   %li= link_to 'Start review',
   restart_admin_conference_booth_path(@conference.short_title, booth),
-  method: :patch, id: "restart_booth_#{booth.id}"
+  method: :patch, id: "restart_booth_#{booth.id}", class: "common_booth_#{booth.id}"
 
 - if booth.transition_possible? :to_accept
   %li= link_to "To accept #{t'booth'}",
   to_accept_admin_conference_booth_path(@conference.short_title, booth),
-  method: :patch, id: "to_accept_booth_#{booth.id}"
+  method: :patch, id: "to_accept_booth_#{booth.id}", class: "common_booth_#{booth.id}"
 
 - if booth.transition_possible? :cancel
   %li= link_to "Cancel #{t'booth'}",
   cancel_admin_conference_booth_path(@conference.short_title, booth),
-  method: :patch, id: "cancel_booth_#{booth.id}"
+  method: :patch, id: "cancel_booth_#{booth.id}", class: "common_booth_#{booth.id}"
 
 - if booth.transition_possible? :confirm
   %li= link_to "Confirm #{t'booth'}",
   confirm_admin_conference_booth_path(@conference.short_title, booth),
-  method: :patch, id: "confirm_booth_#{booth.id}"
+  method: :patch, id: "confirm_booth_#{booth.id}", class: "common_booth_#{booth.id}"

--- a/app/views/admin/booths/index.html.haml
+++ b/app/views/admin/booths/index.html.haml
@@ -54,49 +54,71 @@
           = link_to "#{@conference.booth_limit} #{(t'booth').pluralize}", edit_admin_conference_path(@conference.short_title)
           )
     - if @booths.any?
-      %table.datatable
-        %thead
-          %th
-            %b ID
-          %th
-            %b Logo
-          %th
-            %b Title
-          %th
-            %b Submitter
-          %th
-            %b Responsibles
-          %th
-            %b State
-          %th
-            %b Actions
-        - @booths.each do |booth|
-          %tr
-            %td
-              = booth.id
-            %td
-              - if booth.logo_link
-                = image_tag(booth.picture.thumb.url, width: '20%')
-            %td
-              = link_to booth.title, admin_conference_booth_path(@conference.short_title, booth)
-            %td
-              = link_to booth.submitter.name, admin_user_path(booth.submitter) if booth.submitter
-            %td
-              .responsibles
-                - booth.responsibles.each_with_index do |responsible, i|
-                  = link_to responsible.name, admin_user_path(responsible)
-                  = ", " unless i == booth.responsibles.length - 1
-            %td
-              .btn-group
-                %button{ type: 'button', class: 'btn btn-link dropdown-toggle', 'data-toggle' => 'dropdown' }
-                  = booth.state.humanize
-                  %span.caret
-                %ul.dropdown-menu{ role: 'menu' }
-                  = render 'change_state_dropdown', booth: booth
+      %br
+      = form_for(:booth, url: admin_conference_booths_state_path) do |f|
+        .row
+          .col-md-offset-3.col-md-4
+            = f.select :new_booth_state,
+            [],
+            { include_blank: "Change same state #{(t'booth').pluralize} to other state (select #{(t'booth')} first)" }, { class: 'form-control center', onchange: 'this.form.submit()'}
+        %br
+        %table.datatable
+          %thead
+            %th
+              %b Select
+            %th
+              %b ID
+            %th
+              %b Logo
+            %th
+              %b Title
+            %th
+              %b Submitter
+            %th
+              %b Responsibles
+            %th
+              %b State
+            %th
+              %b Actions
+          - @booths.each do |booth|
+            %tr
               %td
-                = link_to 'Edit', edit_admin_conference_booth_path(@conference.short_title, booth.id),
-                class: 'btn btn-primary'
+                = f.radio_button :current_booth_state, booth.state, { onclick: "showOptions(#{booth.id})" }
+              %td
+                = booth.id
+              %td
+                - if booth.logo_link
+                  = image_tag(booth.picture.thumb.url, width: '20%')
+              %td
+                = link_to booth.title, admin_conference_booth_path(@conference.short_title, booth)
+              %td
+                = link_to booth.submitter.name, admin_user_path(booth.submitter) if booth.submitter
+              %td
+                .responsibles
+                  - booth.responsibles.each_with_index do |responsible, i|
+                    = link_to responsible.name, admin_user_path(responsible)
+                    = ", " unless i == booth.responsibles.length - 1
+              %td
+                .btn-group
+                  %button{ type: 'button', class: 'btn btn-link dropdown-toggle', 'data-toggle' => 'dropdown' }
+                    = booth.state.humanize
+                    %span.caret
+                  %ul.dropdown-menu{ role: 'menu' }
+                    = render 'change_state_dropdown', booth: booth
+                %td
+                  = link_to 'Edit', edit_admin_conference_booth_path(@conference.short_title, booth.id),
+                  class: 'btn btn-primary'
 .row
   .col-md-12.text-right
     - if can? :create, Booth
       = link_to 'New Booth', new_admin_conference_booth_path(@conference.short_title), class: 'button btn btn-primary'
+
+  :javascript
+      function showOptions(booth_id){
+        var states = document.getElementsByClassName("common_booth_" + booth_id);
+        var select_tag = $('#booth_new_booth_state');
+        $('#booth_new_booth_state option:not(:first)').remove();
+        for (var state = 0; state < states.length; state++ ){
+          select_tag.append($("<option></option>").text(states[state].textContent));
+        }
+      }

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -58,6 +58,7 @@ Osem::Application.routes.draw do
           patch :confirm
         end
       end
+      post '/booths_state' => 'booths#booths_state'
 
       resources :registrations, except: [:create, :new] do
         member do

--- a/spec/controllers/admin/booths_controller_spec.rb
+++ b/spec/controllers/admin/booths_controller_spec.rb
@@ -34,12 +34,32 @@ describe Admin::BoothsController do
     describe 'GET index' do
       before { get :index, params: { conference_id: conference.short_title } }
 
-      it 'assigns attributes for booths' do
-        expect(assigns(:booths)).to eq([booth])
+      context 'only viewing' do
+
+        it 'assigns attributes for booths' do
+          expect(assigns(:booths)).to eq([booth])
+        end
+
+        it 'renders index template' do
+          expect(response).to render_template('index')
+        end
       end
 
-      it 'renders index template' do
-        expect(response).to render_template('index')
+      context 'changing bulk state' do
+        before(:example) do
+          post :create, params: { booth: attributes_for(:booth, title: 'example1'), conference_id: conference.short_title }
+          post :create, params: { booth: attributes_for(:booth, title: 'example2'), conference_id: conference.short_title }
+          get :index, params: { conference_id: conference.short_title }
+        end
+
+        it 'before selecting state' do
+          expect(Booth.where(title: ['example1', 'example2']).pluck(:state)).to eq(['new', 'new'])
+        end
+
+        it 'after selecting state' do
+          post :booths_state, params: { booth: { current_booth_state: 'new', new_booth_state: 'Reject' }, conference_id: conference.short_title }
+          expect(Booth.where(title: ['example1', 'example2']).pluck(:state)).to eq(['rejected', 'rejected'])
+        end
       end
     end
 


### PR DESCRIPTION
closes #2574 

**Checklist**

- [x] I have read the [Contribution & Best practices Guide](https://github.com/openSUSE/osem/blob/master/CONTRIBUTING.md).
- [x] My branch is up-to-date with the upstream `master` branch.
- [x] The tests pass locally with my changes.
- [x] I have added tests that prove my fix is effective or that my feature works(if appropriate).
- [x] I have added necessary documentation (if appropriate).

**workflow**
1. Admin visit the booths#index page.
2. Select any booth from the select column.
3. Go to top select bar and select the available options. 
4. Click on the option and all the booths with the same state as that of selected booth will be changed to new state.

**Changing state together**

![ezgif com-video-to-gif](https://user-images.githubusercontent.com/25618739/62945963-66c3e300-bdfd-11e9-9014-9371b5ac7423.gif)
