### PR TITLE
Install missing test dependency in base image

### DIFF
--- a/Dockerfile.base
+++ b/Dockerfile.base
@@ -17,7 +17,7 @@ RUN zypper -n install --no-recommends \
     # as ruby
     ruby2.5-devel \
     # as browser for feature tests
-    chromium
+    chromium xorg-x11-fonts
 
 # Setup sudo
 RUN echo 'osem ALL=(ALL) NOPASSWD: ALL' >> /etc/sudoers


### PR DESCRIPTION
### Checklist

- [x] I have read the [Contribution & Best practices Guide](https://github.com/openSUSE/osem/blob/master/CONTRIBUTING.md).
- [x] My branch is up-to-date with the upstream `master` branch.
- [ ] The tests pass locally with my changes.
- [ ] I have added tests that prove my fix is effective or that my feature works (if appropriate).
- [ ] I have added necessary documentation (if appropriate).

### Short description of what this resolves

In the base Docker image, Chromium crashes due to a missing dependency:

```console
$ docker run --rm osem/base chromium --no-sandbox --headless
…
[0328/183640.873642:FATAL:platform_font_skia.cc(97)] Check failed: InitDefaultFont(). Could not find the default font
```

### Changes proposed in this pull request

Install `xorg-x11-fonts`.