### PR TITLE
Add booth types to booths

### DIFF
--- a/app/controllers/admin/booth_types_controller.rb
+++ b/app/controllers/admin/booth_types_controller.rb
@@ -1,0 +1,55 @@
+# frozen_string_literal: true
+
+module Admin
+  class BoothTypesController < Admin::BaseController
+    load_and_authorize_resource :conference, find_by: :short_title
+    load_and_authorize_resource :program, through: :conference, singleton: true
+    load_and_authorize_resource :booth_type, through: :program
+
+    def index; end
+
+    def edit; end
+
+    def new
+      @booth_type = @conference.program.booth_types.new
+    end
+
+    def create
+      @booth_type = @conference.program.booth_types.new(booth_type_params)
+      if @booth_type.save
+        redirect_to admin_conference_program_booth_types_path(conference_id: @conference),
+                    notice: "#{(t'booth').capitalize} type successfully created."
+      else
+        flash.now[:error] = "Creating #{t 'booth'} type failed: #{@booth_type.errors.full_messages.join('. ')}."
+        render :new
+      end
+    end
+
+    def update
+      if @booth_type.update_attributes(booth_type_params)
+        redirect_to admin_conference_program_booth_types_path(conference_id: @conference),
+                    notice: "#{(t'booth').capitalize} type successfully updated."
+      else
+        flash.now[:error] = "Update #{t 'booth'} type failed: #{@booth_type.errors.full_messages.join('. ')}."
+        render :edit
+      end
+    end
+
+    def destroy
+      if @booth_type.destroy
+        redirect_to admin_conference_program_booth_types_path(conference_id: @conference),
+                    notice: "#{(t'booth').capitalize} type successfully deleted."
+      else
+        redirect_to admin_conference_program_booth_types_path(conference_id: @conference),
+                    error: "Destroying #{t 'booth'} type failed! "\
+                    "#{@booth_type.errors.full_messages.join('. ')}."
+      end
+    end
+
+    private
+
+    def booth_type_params
+      params.require(:booth_type).permit(:title, :description)
+    end
+  end
+end

--- a/app/controllers/admin/booths_controller.rb
+++ b/app/controllers/admin/booths_controller.rb
@@ -8,6 +8,7 @@ module Admin
 
     def index
       @file_name = "#{(t 'booth').pluralize}_for_#{@conference.short_title}"
+      @booth_types = @conference.program.booth_types
       @booth_export_option = params[:booth_export_option]
       respond_to do |format|
         format.html
@@ -25,7 +26,9 @@ module Admin
       end
     end
 
-    def show; end
+    def show
+      @booth_types = @conference.program.booth_types
+    end
 
     def new
       @url = admin_conference_booths_path(@conference.short_title)
@@ -130,7 +133,7 @@ module Admin
     end
 
     def booth_params
-      params.require(:booth).permit(:title, :description, :reasoning, :state, :picture, :conference_id,
+      params.require(:booth).permit(:title, :description, :reasoning, :state, :picture, :conference_id, :booth_type_id,
                                     :created_at, :updated_at, :submitter_relationship, :website_url, :invite_responsible,
                                     responsible_ids: [])
     end

--- a/app/controllers/booths_controller.rb
+++ b/app/controllers/booths_controller.rb
@@ -96,7 +96,7 @@ class BoothsController < ApplicationController
   private
 
   def booth_params
-    params.require(:booth).permit(:title, :description, :reasoning, :state, :picture, :conference_id,
+    params.require(:booth).permit(:title, :description, :reasoning, :state, :picture, :conference_id, :booth_type_id,
                                   :created_at, :updated_at, :submitter_relationship, :website_url, :invite_responsible,
                                   responsible_ids: [])
   end

--- a/app/helpers/events_helper.rb
+++ b/app/helpers/events_helper.rb
@@ -73,6 +73,21 @@ module EventsHelper
     active_dropdown(selection, options)
   end
 
+  def booth_type_dropdown(booth, booth_types, conference_id)
+    selection = booth.booth_type.try(:title) || 'Booth Type'
+    options = booth_types.collect do |booth_type|
+      [
+        booth_type.title,
+        admin_conference_booth_path(
+          conference_id,
+          booth,
+          booth: { booth_type_id: booth_type.id }
+        )
+      ]
+    end
+    active_dropdown(selection, options)
+  end
+
   def track_dropdown(event, tracks, conference_id)
     selection = event.track.try(:name) || 'Track'
     options = tracks.collect do |track|

--- a/app/models/admin_ability.rb
+++ b/app/models/admin_ability.rb
@@ -102,6 +102,7 @@ class AdminAbility
     signed_in_with_organizer_role(user, conf_ids_for_organization_admin)
   end
 
+  # rubocop:disable Metrics/AbcSize
   def signed_in_with_organizer_role(user, conf_ids_for_organization_admin = [])
     # ids of all the conferences for which the user has the 'organizer' role and
     # conferences that belong to organizations for which user is 'organization_admin'
@@ -131,6 +132,7 @@ class AdminAbility
     can :manage, Cfp, program: { conference_id: conf_ids }
     can :manage, Event, program: { conference_id: conf_ids }
     can :manage, EventType, program: { conference_id: conf_ids }
+    can :manage, BoothType, program: { conference_id: conf_ids }
     can :manage, Track, program: { conference_id: conf_ids }
     can :manage, DifficultyLevel, program: { conference_id: conf_ids }
     can :manage, Commercial, commercialable_type: 'Event',
@@ -163,6 +165,7 @@ class AdminAbility
     can [:index, :revert_object, :revert_attribute], PaperTrail::Version, item_type: 'User'
     can [:index, :revert_object, :revert_attribute], PaperTrail::Version, conference_id: conf_ids
   end
+  # rubocop:enable Metrics/AbcSize
 
   def signed_in_with_cfp_role(user)
     # ids of all the conferences for which the user has the 'cfp' role
@@ -175,6 +178,7 @@ class AdminAbility
     can :manage, Booth, conference_id: conf_ids_for_cfp
     can :manage, Event, program: { conference_id: conf_ids_for_cfp }
     can :manage, EventType, program: { conference_id: conf_ids_for_cfp }
+    can :manage, BoothType, program: { conference_id: conf_ids_for_cfp }
     can :manage, Track, program: { conference_id: conf_ids_for_cfp }
     can :manage, DifficultyLevel, program: { conference_id: conf_ids_for_cfp }
     can :manage, EmailSettings, conference_id: conf_ids_for_cfp
@@ -201,7 +205,7 @@ class AdminAbility
     end
 
     can [:index, :revert_object, :revert_attribute], PaperTrail::Version,
-        item_type: %w[Event EventType Track DifficultyLevel EmailSettings Room Cfp Program Comment], conference_id: conf_ids_for_cfp
+        item_type: %w[Event EventType BoothType Track DifficultyLevel EmailSettings Room Cfp Program Comment], conference_id: conf_ids_for_cfp
     can [:index, :revert_object, :revert_attribute], PaperTrail::Version,
         ["item_type = 'Commercial' AND conference_id IN (?) AND (object LIKE '%Event%' OR object_changes LIKE '%Event%')", conf_ids_for_cfp] do |version|
       version.item_type == 'Commercial' && conf_ids_for_cfp.include?(version.conference_id) &&

--- a/app/models/booth.rb
+++ b/app/models/booth.rb
@@ -7,6 +7,7 @@ class Booth < ApplicationRecord
   attr_accessor :invite_responsible
 
   belongs_to :conference
+  belongs_to :booth_type
   has_many :booth_requests, dependent: :destroy
   has_many :users, through: :booth_requests
 

--- a/app/models/booth_type.rb
+++ b/app/models/booth_type.rb
@@ -1,0 +1,17 @@
+# frozen_string_literal: true
+
+class BoothType < ApplicationRecord
+  belongs_to :program, touch: true
+  has_many :booths, dependent: :restrict_with_error
+
+  has_paper_trail meta:   { conference_id: :conference_id },
+                  ignore: %i[updated_at]
+
+  validates :title, presence: true
+
+  private
+
+  def conference_id
+    program.conference_id
+  end
+end

--- a/app/models/conference.rb
+++ b/app/models/conference.rb
@@ -52,6 +52,7 @@ class Conference < ApplicationRecord
            through: :program,
            source:  :events
   has_many :event_types, through: :program
+  has_many :booth_types, through: :program
 
   has_many :surveys, as: :surveyable, dependent: :destroy do
     def for_registration

--- a/app/models/program.rb
+++ b/app/models/program.rb
@@ -9,6 +9,7 @@ class Program < ApplicationRecord
 
   has_many :cfps, dependent: :destroy
   has_many :event_types, dependent: :destroy
+  has_many :booth_types, dependent: :destroy
   has_many :tracks, dependent: :destroy
   has_many :difficulty_levels, dependent: :destroy
   has_many :schedules, dependent: :destroy

--- a/app/views/admin/booth_types/_form.html.haml
+++ b/app/views/admin/booth_types/_form.html.haml
@@ -1,0 +1,17 @@
+.row
+  .col-md-12
+    .page-header
+      %h1
+        - if booth_type.new_record?
+          New
+        #{(t'booth').capitalize} Type
+        = booth_type.title
+.row
+  .col-md-12
+    = semantic_form_for(booth_type,
+     url: (booth_type.new_record? ? admin_conference_program_booth_types_path : admin_conference_program_booth_type_path(conference,
+     booth_type))) do |f|
+      = f.input :title, input_html: { autofocus: true }
+      = f.input :description
+      %p.text-right
+        = f.action :submit, as: :button, button_html: { class: 'btn btn-primary' }

--- a/app/views/admin/booth_types/_form.html.haml
+++ b/app/views/admin/booth_types/_form.html.haml
@@ -4,7 +4,7 @@
       %h1
         - if booth_type.new_record?
           New
-        #{(t'booth').capitalize} Type
+        #{(t 'booth').capitalize} Type
         = booth_type.title
 .row
   .col-md-12

--- a/app/views/admin/booth_types/edit.html.haml
+++ b/app/views/admin/booth_types/edit.html.haml
@@ -1,0 +1,2 @@
+= render 'form', booth_type: @booth_type, conference: @conference
+

--- a/app/views/admin/booth_types/index.html.haml
+++ b/app/views/admin/booth_types/index.html.haml
@@ -1,0 +1,29 @@
+.row
+  .col-md-12
+    .page-header
+      %h1 #{(t'booth').capitalize} Types
+      %p.text-muted
+        The different types of #{(t 'booth').pluralize} in your conference
+.row
+  .col-md-12
+    %table.table.table-hover#track-types
+      %thead
+        %th Title
+        %th Description
+        %th Actions
+      %tbody
+        - @conference.program.booth_types.each do |booth_type|
+          %tr
+            %td
+              = booth_type.title
+            %td
+              = booth_type.description
+            %td
+              .btn-group{ role: 'group' }
+                = link_to 'Edit', edit_admin_conference_program_booth_type_path(@conference.short_title, booth_type.id),
+                method: :get, class: 'btn btn-primary'
+                = link_to 'Delete', admin_conference_program_booth_type_path(@conference.short_title, booth_type.id),
+                method: :delete, class: 'btn btn-danger', data: { confirm: "Do you really want to delete #{booth_type.title}?" }
+.row
+  .col-md-12.text-right
+    = link_to "Add #{(t'booth').capitalize} Type", new_admin_conference_program_booth_type_path(@conference.short_title), class: 'btn btn-primary'

--- a/app/views/admin/booth_types/index.html.haml
+++ b/app/views/admin/booth_types/index.html.haml
@@ -1,7 +1,7 @@
 .row
   .col-md-12
     .page-header
-      %h1 #{(t'booth').capitalize} Types
+      %h1 #{(t 'booth').capitalize} Types
       %p.text-muted
         The different types of #{(t 'booth').pluralize} in your conference
 .row
@@ -26,4 +26,4 @@
                 method: :delete, class: 'btn btn-danger', data: { confirm: "Do you really want to delete #{booth_type.title}?" }
 .row
   .col-md-12.text-right
-    = link_to "Add #{(t'booth').capitalize} Type", new_admin_conference_program_booth_type_path(@conference.short_title), class: 'btn btn-primary'
+    = link_to "Add #{(t 'booth').capitalize} Type", new_admin_conference_program_booth_type_path(@conference.short_title), class: 'btn btn-primary'

--- a/app/views/admin/booth_types/new.html.haml
+++ b/app/views/admin/booth_types/new.html.haml
@@ -1,0 +1,1 @@
+= render 'form', booth_type: @booth_type, conference: @conference

--- a/app/views/admin/booths/edit.html.haml
+++ b/app/views/admin/booths/edit.html.haml
@@ -2,4 +2,4 @@
   Editing
   = @booth.title
 
-= render 'booths/form'
+= render 'booths/form', conference: @conference

--- a/app/views/admin/booths/index.html.haml
+++ b/app/views/admin/booths/index.html.haml
@@ -63,6 +63,8 @@
           %th
             %b Title
           %th
+            %b Type
+          %th
             %b Submitter
           %th
             %b Responsibles
@@ -79,6 +81,8 @@
                 = image_tag(booth.picture.thumb.url, width: '20%')
             %td
               = link_to booth.title, admin_conference_booth_path(@conference.short_title, booth)
+            %td
+              = booth_type_dropdown(booth, @booth_types, @conference.short_title)
             %td
               = link_to booth.submitter.name, admin_user_path(booth.submitter) if booth.submitter
             %td

--- a/app/views/admin/booths/new.html.haml
+++ b/app/views/admin/booths/new.html.haml
@@ -1,3 +1,3 @@
 %h1 New #{t'booth'}
 
-= render 'booths/form'
+= render 'booths/form', conference: @conference

--- a/app/views/admin/booths/show.html.haml
+++ b/app/views/admin/booths/show.html.haml
@@ -22,6 +22,11 @@
           = markdown(@booth.reasoning)
       %tr
         %td.col-md-2
+          %b Type
+        %td
+          = booth_type_dropdown(@booth, @booth_types, @conference.short_title)
+      %tr
+        %td.col-md-2
           %b Website
         %td
           - if @booth.website_url.present?

--- a/app/views/booths/_form.html.haml
+++ b/app/views/booths/_form.html.haml
@@ -13,7 +13,7 @@
 
         = f.input :booth_type_id, as: :select,
           collection: conference.program.booth_types.map {|type| ["#{type.title}", type.id]},
-          include_blank: false, label: 'Type', input_html: { class: 'select-help-toggle' } if conference.program.booth_types.any?
+          include_blank: 'Please select a type ...', label: 'Type', input_html: { class: 'select-help-toggle' } if conference.program.booth_types.any?
 
         - conference.program.booth_types.each do |booth_type|
           %span{ class: 'help-block select-help-text booth_booth_type_id collapse', id: "#{booth_type.id}-help" }

--- a/app/views/booths/_form.html.haml
+++ b/app/views/booths/_form.html.haml
@@ -10,6 +10,14 @@
         = f.input :submitter_relationship, input_html: { rows: 5, data: { provide: 'markdown-editable' } }, required: true,
           label: 'Submitter\'s relation',
           hint: 'e.g. employee, comunity manager, etc'
+
+        = f.input :booth_type_id, as: :select,
+          collection: conference.program.booth_types.map {|type| ["#{type.title}", type.id]},
+          include_blank: false, label: 'Type', input_html: { class: 'select-help-toggle' } if conference.program.booth_types.any?
+
+        - conference.program.booth_types.each do |booth_type|
+          %span{ class: 'help-block select-help-text booth_booth_type_id collapse', id: "#{booth_type.id}-help" }
+            = booth_type.description
         = f.input :website_url
         = responsibles_selector_input f
         = f.input :invite_responsible,

--- a/app/views/booths/edit.html.haml
+++ b/app/views/booths/edit.html.haml
@@ -3,4 +3,4 @@
     Editing
     = @booth.title
 
-  = render 'form'
+  = render 'form', conference: @conference

--- a/app/views/booths/new.html.haml
+++ b/app/views/booths/new.html.haml
@@ -1,4 +1,4 @@
 .container
   %h1 Request a #{t'booth'}
 
-  = render 'form'
+  = render 'form', conference: @conference

--- a/app/views/booths/show.html.haml
+++ b/app/views/booths/show.html.haml
@@ -23,6 +23,11 @@
             = markdown(@booth.reasoning)
         %tr
           %td.col-md-2
+            %b Type
+          %td
+            = @booth.booth_type.title
+        %tr
+          %td.col-md-2
             %b Website
           %td
             - if @booth.website_url.present?

--- a/app/views/layouts/_admin_sidebar.html.haml
+++ b/app/views/layouts/_admin_sidebar.html.haml
@@ -121,6 +121,10 @@
       = link_to  admin_conference_booths_path(@conference.short_title) do
         %span.fa.fa-shopping-bag
         = (t'booth').pluralize.capitalize
+      %ul
+        - if can? :update, @conference.program.booth_types.build
+          %li{class: active_nav_li(admin_conference_program_booth_types_path(@conference))}
+            = link_to "#{(t'booth').pluralize.capitalize} Types", admin_conference_program_booth_types_path(@conference.short_title)
   - if can? :update, @conference.email_settings
     %li{class: active_nav_li(admin_conference_emails_path(@conference.short_title))}
       = link_to(admin_conference_emails_path(@conference.short_title)) do

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -95,6 +95,7 @@ Osem::Application.routes.draw do
           end
         end
         resources :event_types
+        resources :booth_types
         resources :difficulty_levels
         post 'mass_upload_commercials' => 'commercials#mass_upload'
         resources :events do

--- a/db/migrate/20190817094930_create_booth_types.rb
+++ b/db/migrate/20190817094930_create_booth_types.rb
@@ -1,0 +1,12 @@
+class CreateBoothTypes < ActiveRecord::Migration[5.2]
+  def change
+    create_table :booth_types do |t|
+      t.references :program
+      t.string :title, null: false
+      t.string :description
+
+      t.timestamps
+    end
+    add_reference :booths, :booth_type, index: true
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2019_06_03_143107) do
+ActiveRecord::Schema.define(version: 2019_08_17_094930) do
 
   create_table "answers", force: :cascade do |t|
     t.string "title"
@@ -28,6 +28,15 @@ ActiveRecord::Schema.define(version: 2019_06_03_143107) do
     t.index ["user_id"], name: "index_booth_requests_on_user_id"
   end
 
+  create_table "booth_types", force: :cascade do |t|
+    t.integer "program_id"
+    t.string "title", null: false
+    t.string "description"
+    t.datetime "created_at", null: false
+    t.datetime "updated_at", null: false
+    t.index ["program_id"], name: "index_booth_types_on_program_id"
+  end
+
   create_table "booths", force: :cascade do |t|
     t.string "title"
     t.text "description"
@@ -39,6 +48,8 @@ ActiveRecord::Schema.define(version: 2019_06_03_143107) do
     t.integer "conference_id"
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
+    t.integer "booth_type_id"
+    t.index ["booth_type_id"], name: "index_booths_on_booth_type_id"
   end
 
   create_table "cfps", force: :cascade do |t|


### PR DESCRIPTION
In certain cases we need a type field for stands which could be dropdown from which the user can choose.
In case of FOSDEM it could be 'one table' or 'two table', these may not be the same for all conferences and may even change from year to year therefore it should be customisable.

Screenshots:
![Screenshot from 2019-08-17 18-21-04](https://user-images.githubusercontent.com/26951824/63212093-42c61180-c11d-11e9-9500-da236849467e.png)
![Screenshot from 2019-08-17 18-21-11](https://user-images.githubusercontent.com/26951824/63212094-43f73e80-c11d-11e9-8472-c1c9170ee4e9.png)
![Screenshot from 2019-08-17 18-21-31](https://user-images.githubusercontent.com/26951824/63212096-46f22f00-c11d-11e9-9f80-6d9895a5cade.png)
![Screenshot from 2019-08-17 18-23-46](https://user-images.githubusercontent.com/26951824/63212097-48bbf280-c11d-11e9-99da-ed8bd86e1923.png)

