### PR TITLE
Surveys: Grooming of messages to user

### DIFF
--- a/app/views/surveys/show.html.haml
+++ b/app/views/surveys/show.html.haml
@@ -26,3 +26,8 @@
       .row
         .col-md-10.col-md-offset-1
           = f.submit 'Submit', class: 'btn btn-primary pull-right', disabled: !(can? :reply, @survey)
+          .pull-left
+            - if @survey.during_registration?
+              = link_to 'Back to Registration', conference_conference_registration_path(@conference)
+            - elsif @survey.after_event?
+              = link_to 'Back', conference_program_proposal_path(@conference, @survey.surveyable)


### PR DESCRIPTION
**Checklist**

- [x] I have read the [Contribution & Best practices Guide](https://github.com/openSUSE/osem/blob/master/CONTRIBUTING.md).
- [x] My branch is up-to-date with the upstream `master` branch.
- [ ] The tests pass locally with my changes.
- [ ] I have added tests that prove my fix is effective or that my feature works(if appropriate).
- [ ] I have added necessary documentation (if appropriate).

**Short description of what this resolves/which [issues](https://github.com/openSUSE/osem/issues) does this fix?:**

<!-- List the issue number resolved with this change; if there is no open issue, describe the problem this request solves -->

https://github.com/openSUSE/osem/issues/2639

**Changes proposed in this pull request:**

<!-- Summarize the changes, using declarative language. -->

* Groom error message when survey is closed
* Add flash success and error message for when user replies
* Show **Back** link (for surveys `during_registration` and `after_event`)
