### PR TITLE
Supports talks without speakers

### DIFF
--- a/app/models/event.rb
+++ b/app/models/event.rb
@@ -44,7 +44,6 @@ class Event < ApplicationRecord
   validates :abstract, presence: true
   validates :event_type, presence: true
   validates :program, presence: true
-  validates :speakers, presence: true
   validates :max_attendees, numericality: { only_integer: true, greater_than_or_equal_to: 1, allow_nil: true }
 
   validate :max_attendees_no_more_than_room_size

--- a/app/views/admin/events/_datatable_row.haml
+++ b/app/views/admin/events/_datatable_row.haml
@@ -24,11 +24,15 @@
         Unknown submitter
 
     %td
-      - event.speakers_ordered.each do |speaker|
-        .speaker
-          = link_to speaker.name, admin_user_path(speaker)
-          - unless speaker.registrations.for_conference(event.conference)
-            %span.label.label-danger Unregistered
+      - if event.speakers.any?
+        - event.speakers_ordered.each do |speaker|
+          .speaker
+            = link_to speaker.name, admin_user_path(speaker)
+            - unless speaker.registrations.for_conference(event.conference)
+              %span.label.label-danger Unregistered
+      - else
+        .small
+          No Speaker
 
     - if @program.languages.present?
       %td

--- a/app/views/admin/events/show.html.haml
+++ b/app/views/admin/events/show.html.haml
@@ -69,9 +69,10 @@
               %span{ 'class' => [icon_for_todo(progress_status['registered']), 'fa-lg'] }
           %tr
             %td
-              - if @event.speakers.count == 1
+              - speakers_count = @event.speakers.count
+              - if speakers_count == 1
                 = link_to 'Fill out speaker\'s biography', edit_admin_user_path(@event.speakers.first)
-              - else
+              - elsif speakers_count > 1
                 Fill out speaker's biography:
                 = speaker_links(@event)
             %td{ 'class' => class_for_todo(progress_status['biographies']) }

--- a/app/views/admin/reports/_all_events.html.haml
+++ b/app/views/admin/reports/_all_events.html.haml
@@ -27,10 +27,14 @@
           %td
             = link_to event.title, edit_admin_conference_program_event_path(@conference.short_title, event)
             %br
-            .small
-              (Presented by
-              = speaker_links(event)
-              )
+            - if(event.speakers.any?)
+              .small
+                (Presented by
+                = speaker_links(event)
+                )
+            - else
+              .small
+                (No speaker)
 
           - %w(registered biographies commercials subtitle difficulty_level).each do |info|
             %td{'data-order' => "#{progress_status[info]}"}

--- a/app/views/admin/reports/_events_without_commercials.html.haml
+++ b/app/views/admin/reports/_events_without_commercials.html.haml
@@ -18,4 +18,8 @@
           %td= event.id
           %td= link_to event.title, edit_admin_conference_program_event_path(@conference.short_title, event)
           %td
-            = speaker_links(event)
+            - if(event.speakers.any?)
+              = speaker_links(event)
+            - else
+              .small
+                (No speaker)

--- a/app/views/proposals/show.html.haml
+++ b/app/views/proposals/show.html.haml
@@ -27,27 +27,28 @@
   .row
     .col-md-3
       %h3
+      - if event.speakers.any?
         Presented by:
-      - @speakers_ordered.each do |speaker|
-        .speakerinfo
-          .row
-            .col-md-4
-              = image_tag speaker.gravatar_url(:size => 120), class: 'img-responsive img-rounded'
-            .col-md-8
-              %h4
-                = link_to speaker.name, user_path(speaker.id)
-                %br
-                - if speaker.email_public?
-                  = mail_to "#{ speaker.email }" do
-                    %i.fa.fa-envelope-o.fa-2x
-              - if speaker.affiliation?
-                .text-muted
-                  from
-                  = speaker.affiliation
-          -if speaker.biography?
-            .row.speakerbio
-              .col-md-12
-                = markdown(speaker.biography)
+        - @speakers_ordered.each do |speaker|
+          .speakerinfo
+            .row
+              .col-md-4
+                = image_tag speaker.gravatar_url(:size => 120), class: 'img-responsive img-rounded'
+              .col-md-8
+                %h4
+                  = link_to speaker.name, user_path(speaker.id)
+                  %br
+                  - if speaker.email_public?
+                    = mail_to "#{ speaker.email }" do
+                      %i.fa.fa-envelope-o.fa-2x
+                - if speaker.affiliation?
+                  .text-muted
+                    from
+                    = speaker.affiliation
+            -if speaker.biography?
+              .row.speakerbio
+                .col-md-12
+                  = markdown(speaker.biography)
     .col-md-9
       .row
         .col-md-12

--- a/app/views/schedules/_event.html.haml
+++ b/app/views/schedules/_event.html.haml
@@ -15,7 +15,8 @@
       %small
         = event.subtitle
     %h4
-      presented by #{event.speaker_names}
+      - if(event.speakers.any?)
+        presented by #{event.speaker_names}
     %p
       = markdown(truncate(event.abstract, length: 400))
       = link_to 'more', conference_program_proposal_path(@conference.short_title, event.id) if event.abstract.length > 400


### PR DESCRIPTION
Admins may want to have discussions or any other general activity
that does not have any particular speaker. Thus, speaker validation
is removed.

Closes https://github.com/openSUSE/osem/issues/2520


