### PR TITLE
add condition for booth rejection mail

### DIFF
--- a/app/controllers/admin/booths_controller.rb
+++ b/app/controllers/admin/booths_controller.rb
@@ -92,7 +92,9 @@ module Admin
       @booth.reject!
 
       if @booth.save
-        Mailbot.conference_booths_rejection_mail(@booth).deliver_later
+        if @conference.email_settings.send_on_booths_rejection
+          Mailbot.conference_booths_rejection_mail(@booth).deliver_later
+        end
         redirect_to admin_conference_booths_path(conference_id: @conference.short_title),
                     notice: "#{(t'booth').capitalize} successfully rejected."
       else


### PR DESCRIPTION
Add a condition to send email only when "send_on_booths_rejection" is true. At present, an email is sent whenever a booth is rejected not depending on whether "send_on_booths_rejection" is true or false.

