### PR TITLE
fixes redirect loop

### DIFF
--- a/app/controllers/users/omniauth_callbacks_controller.rb
+++ b/app/controllers/users/omniauth_callbacks_controller.rb
@@ -35,8 +35,7 @@ module Users
         openid.save!
 
         sign_in user
-        redirect_to request.env['omniauth.origin'] || root_path,
-                    notice: "#{user.email} signed in successfully with #{provider}"
+        redirect_to root_path, notice: "#{user.email} signed in successfully with #{provider}"
       rescue => e
         flash[:error] = e.message
         redirect_back_or_to new_user_registration_path

--- a/app/views/proposals/show.html.haml
+++ b/app/views/proposals/show.html.haml
@@ -27,7 +27,7 @@
   .row
     .col-md-3
       %h3
-      - if event.speakers.any?
+      - if @event.speakers.any?
         Presented by:
         - @speakers_ordered.each do |speaker|
           .speakerinfo


### PR DESCRIPTION

**Checklist**

- [x] I have read the [Contribution & Best practices Guide](https://github.com/openSUSE/osem/blob/master/CONTRIBUTING.md).
- [x] My branch is up-to-date with the upstream `master` branch.
- [x] The tests pass locally with my changes.
- [ ] I have added tests that prove my fix is effective or that my feature works(if appropriate).
- [ ] I have added necessary documentation (if appropriate).

**Short description of what this resolves/which [issues](https://github.com/openSUSE/osem/issues) does this fix?:**

Redirecting users to `/account/sign_in` caused a redirect loop which crashed the page, but still adds them to the `users` table correctly.. Forcing users to the `root_path` solves the redirect loop.

<!-- List the issue number resolved with this change; if there is no open issue, describe the problem this request solves -->

- Fixes #2618 

**Changes proposed in this pull request:**

<!-- Summarize the changes, using declarative language. -->

- Redirect users back to `root_app` line 38 of `app/controllers/users/omniauth_callbacks_controller.rb` to solve a redirect loop caused by sending the omniauth flow back to `account/sign_in`. 


