### PR TITLE
Use version range instead of OSEM_RUBY_VERSION.

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -2,7 +2,7 @@
 
 source 'https://rubygems.org'
 
-ruby ENV['OSEM_RUBY_VERSION'] || '2.5.0'
+ruby '~> 2.5.0'
 
 # rails-assets requires >= 1.8.4
 if Gem::Version.new(Bundler::VERSION) < Gem::Version.new('1.8.4')

--- a/dotenv.example
+++ b/dotenv.example
@@ -32,9 +32,6 @@
 # OSEM_MEMCACHED_USERNAME='root'
 # OSEM_MEMCACHED_PASSWORD='1234'
 
-# The ruby version to use
-# OSEM_RUBY_VERSION=2.5.0
-
 # What time is it?
 # OSEM_TIME_ZONE="UTC"
 


### PR DESCRIPTION
### Checklist

- [x] I have read the [Contribution & Best practices Guide](https://github.com/openSUSE/osem/blob/master/CONTRIBUTING.md).
- [x] My branch is up-to-date with the upstream `master` branch.
- [ ] The tests pass locally with my changes.
- [ ] I have added tests that prove my fix is effective or that my feature works (if appropriate).
- [ ] I have added necessary documentation (if appropriate).

### Short description of what this resolves

In order to accommodate variation in the version of Ruby across environments, the Gemfile is currently runtime-configurable via `OSEM_RUBY_VERSION`:

https://github.com/openSUSE/osem/blob/e6f3aa559ea4c3850035c2c2b7ae9aea26bb4ed3/Gemfile#L5

This mechanism is incompatible with typical Docker environments since, by design, the runtime configuration has no effect on builds:

```console
$ docker-compose build osem
…
Your Ruby version is 2.5.5, but your Gemfile specified 2.5.0
```

Furthermore, that it's apparently become routine to circumvent the Ruby specification raises the question of why that constraint exists at all. If users are typically expected to set `OSEM_RUBY_VERSION`, what purpose does the Ruby specification serve?

### Changes proposed in this pull request

As with the other dependencies, specify a range of compatible versions. I've guessed at a conservative starting point:

```ruby
ruby '~> 2.5.0'
```