### PR TITLE
Resolve conflict between WebMock and Webdrivers

### DIFF
--- a/spec/support/external_request.rb
+++ b/spec/support/external_request.rb
@@ -2,7 +2,10 @@
 
 # Mock external requests to youtube
 require 'webmock/rspec'
-WebMock.disable_net_connect!(allow_localhost: true, allow: /stripe.com/)
+driver_urls = Webdrivers::Common.subclasses.map do |driver|
+  Addressable::URI.parse(driver.base_url).host
+end
+WebMock.disable_net_connect!(allow_localhost: true, allow: [*driver_urls, /stripe.com/])
 
 RSpec.configure do |config|
   config.before(:each) do


### PR DESCRIPTION
### Checklist

- [x] I have read the [Contribution & Best practices Guide](https://github.com/openSUSE/osem/blob/master/CONTRIBUTING.md).
- [x] My branch is up-to-date with the upstream `master` branch.
- [ ] The tests pass locally with my changes.
- [ ] I have added tests that prove my fix is effective or that my feature works(if appropriate).
- [ ] I have added necessary documentation (if appropriate).

### Short description of what this resolves

Webdrivers attempts to automatically install/update ChromeDriver, but WebMock blocks it, causing tests to fail (#2557):

```console
$ docker-compose run --rm osem bundle exec rake db:bootstrap
$ docker-compose run --rm osem bundle exec rspec --fail-fast --tag js
…
          WebMock::NetConnectNotAllowedError:
            Real HTTP connections are disabled. Unregistered request: GET https://chromedriver.storage.googleapis.com/LATEST_RELEASE_80.0.3987 …
```

### Changes proposed in this pull request

Whitelist the update URLs, as in titusfortner/webdrivers#109.