### PR TITLE
Work around ChromeDriver/Chromium crash

### DIFF
--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -78,12 +78,10 @@ RSpec.configure do |config|
   end
 
   Capybara.register_driver :chrome_headless do |app|
-    capabilities = Selenium::WebDriver::Remote::Capabilities.chrome(
-      chromeOptions: { args: %w(headless disable-gpu window-size=1920x1080 no-sandbox) }
+    options = Selenium::WebDriver::Chrome::Options.new(
+      args: %w(headless disable-gpu window-size=1920x1080 no-sandbox)
     )
-    Capybara::Selenium::Driver.new(
-      app, browser: :chrome, desired_capabilities: capabilities
-    )
+    Capybara::Selenium::Driver.new(app, browser: :chrome, options: options)
   end
 
   Capybara.default_max_wait_time = 10 # seconds


### PR DESCRIPTION
### Checklist

- [x] I have read the [Contribution & Best practices Guide](https://github.com/openSUSE/osem/blob/master/CONTRIBUTING.md).
- [x] My branch is up-to-date with the upstream `master` branch.
- [ ] The tests pass locally with my changes.
- [ ] I have added tests that prove my fix is effective or that my feature works(if appropriate).
- [ ] I have added necessary documentation (if appropriate).

### Short description of what this resolves

Chromium crashes during tests. I don't understand why.

```console
$ docker-compose run --rm osem bundle exec rake db:bootstrap
$ docker-compose run --rm osem bundle exec rspec --fail-fast --tag js
…
          Selenium::WebDriver::Error::UnknownError:
            unknown error: Chrome failed to start: exited abnormally.
              (unknown error: DevToolsActivePort file doesn't exist)
              (The process started from chrome location /usr/bin/chromium is no longer running, so ChromeDriver is assuming that Chrome has crashed.)
```

### Changes proposed in this pull request

Configuring ChromeDriver via `Chrome::Options` instead of `Capabilities` seems to work around the problem. 🤷

If nothing else, doing it this way is consistent with ChromeDriver's [recommendation](https://chromedriver.chromium.org/capabilities#TOC-List-of-recognized-capabilities):

> If possible, use the `ChromeOptions` class instead of specifying these directly.