### PR TITLE
DRY on controllers/conferences_controller#index

### DIFF
--- a/app/controllers/conferences_controller.rb
+++ b/app/controllers/conferences_controller.rb
@@ -6,8 +6,8 @@ class ConferencesController < ApplicationController
   load_and_authorize_resource find_by: :short_title, except: :show
 
   def index
-    @current    = Conference.where('end_date >= ?', Date.current).reorder(start_date: :asc)
-    @antiquated = Conference.where('end_date < ?', Date.current)
+    @current    = Conference.upcoming.reorder(start_date: :asc)
+    @antiquated = Conference.past
     if @antiquated.empty? && @current.empty? && User.empty?
       render :new_install
     end


### PR DESCRIPTION
Conferences.incoming is defined on the model as scope:

`scope :upcoming, (-> { where('end_date >= ?', Date.current) })`

Conference.past

`scope :past, (-> { where('end_date < ?', Date.current) })`

**Checklist**

- [x] I have read the [Contribution & Best practices Guide](https://github.com/openSUSE/osem/blob/master/CONTRIBUTING.md).
- [x] My branch is up-to-date with the upstream `master` branch.
- [x] The tests pass locally with my changes.
- [x] I have added tests that prove my fix is effective or that my feature works(if appropriate).
- [x] I have added necessary documentation (if appropriate).


**Short description of what this resolves/which [issues](https://github.com/openSUSE/osem/issues) does this fix?:**

Remove the duplication on controller#index
This is part of #2555 