### PR TITLE
Explicitly configure database authentication in Docker Compose

### DIFF
--- a/INSTALL.md
+++ b/INSTALL.md
@@ -37,7 +37,7 @@ There is a rudimentary docker-compose configuration for production usage (`docke
 
 
 1. Configure OSEM
-   You have at least to set `SECRET_KEY_BASE`
+   You have at least to set `OSEM_DB_PASSWORD` and `SECRET_KEY_BASE`
    ```
    cp dotenv.example .env.production
    vim .env.production

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -5,6 +5,7 @@ services:
     image: postgres
     environment:
       PGDATA: /var/lib/postgresql/data/pgdata
+      POSTGRES_PASSWORD: $OSEM_DB_PASSWORD
   osem:
     build:
       context: .

--- a/docker-compose.yml.production-example
+++ b/docker-compose.yml.production-example
@@ -5,6 +5,7 @@ services:
     image: postgres
     environment:
       PGDATA: /var/lib/postgresql/data/pgdata
+      POSTGRES_PASSWORD: $OSEM_DB_PASSWORD
     volumes:
       - osem_production_database:/var/lib/postgresql/data/pgdata
   production_web:


### PR DESCRIPTION
### Checklist

- [x] I have read the [Contribution & Best practices Guide](https://github.com/openSUSE/osem/blob/master/CONTRIBUTING.md).
- [x] My branch is up-to-date with the upstream `master` branch.
- [ ] The tests pass locally with my changes.
- [ ] I have added tests that prove my fix is effective or that my feature works(if appropriate).
- [x] I have added necessary documentation (if appropriate).

### Short description of what this resolves

The PostgreSQL Docker image [now requires](https://github.com/docker-library/postgres/pull/658) explicit configuration of the authentication method.

```console
$ docker-compose up database
Creating network "osem_default" with the default driver
Creating osem_database_1 ... done
Attaching to osem_database_1
database_1  | Error: Database is uninitialized and superuser password is not specified.
database_1  |        You must specify POSTGRES_PASSWORD to a non-empty value for the
database_1  |        superuser. For example, "-e POSTGRES_PASSWORD=password" on "docker run".
database_1  |
database_1  |        You may also use "POSTGRES_HOST_AUTH_METHOD=trust" to allow all
database_1  |        connections without a password. This is *not* recommended.
database_1  |
database_1  |        See PostgreSQL documentation about "trust":
database_1  |        https://www.postgresql.org/docs/current/auth-trust.html
osem_database_1 exited with code 1
```

### Changes proposed in this pull request

Expect that `OSEM_DB_PASSWORD` is set, and configure PostgreSQL to use that.