### PR TITLE
Revert change of active user definition

### DIFF
--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -34,7 +34,7 @@ class User < ApplicationRecord
   scope :comment_notifiable, ->(conference) {joins(:roles).where('roles.name IN (?)', [:organizer, :cfp]).where('roles.resource_type = ? AND roles.resource_id = ?', 'Conference', conference.id)}
 
   # scopes for user distributions
-  scope :active, lambda {
+  scope :recent, lambda {
     where('last_sign_in_at > ?', Date.today - 3.months).where(is_disabled: false)
   }
   scope :unconfirmed, -> { where('confirmed_at IS NULL') }
@@ -86,6 +86,9 @@ class User < ApplicationRecord
   accepts_nested_attributes_for :roles
 
   scope :admin, -> { where(is_admin: true) }
+  scope :active, lambda {
+    where(is_disabled: false)
+  }
 
   validates :email, presence: true
 
@@ -174,7 +177,7 @@ class User < ApplicationRecord
   # * +hash+ -> hash
   def self.distribution
     {
-      'Active'      => User.active.count,
+      'Active'      => User.recent.count,
       'Unconfirmed' => User.unconfirmed.count,
       'Dead'        => User.dead.count
     }

--- a/spec/models/user_spec.rb
+++ b/spec/models/user_spec.rb
@@ -101,9 +101,9 @@ describe User do
     end
 
     describe 'user distribution scopes' do
-      it 'scopes active users' do
+      it 'scopes recent users' do
         create(:user, last_sign_in_at: Date.today - 3.months + 1.day) # active
-        expect(User.active.count).to eq(1)
+        expect(User.recent.count).to eq(1)
       end
 
       it 'scopes unconfirmed users' do


### PR DESCRIPTION
Closes #2560

Active users are needed for selectize, and the active definition changed to show recent users in #2297

This reverts that change, and provides
* active scope (user not disabled)
* recent scope (for use in #2297 changes, ie user distribution)

**Checklist**

- [ ] I have read the [Contribution & Best practices Guide](https://github.com/openSUSE/osem/blob/master/CONTRIBUTING.md).
- [ ] My branch is up-to-date with the upstream `master` branch.
- [ ] The tests pass locally with my changes.
- [ ] I have added tests that prove my fix is effective or that my feature works(if appropriate).
- [ ] I have added necessary documentation (if appropriate).

**Short description of what this resolves/which [issues](https://github.com/openSUSE/osem/issues) does this fix?:**

<!-- List the issue number resolved with this change; if there is no open issue, describe the problem this request solves -->

Selectize does not bring all the users it used to (and should) which is all users that are not disabled. 
More detailed explanation in https://github.com/openSUSE/osem/issues/2560

**Changes proposed in this pull request:**

<!-- Summarize the changes, using declarative language. -->

- Use **recent** scope for the distribution introduced in https://github.com/openSUSE/osem/pull/2297
- Keep recent scope for its previous use
