### PR TITLE
Ignore schema.rb in RuboCop

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -2,6 +2,10 @@ require: rubocop-rspec
 
 inherit_from: .rubocop_todo.yml
 
+inherit_mode:
+  merge:
+    - Exclude
+
 AllCops:
   UseCache: true
   CacheRootDirectory: tmp/rubocop_cache_rails_dir

--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -6,6 +6,8 @@ AllCops:
   UseCache: true
   CacheRootDirectory: tmp/rubocop_cache_rails_dir
   MaxFilesInCache: 4000
+  Exclude:
+    - db/schema.rb
 
 #################### Style ###########################
 

--- a/.rubocop_todo.yml
+++ b/.rubocop_todo.yml
@@ -1155,7 +1155,6 @@ Style/StringLiterals:
     - 'config/deploy.rb'
     - 'config/environments/production.rb'
     - 'config/puma.rb'
-    - 'db/schema.rb'
     - 'lib/tasks/dump_db.rake'
     - 'lib/tasks/events_registrations.rake'
     - 'lib/tasks/factory_bot.rake'


### PR DESCRIPTION
### Checklist

- [x] I have read the [Contribution & Best practices Guide](https://github.com/openSUSE/osem/blob/master/CONTRIBUTING.md).
- [x] My branch is up-to-date with the upstream `master` branch.
- [x] The tests pass locally with my changes.
- [ ] I have added tests that prove my fix is effective or that my feature works(if appropriate).
- [ ] I have added necessary documentation (if appropriate).

### Short description of what this resolves

Rails now [formats](https://github.com/rails/rails/pull/28678) the schema version for readability, but RuboCop doesn't understand this usage:

```console
$ docker-compose run --rm osem bundle exec rubocop -Dc .rubocop.yml
…
db/schema.rb:13:38: C: Style/NumericLiterals: Use underscores(_) as thousands separator and separate every 3 digits with them.
ActiveRecord::Schema.define(version: 2020_03_31_214534) do
                                     ^^^^^^^^^^^^^^^^^
```

### Changes proposed in this pull request

Ignore it.