### PR TITLE
Add vote functionality to tracks

### DIFF
--- a/app/controllers/admin/events_controller.rb
+++ b/app/controllers/admin/events_controller.rb
@@ -47,8 +47,8 @@ module Admin
       @versions = @event.versions |
                   PaperTrail::Version.where(item_type: 'Commercial').where('object LIKE ?', "%commercialable_id: #{@event.id}\ncommercialable_type: Event%") |
                   PaperTrail::Version.where(item_type: 'Commercial').where('object_changes LIKE ?', "%commercialable_id:\n- \n- #{@event.id}\ncommercialable_type:\n- \n- Event%") |
-                  PaperTrail::Version.where(item_type: 'Vote').where('object_changes LIKE ?', "%\nevent_id:\n- \n- #{@event.id}\n%") |
-                  PaperTrail::Version.where(item_type: 'Vote').where('object LIKE ?', "%\nevent_id: #{@event.id}\n%")
+                  PaperTrail::Version.where(item_type: 'Vote').where('object_changes LIKE ?', "%votable_type:\n- \n- Event\nvotable_id:\n- \n- #{@event.id}%") |
+                  PaperTrail::Version.where(item_type: 'Vote').where('object LIKE ?', "%votable_type: Event\nvotable_id: #{@event.id}%")
     end
 
     def edit
@@ -141,7 +141,7 @@ module Admin
     def vote
       @votes = @event.votes.includes(:user)
 
-      if (votes = current_user.votes.find_by_event_id(params[:id]))
+      if (votes = current_user.votes.find_by(votable: @event))
         votes.update_attributes(rating: params[:rating])
       else
         @myvote = @event.votes.build

--- a/app/controllers/admin/tracks_controller.rb
+++ b/app/controllers/admin/tracks_controller.rb
@@ -30,6 +30,7 @@ module Admin
     end
 
     def show
+      @votes = @track.votes.includes(:user)
       respond_to do |format|
         format.html { render }
         format.json { render json: @conference.tracks.to_json }
@@ -62,6 +63,24 @@ module Admin
       else
         flash.now[:error] = "Track update failed: #{@track.errors.full_messages.join('. ')}."
         render :edit
+      end
+    end
+
+    def vote
+      @votes = @track.votes.includes(:user)
+
+      if (votes = current_user.votes.find_by(votable: @track))
+        votes.update_attributes(rating: params[:rating])
+      else
+        @myvote = @track.votes.build
+        @myvote.user = current_user
+        @myvote.rating = params[:rating]
+        @myvote.save
+      end
+
+      respond_to do |format|
+        format.html { redirect_to admin_conference_program_track_path(@conference.short_title, @track) }
+        format.js
       end
     end
 

--- a/app/models/event.rb
+++ b/app/models/event.rb
@@ -18,7 +18,7 @@ class Event < ApplicationRecord
   has_one :submitter_event_user, -> { where(event_role: 'submitter') }, class_name: 'EventUser'
   has_one  :submitter, through: :submitter_event_user, source: :user
 
-  has_many :votes, dependent: :destroy
+  has_many :votes, as: :votable
   has_many :voters, through: :votes, source: :user
   has_many :commercials, as: :commercialable, dependent: :destroy
   has_many :surveys, as: :surveyable, dependent: :destroy

--- a/app/models/vote.rb
+++ b/app/models/vote.rb
@@ -2,7 +2,7 @@
 
 class Vote < ApplicationRecord
   belongs_to :user
-  belongs_to :event
+  belongs_to :votable, polymorphic: true
 
   has_paper_trail ignore: [:updated_at], meta: { conference_id: :conference_id }
 
@@ -11,6 +11,6 @@ class Vote < ApplicationRecord
   private
 
   def conference_id
-    event.program.conference_id
+    votable.program.conference_id
   end
 end

--- a/app/views/admin/tracks/_datatable_row_rating.haml
+++ b/app/views/admin/tracks/_datatable_row_rating.haml
@@ -1,0 +1,12 @@
+- if show_votes
+  %div{ data: { toggle: 'tooltip' }, title: rating_tooltip(track, max_rating) }<
+    = rating_stars(track.average_rating, max_rating, avgrate: true)
+
+.clearfix
+  - if track.voted?(current_user)
+    %span.label.label-success
+      You voted:
+      = rating_fraction(track.user_rating(current_user), max_rating)
+  - else
+    %span.label.label-danger
+      Not rated

--- a/app/views/admin/tracks/_voting.html.haml
+++ b/app/views/admin/tracks/_voting.html.haml
@@ -1,0 +1,62 @@
+%table.table#myrating
+  - if show_votes
+    %tr
+      %td.col-md-2
+        %b Rating
+      %td
+        #{track.average_rating}/#{max_rating}
+        = rating_stars(track.average_rating, max_rating, avgrate: true)
+    %tr
+      %td
+        %b Voters
+      %td
+        = votes.length
+        - if votes.present?
+          (
+          = votes.collect(&:name).to_sentence
+          )
+  %tr
+    %td.col-md-2
+      %b Your vote
+    %td
+      - if voting_period
+        - max_rating.times do |counter|
+          - if track.user_rating(current_user) > counter
+            = link_to '', vote_admin_conference_program_track_path(conference_id, track, rating: counter + 1),
+              remote: true,
+              id: "label#{counter + 1}",
+              class: 'rating myrating bright',
+              voted: true
+          - else
+            = link_to '', vote_admin_conference_program_track_path(conference_id, track, rating: counter + 1),
+              remote: true,
+              id: "label#{counter + 1}",
+              class: 'rating myrating'
+      - else
+        = rating_stars(track.user_rating(current_user), max_rating, voted: true)
+        (Voting period is closed)
+
+  - if show_votes
+    - if votes.present?
+      - votes.each do |vote|
+        - unless vote.user_id == current_user.id
+          %tr
+            %td
+              = vote.name
+            %td
+              = rating_stars(vote.rating, max_rating)
+
+:javascript
+  $(".myrating").hover(
+    function() {    // mouseover
+        $(this).prevAll().andSelf().addClass('glow');
+    },
+    function() {  // mouseout
+        $(this).siblings().andSelf().removeClass('glow');
+    }
+  );
+
+  $(".myrating").click(function() {
+    $(this).siblings().removeClass("bright");
+    $(this).prevAll().andSelf().addClass("bright");
+  });

--- a/app/views/admin/tracks/index.html.haml
+++ b/app/views/admin/tracks/index.html.haml
@@ -37,6 +37,9 @@
         %thead
           %th ID
           %th Name
+          - if @program.rating_enabled?
+            %th
+              %b Rating
           %th Description
           %th Room
           %th Start Date
@@ -54,6 +57,12 @@
                 = link_to admin_conference_program_track_path(@conference.short_title, track), class: 'btn' do
                   %span.label{style: "background-color: #{track.color}; color: #{ contrast_color(track.color) }"}
                     = track.name
+              - if @program.rating_enabled?
+                %td.col-md-1{ data: { order: track.average_rating } }
+                  = render 'datatable_row_rating',
+                    track:      track,
+                    show_votes: @program.show_voting?,
+                    max_rating: @program.rating
               %td
                 %p
                   = markdown(truncate(track.description))

--- a/app/views/admin/tracks/show.html.haml
+++ b/app/views/admin/tracks/show.html.haml
@@ -104,6 +104,14 @@
                   %b Relevance
                 %td
                   = markdown(@track.relevance)
+            - if @conference.program.rating_enabled?
+              = render 'voting',
+                  track:         @track,
+                  show_votes:    @program.show_voting?,
+                  max_rating:    @program.rating,
+                  voting_period: @program.voting_period?,
+                  votes:         @votes,
+                  conference_id: @conference.short_title
 
     .tab-pane#events
       .col-md-12

--- a/app/views/admin/tracks/vote.js.erb
+++ b/app/views/admin/tracks/vote.js.erb
@@ -1,0 +1,10 @@
+$('table#myrating').replaceWith(
+  "<%= escape_javascript(render 'voting', \
+         track:         @track, \
+         show_votes:    @program.show_voting?, \
+         max_rating:    @program.rating, \
+         voting_period: @program.voting_period?, \
+         votes:         @votes, \
+         conference_id: @conference.short_title \
+       ) %>"
+);

--- a/app/views/admin/versions/_object_desc_and_link.html.haml
+++ b/app/views/admin/versions/_object_desc_and_link.html.haml
@@ -70,7 +70,7 @@
 
 - when 'EventsRegistration', 'Comment', 'Vote', 'Event'
   event
-  - event_id = object.try(:event_id) || object.try(:commentable_id) || object.id
+  - event_id = object.try(:votable_id) || object.try(:event_id) || object.try(:commentable_id) || object.id
   = link_to (current_or_last_object_state('Event', event_id).try(:title) || 'deleted event'),
           admin_conference_program_event_path(conference_short_title, event_id)
 

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -87,6 +87,7 @@ Osem::Application.routes.draw do
             patch :reject
             patch :cancel
             patch :update_selected_schedule
+            get :vote
           end
           resources :roles, only: [:show, :edit, :update] do
             member do

--- a/db/migrate/20190807165246_add_polymorphic_to_vote.rb
+++ b/db/migrate/20190807165246_add_polymorphic_to_vote.rb
@@ -1,0 +1,6 @@
+class AddPolymorphicToVote < ActiveRecord::Migration[5.2]
+  def change
+    add_column :votes, :votable_type, :string
+    add_column :votes, :votable_id, :integer
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2019_06_03_143107) do
+ActiveRecord::Schema.define(version: 2019_08_07_165246) do
 
   create_table "answers", force: :cascade do |t|
     t.string "title"
@@ -660,6 +660,8 @@ ActiveRecord::Schema.define(version: 2019_06_03_143107) do
     t.datetime "created_at"
     t.datetime "updated_at"
     t.integer "user_id"
+    t.string "votable_type"
+    t.integer "votable_id"
   end
 
   create_table "vpositions", force: :cascade do |t|

--- a/spec/factories/votes.rb
+++ b/spec/factories/votes.rb
@@ -2,8 +2,10 @@
 
 FactoryBot.define do
   factory :vote do
-    event
     user
     rating { 1 }
+
+    association :votable, factory: :event
+
   end
 end

--- a/spec/features/versions_spec.rb
+++ b/spec/features/versions_spec.rb
@@ -406,7 +406,7 @@ feature 'Version' do
     conference.program.rating = 1
     create(:event, program: conference.program, title: 'My first event')
     event = create(:event, program: conference.program, title: 'My second event')
-    create(:vote, user: organizer, event: event)
+    create(:vote, user: organizer, votable: event)
     Vote.last.destroy
     PaperTrail::Version.last.reify.save
 

--- a/spec/models/event_spec.rb
+++ b/spec/models/event_spec.rb
@@ -227,13 +227,13 @@ describe Event do
     end
 
     it 'returns 0 if the event has no votes from that user' do
-      create(:vote, user: another_user, event: event)
+      create(:vote, user: another_user, votable: event)
       expect(event.user_rating(user)).to eq 0
     end
 
     it 'returns the rating if the event has votes from that user' do
-      create(:vote, user: another_user, event: event, rating: 3)
-      create(:vote, user: user, event: event, rating: 2)
+      create(:vote, user: another_user, votable: event, rating: 3)
+      create(:vote, user: user, votable: event, rating: 2)
       expect(event.user_rating(user)).to eq 2
     end
   end
@@ -244,17 +244,17 @@ describe Event do
     end
 
     it 'returns false if the event has no votes by that user' do
-      create(:vote, user: another_user, event: event)
+      create(:vote, user: another_user, votable: event)
       expect(event.voted?(user)).to eq false
     end
 
     it 'returns true when the event has votes' do
-      create(:vote, user: another_user, event: event)
+      create(:vote, user: another_user, votable: event)
       expect(event.voted?).to eq true
     end
 
     it 'returns true when the event has votes by that user' do
-      create(:vote, user: user, event: event)
+      create(:vote, user: user, votable: event)
       expect(event.voted?(user)).to eq true
     end
   end
@@ -269,8 +269,8 @@ describe Event do
     context 'returns the average voting' do
       before :each do
         another_user = create(:user)
-        create(:vote, user: user, event: event, rating: 1)
-        create(:vote, user: another_user, event: event, rating: 3)
+        create(:vote, user: user, votable: event, rating: 1)
+        create(:vote, user: another_user, votable: event, rating: 3)
       end
 
       it 'when there are votes and the average is integer' do
@@ -279,7 +279,7 @@ describe Event do
 
       it 'when there are votes and the average is float' do
         new_user = create(:user)
-        create(:vote, user: new_user, event: event, rating: 3)
+        create(:vote, user: new_user, votable: event, rating: 3)
         expect(event.average_rating).to eq '2.33'
       end
     end


### PR DESCRIPTION
To help better assess track submission while working as a team it is important to have a means by which anyone involved in this process can indicate his or her preference regarding any submission.

Most often than not, there will be more submission than what can be accepted and allowing this feature for Tracks/Booths along with events helps to prioritize these submissions which would make decision making easier.


- Changed the association between `Vote` and `Event` to polymorphic and added an association between `Vote` and `Track`. 
- Added the required partials for voting and reused the event_helpers for rating stars and tooltip


![Screenshot from 2019-08-10 18-56-38](https://user-images.githubusercontent.com/26951824/62822415-b194ef00-bba0-11e9-8334-e3ba065c9ec8.png)
![Screenshot from 2019-08-10 18-56-56](https://user-images.githubusercontent.com/26951824/62822416-b2c61c00-bba0-11e9-84a9-8fb074e9248b.png)

.