### PR TITLE
Add additional fields to booth submission.

### DIFF
--- a/app/controllers/admin/booths_controller.rb
+++ b/app/controllers/admin/booths_controller.rb
@@ -132,7 +132,7 @@ module Admin
     def booth_params
       params.require(:booth).permit(:title, :description, :reasoning, :state, :picture, :conference_id,
                                     :created_at, :updated_at, :submitter_relationship, :website_url, :invite_responsible,
-                                    responsible_ids: [])
+                                    :email, :accepted_code_of_conduct, :special_requirements, responsible_ids: [])
     end
   end
 end

--- a/app/controllers/booths_controller.rb
+++ b/app/controllers/booths_controller.rb
@@ -98,6 +98,6 @@ class BoothsController < ApplicationController
   def booth_params
     params.require(:booth).permit(:title, :description, :reasoning, :state, :picture, :conference_id,
                                   :created_at, :updated_at, :submitter_relationship, :website_url, :invite_responsible,
-                                  responsible_ids: [])
+                                  :email, :accepted_code_of_conduct, :special_requirements, responsible_ids: [])
   end
 end

--- a/app/models/booth.rb
+++ b/app/models/booth.rb
@@ -25,9 +25,14 @@ class Booth < ApplicationRecord
             :state,
             :responsibles,
             :conference_id,
+            :email,
             :website_url,
             :submitter_relationship,
             presence: true
+
+  validates :accepted_code_of_conduct, acceptance: {
+    if: -> { conference.try(:code_of_conduct).present? }
+  }
 
   scope :accepted, -> { where(state: 'accepted') }
   scope :confirmed, -> { where(state: 'confirmed') }

--- a/app/models/booth.rb
+++ b/app/models/booth.rb
@@ -25,7 +25,6 @@ class Booth < ApplicationRecord
             :state,
             :responsibles,
             :conference_id,
-            :email,
             :website_url,
             :submitter_relationship,
             presence: true

--- a/app/views/admin/booths/edit.html.haml
+++ b/app/views/admin/booths/edit.html.haml
@@ -2,4 +2,4 @@
   Editing
   = @booth.title
 
-= render 'booths/form'
+= render 'booths/form', booth: @booth, conference: @conference

--- a/app/views/admin/booths/new.html.haml
+++ b/app/views/admin/booths/new.html.haml
@@ -1,3 +1,3 @@
 %h1 New #{t'booth'}
 
-= render 'booths/form'
+= render 'booths/form', booth: @booth, conference: @conference

--- a/app/views/admin/booths/show.html.haml
+++ b/app/views/admin/booths/show.html.haml
@@ -22,6 +22,11 @@
           = markdown(@booth.reasoning)
       %tr
         %td.col-md-2
+          %b Email
+        %td
+          = markdown(@booth.email)
+      %tr
+        %td.col-md-2
           %b Website
         %td
           - if @booth.website_url.present?
@@ -47,6 +52,12 @@
               = responsibles.email
               )
               = " , " unless i == @booth.responsibles.length - 1
+      %tr
+        %td.col-md-2
+          %b Special Requirements
+        %td
+          - if @booth.special_requirements.present?
+            = @booth.special_requirements
       %tr
         %td.col-md-2
           %b Submitted on

--- a/app/views/booths/_form.html.haml
+++ b/app/views/booths/_form.html.haml
@@ -10,12 +10,32 @@
         = f.input :submitter_relationship, input_html: { rows: 5, data: { provide: 'markdown-editable' } }, required: true,
           label: 'Submitter\'s relation',
           hint: 'e.g. employee, comunity manager, etc'
+        = f.input :email, hint: 'Contact email address for your stand. This will be public.'
         = f.input :website_url
         = responsibles_selector_input f
         = f.input :invite_responsible,
           hint: "This field is to invite unregistered users using their email to become #{(t'booth_responsible').pluralize}."
         = image_tag f.object.picture.thumb.url if f.object.picture?
         = f.input :picture
+
+        %p.text-right
+          = link_to '#requirements', 'data-toggle' => 'collapse' do
+            Do you have any special requirements?
+        #requirements{ class: "collapse #{ 'in' if booth.special_requirements.present? }" }
+          = f.input :special_requirements, input_html: { rows: 5 }, label: 'Requirements', placeholder: 'Eg. Whiteboard, printer, or something like that.'
+
+        - unless conference.code_of_conduct.blank?
+          - code_of_conduct_link = link_to 'Code of Conduct', '#',
+            data: { toggle: 'modal', target: '#modal-code-of-conduct'}
+          - if booth.accepted_code_of_conduct
+            = fa_icon 'check-square-o'
+            I have read and accepted the
+            = code_of_conduct_link
+          - else
+            = f.input :accepted_code_of_conduct,
+            label: "I have read and accept the #{code_of_conduct_link}".html_safe,
+            required: true
+          = render 'conferences/code_of_conduct', organization: conference.organization
 
         %p.text-right
           - if @booth.new_record?

--- a/app/views/booths/edit.html.haml
+++ b/app/views/booths/edit.html.haml
@@ -3,4 +3,4 @@
     Editing
     = @booth.title
 
-  = render 'form'
+  = render 'form', booth: @booth, conference: @conference

--- a/app/views/booths/new.html.haml
+++ b/app/views/booths/new.html.haml
@@ -1,4 +1,4 @@
 .container
   %h1 Request a #{t'booth'}
 
-  = render 'form'
+  = render 'form', booth: @booth, conference: @conference

--- a/app/views/booths/show.html.haml
+++ b/app/views/booths/show.html.haml
@@ -23,6 +23,11 @@
             = markdown(@booth.reasoning)
         %tr
           %td.col-md-2
+            %b Email
+          %td
+            = markdown(@booth.email)
+        %tr
+          %td.col-md-2
             %b Website
           %td
             - if @booth.website_url.present?
@@ -49,6 +54,12 @@
                   = responsibles.email
                   )
                 = ", " unless i == @booth.responsibles.length - 1
+        %tr
+          %td.col-md-2
+            %b Special Requirements
+          %td
+            - if @booth.special_requirements.present?
+              = @booth.special_requirements
         %tr
           %td.col-md-2
             %b Submitted on

--- a/db/migrate/20190816084920_add_additional_fields_to_booths.rb
+++ b/db/migrate/20190816084920_add_additional_fields_to_booths.rb
@@ -1,0 +1,7 @@
+class AddAdditionalFieldsToBooths < ActiveRecord::Migration[5.2]
+  def change
+    add_column :booths, :accepted_code_of_conduct, :boolean
+    add_column :booths, :email, :string
+    add_column :booths, :special_requirements, :string
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2019_06_03_143107) do
+ActiveRecord::Schema.define(version: 2019_08_16_084920) do
 
   create_table "answers", force: :cascade do |t|
     t.string "title"
@@ -39,6 +39,9 @@ ActiveRecord::Schema.define(version: 2019_06_03_143107) do
     t.integer "conference_id"
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
+    t.boolean "accepted_code_of_conduct"
+    t.string "email"
+    t.string "special_requirements"
   end
 
   create_table "cfps", force: :cascade do |t|

--- a/spec/factories/booths.rb
+++ b/spec/factories/booths.rb
@@ -7,6 +7,7 @@ FactoryBot.define do
     reasoning { Faker::Lorem.paragraph }
     website_url { Faker::Internet.url }
     submitter_relationship { Faker::Lorem.paragraph }
+    email { Faker::Internet.email }
 
     conference
 


### PR DESCRIPTION
This PR adds some additional fields in Booth/Stand submission form:
`email` : This is a public email for the stand.

`special_requirements` : This is a optional fields in case the submitter want to indicate any additional requirements that he may have such as a printer etc.

`accepted_code_of_conduct` : This is a boolean field, incase the organisation has a code of conduct it is necessary for the submitter to read and agree to it before make his submission.

Also the social media fields( perhaps also the source location/ license) would also be included in the form which the user will be able to fill upon acceptance.

![image](https://user-images.githubusercontent.com/26951824/63633828-f96d4900-c66b-11e9-84f5-dadbc4b8a855.png)

![image](https://user-images.githubusercontent.com/26951824/63633835-1d308f00-c66c-11e9-80ca-99253ab3989b.png)

