### PR TITLE
sort by email if name doesnt exist

### DIFF
--- a/app/helpers/application_helper.rb
+++ b/app/helpers/application_helper.rb
@@ -132,7 +132,7 @@ module ApplicationHelper
   end
 
   def user_selector_input(field, form, hint = '', multiple = true)
-    users = User.where(is_disabled: false).pluck(:id, :name, :username, :email).map { |user| [user[0], user[1].blank? ? user[2] : user[1], user[2], user[3]] }.sort_by { |user| user[1].downcase }
+    users = User.order('LOWER(name)', :email).where(is_disabled: false).pluck(:id, :name, :username, :email).map { |user| [user[0], user[1].blank? ? user[2] : user[1], user[2], user[3]] }
     form.input(
       field,
       as:            :select,


### PR DESCRIPTION
When a user does not have a name then sort_by fails and produces an error. 
Hence, order is used to sort by name and then by email at the database level as it is more efficient than using it after the pluck.
