### PR TITLE
Fix bug in UserDatatable query affecting PostgreSQL

### DIFF
--- a/app/datatables/user_datatable.rb
+++ b/app/datatables/user_datatable.rb
@@ -47,10 +47,12 @@ class UserDatatable < AjaxDatatablesRails::Base
   end
   # rubocop:enable Naming/AccessorMethodName
 
+  # Workaround for jbox-web/ajax-datatables-rails#293
   def records_total_count
     fetch_records.unscope(:group).count(:all)
   end
 
+  # Workaround for jbox-web/ajax-datatables-rails#293
   def records_filtered_count
     filter_records(fetch_records).unscope(:group).count(:all)
   end

--- a/app/datatables/user_datatable.rb
+++ b/app/datatables/user_datatable.rb
@@ -49,12 +49,12 @@ class UserDatatable < AjaxDatatablesRails::Base
 
   # Workaround for jbox-web/ajax-datatables-rails#293
   def records_total_count
-    fetch_records.unscope(:group).count(:all)
+    fetch_records.unscope(:group, :select).count(:all)
   end
 
   # Workaround for jbox-web/ajax-datatables-rails#293
   def records_filtered_count
-    filter_records(fetch_records).unscope(:group).count(:all)
+    filter_records(fetch_records).unscope(:group, :select).count(:all)
   end
 
   # ==== These methods represent the basic operations to perform on records


### PR DESCRIPTION
### Checklist

- [x] I have read the [Contribution & Best practices Guide](https://github.com/openSUSE/osem/blob/master/CONTRIBUTING.md).
- [x] My branch is up-to-date with the upstream `master` branch.
- [x] The tests pass locally with my changes.
- [ ] I have added tests that prove my fix is effective or that my feature works (if appropriate).
- [ ] I have added necessary documentation (if appropriate).

### Short description of what this resolves

The current workaround to jbox-web/ajax-datatables-rails#293 results in an invalid query on PostgreSQL:

```console
$ docker-compose run --rm osem bundle exec rspec ./spec/datatables/user_datatable_spec.rb:97
…
     Failure/Error: fetch_records.unscope(:group).count(:all)

     ActiveRecord::StatementInvalid:
       PG::GroupingError: ERROR:  column "users.id" must appear in the GROUP BY clause or be used in an aggregate function
       LINE 1: SELECT COUNT(*) FROM (SELECT DISTINCT users.*, COUNT(CASE WH...
                                                     ^
```

### Changes proposed in this pull request

Unscope both the custom `select` and `group` when counting, not just `group`.