### PR TITLE
Resolve CVE-2019-16892 with rubyzip 1.3.0

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -508,7 +508,7 @@ GEM
     ruby_dep (1.5.0)
     ruby_parser (3.11.0)
       sexp_processor (~> 4.9)
-    rubyzip (1.2.2)
+    rubyzip (1.3.0)
     safe_yaml (1.0.4)
     sass (3.7.2)
       sass-listen (~> 4.0.0)


### PR DESCRIPTION
re: https://hakiri.io/github/openSUSE/osem/master/eb6319a8eb390e68aaae68aab9374bde5ca1718c/warnings?name=Denial+of+Service
