### PR TITLE
Decouple tests from unspecified data ordering

### DIFF
--- a/spec/controllers/admin/roles_controller_spec.rb
+++ b/spec/controllers/admin/roles_controller_spec.rb
@@ -91,7 +91,7 @@ describe Admin::RolesController do
                                      user:          { email: 'user1@osem.io' },
                                      id:            'organizer' }
 
-        expect(user1.roles).to eq [organizer_role, cfp_role]
+        expect(user1.roles).to contain_exactly(cfp_role, organizer_role)
       end
     end
 
@@ -109,7 +109,7 @@ describe Admin::RolesController do
                                      user:          { email: 'user1@osem.io' },
                                      id:            'organizer' }
 
-        expect(user1.roles).to eq [organizer_role, cfp_role]
+        expect(user1.roles).to contain_exactly(cfp_role, organizer_role)
 
         post :toggle_user, params: { conference_id: conference.short_title,
                                      user:          { email: 'user1@osem.io', state: 'false' },

--- a/spec/controllers/api/v1/conferences_controller_spec.rb
+++ b/spec/controllers/api/v1/conferences_controller_spec.rb
@@ -21,8 +21,7 @@ describe Api::V1::ConferencesController do
     end
 
     it 'returns correct conferences' do
-      expect(@json[0]['short_title']).to eq('conf_one')
-      expect(@json[1]['short_title']).to eq('conf_two')
+      expect(@json.map { |c| c['short_title'] }).to contain_exactly('conf_one', 'conf_two')
     end
   end
 

--- a/spec/controllers/api/v1/events_controller_spec.rb
+++ b/spec/controllers/api/v1/events_controller_spec.rb
@@ -15,9 +15,7 @@ describe Api::V1::EventsController do
         json = JSON.parse(response.body)['events']
         expect(response).to be_success
 
-        expect(json.length).to eq(2)
-        expect(json[0]['title']).to eq('Example Event')
-        expect(json[1]['title']).to eq('Conference Event')
+        expect(json.map { |e| e['title'] }).to contain_exactly('Conference Event', 'Example Event')
       end
     end
 

--- a/spec/features/roles_spec.rb
+++ b/spec/features/roles_spec.rb
@@ -66,7 +66,7 @@ feature Role do
     scenario "removes role #{role_name}", feature: true, js: true do
       click_link('Users', href: admin_conference_role_path(conference.short_title, role_name))
 
-      bootstrap_switch = first('td').find('.bootstrap-switch-container')
+      bootstrap_switch = find('tr', text: user_with_role.name).find('.bootstrap-switch-container')
       bootstrap_switch.click
 
       expect(page).to have_css('.alert', text: "Successfully removed role #{role_name} from user #{user_with_role.email}")


### PR DESCRIPTION
### Checklist

- [x] I have read the [Contribution & Best practices Guide](https://github.com/openSUSE/osem/blob/master/CONTRIBUTING.md).
- [x] My branch is up-to-date with the upstream `master` branch.
- [ ] The tests pass locally with my changes.
- [ ] I have added tests that prove my fix is effective or that my feature works(if appropriate).
- [ ] I have added necessary documentation (if appropriate).

### Short description of what this resolves

Various tests accidentally depended on unspecified data ordering, and passed [with SQLite](https://github.com/openSUSE/osem/issues/2256) but failed intermittently with PostgreSQL.

### Changes proposed in this pull request

- Test data independently of ordering.
- Avoid accessing the global version history.