### PR TITLE
Remove superfluous click to display Markdown editor

### DIFF
--- a/app/views/admin/cfps/_form.html.haml
+++ b/app/views/admin/cfps/_form.html.haml
@@ -17,7 +17,7 @@
         input_html: { class: 'form-control',
           id: 'registration-period-end-datepicker' }
       = f.input :description, hint: markdown_hint,
-        input_html: { rows: 2, data: { provide: 'markdown-editable' } }
+        input_html: { rows: 2, data: { provide: 'markdown' } }
       - if cfp.cfp_type == 'events'
         = f.input :enable_registrations, as: :boolean,
           hint: 'Allow submitters to request registration?'

--- a/app/views/admin/conferences/edit.html.haml
+++ b/app/views/admin/conferences/edit.html.haml
@@ -9,7 +9,7 @@
     = semantic_form_for(@conference, url: admin_conference_path(@conference.short_title), html: {multipart: true}) do |f|
       = f.input :title, hint: "The full title of the conference, e.g. 'openSUSE Conference 2014'"
       = f.input :short_title, hint: "A short title, e.g. 'oSC14', to be used in URLs"
-      = f.input :description, hint: markdown_hint('A description of the conference.'), input_html: { rows: 5, data: { provide: 'markdown-editable' } }
+      = f.input :description, hint: markdown_hint('A description of the conference.'), input_html: { rows: 5, data: { provide: 'markdown' } }
       = f.input :color, hint: 'The color will be used eg for the dashboard.', input_html: {size: 6, type: 'color'}
       = f.label 'Conference Logo'
       %br

--- a/app/views/admin/lodgings/_form.html.haml
+++ b/app/views/admin/lodgings/_form.html.haml
@@ -11,7 +11,7 @@
     = semantic_form_for(@lodging, url: (@lodging.new_record? ? admin_conference_lodgings_path : admin_conference_lodging_path(@conference.short_title, @lodging))) do |f|
       = f.input :name, input_html: { autofocus: true}
       = f.input :website_link, input_html: { type: :url }
-      = f.input :description, input_html: { rows: 5, cols: 20, data: { provide: 'markdown-editable' } }, hint: markdown_hint
+      = f.input :description, input_html: { rows: 5, cols: 20, data: { provide: 'markdown' } }, hint: markdown_hint
       - if @lodging.picture?
         = image_tag @lodging.picture.thumb.url
       = f.input :picture

--- a/app/views/admin/organizations/_form.html.haml
+++ b/app/views/admin/organizations/_form.html.haml
@@ -2,11 +2,11 @@
   = f.inputs name: 'Organization details' do
     = f.input :name, as: :string, required: true
     = f.input :description, as: :text,
-      input_html: { rows: 10, data: { provide: 'markdown-editable' } },
+      input_html: { rows: 10, data: { provide: 'markdown' } },
       hint: markdown_hint,
       placeholder: 'Decribe about your organization...'
     = f.input :code_of_conduct, as: :text,
-      input_html: { rows: 10, data: { provide: 'markdown-editable' } },
+      input_html: { rows: 10, data: { provide: 'markdown' } },
       hint: markdown_hint,
       placeholder: 'Rules governing behavior and dispute resolution...'
     = image_tag f.object.picture.thumb.url if f.object.picture?

--- a/app/views/admin/resources/_form.html.haml
+++ b/app/views/admin/resources/_form.html.haml
@@ -9,7 +9,7 @@
   .col-md-8
     = semantic_form_for(@resource, :url => (@resource.new_record? ? admin_conference_resources_path : admin_conference_resource_path(@conference.short_title, @resource))) do |f|
       = f.input :name, input_html: { autofocus: true }
-      = f.input :description, input_html: { rows: 5, data: { provide: 'markdown-editable' } }
+      = f.input :description, input_html: { rows: 5, data: { provide: 'markdown' } }
       = f.input :used
       = f.input :quantity
       %p.text-right

--- a/app/views/admin/sponsors/_form.html.haml
+++ b/app/views/admin/sponsors/_form.html.haml
@@ -10,7 +10,7 @@
   .col-md-8
     = semantic_form_for(@sponsor, url: (@sponsor.new_record? ? admin_conference_sponsors_path : admin_conference_sponsor_path(@conference.short_title, @sponsor))) do |f|
       = f.input :name, input_html: { autofocus: true }
-      = f.input :description, input_html: { rows: 5, cols: 20, data: { provide: 'markdown-editable' } }, hint: markdown_hint
+      = f.input :description, input_html: { rows: 5, cols: 20, data: { provide: 'markdown' } }, hint: markdown_hint
       = image_tag f.object.picture.thumb.url if f.object.picture?
       = f.input :picture
       = f.input :website_url

--- a/app/views/admin/tickets/_form.html.haml
+++ b/app/views/admin/tickets/_form.html.haml
@@ -10,7 +10,7 @@
   .col-md-8
     = semantic_form_for(@ticket, url: (@ticket.new_record? ? admin_conference_tickets_path : admin_conference_ticket_path(@conference.short_title, @ticket))) do |f|
       = f.input :title, input_html: { autofocus: true }
-      = f.input :description, input_html: { rows: 5, data: { provide: 'markdown-editable' } }
+      = f.input :description, input_html: { rows: 5, data: { provide: 'markdown' } }
       = f.input :price
       = f.input :price_currency, as: :select, class: 'form-control', collection: ['USD', 'EUR', 'GBP', 'INR', 'CNY', 'CHF'], include_blank: false
       = f.input :registration_ticket, hint: 'A registration ticket is with which user register for the conference.'

--- a/app/views/admin/tracks/_form.html.haml
+++ b/app/views/admin/tracks/_form.html.haml
@@ -23,6 +23,6 @@
           with
           = link_to 'rooms', admin_conference_venue_rooms_path(@conference.short_title)
           , if you want to select a room for the track.
-      = f.input :description, input_html: {rows: 2, data: { provide: 'markdown-editable' } }, hint: markdown_hint
+      = f.input :description, input_html: {rows: 2, data: { provide: 'markdown' } }, hint: markdown_hint
       = f.input :cfp_active, label: 'Allow event submitters to select this track for their proposal'
       = f.action :submit, as: :button, button_html: { class: 'btn btn-primary' }

--- a/app/views/admin/users/_form.html.haml
+++ b/app/views/admin/users/_form.html.haml
@@ -20,7 +20,7 @@
     = f.input :email
     = f.input :password if @user.new_record?
     = f.input :affiliation, as: :string
-    = f.input :biography, input_html: { rows: 10, data: { provide: 'markdown-editable' } },
+    = f.input :biography, input_html: { rows: 10, data: { provide: 'markdown' } },
       hint: markdown_hint
   = f.actions do
     = f.action :submit, button_html: {class: 'btn btn-primary'}

--- a/app/views/admin/venues/_form.html.haml
+++ b/app/views/admin/venues/_form.html.haml
@@ -14,7 +14,7 @@
       .col-md-8
         = semantic_form_for(@venue, url: admin_conference_venue_path(@conference.short_title)) do |f|
           = f.inputs :name, :website
-          = f.input :description, input_html: { rows: 5, cols: 20, data: { provide: 'markdown-editable' } }, hint: markdown_hint
+          = f.input :description, input_html: { rows: 5, cols: 20, data: { provide: 'markdown' } }, hint: markdown_hint
           = f.label 'Venue Logo'
           %br
           - if @venue.picture?

--- a/app/views/booths/_form.html.haml
+++ b/app/views/booths/_form.html.haml
@@ -3,11 +3,11 @@
     .col-md-8
       = semantic_form_for(@booth,  url: @url, html: { multipart: true }) do |f|
         = f.input :title, as: :string, input_html: { autofocus: true }, required: true
-        = f.input :description, input_html: { rows: 5, data: { provide: 'markdown-editable' } }, required: true,
+        = f.input :description, input_html: { rows: 5, data: { provide: 'markdown' } }, required: true,
           hint: 'This field becomes public upon request acceptance'
-        = f.input :reasoning, input_html: { rows: 5, data: { provide: 'markdown-editable' } }, required: true,
+        = f.input :reasoning, input_html: { rows: 5, data: { provide: 'markdown' } }, required: true,
           label: 'How it fits the conference'
-        = f.input :submitter_relationship, input_html: { rows: 5, data: { provide: 'markdown-editable' } }, required: true,
+        = f.input :submitter_relationship, input_html: { rows: 5, data: { provide: 'markdown' } }, required: true,
           label: 'Submitter\'s relation',
           hint: 'e.g. employee, comunity manager, etc'
         = f.input :website_url

--- a/app/views/proposals/_proposal_form.html.haml
+++ b/app/views/proposals/_proposal_form.html.haml
@@ -29,7 +29,7 @@
       %span{ class: 'help-block select-help-text collapse event_difficulty_level_id', id: "#{difficulty_level.id}-help" }
         = difficulty_level.description
 
-    = f.input :abstract, required: true, input_html: { rows: 5, data: { provide: 'markdown-editable' } },
+    = f.input :abstract, required: true, input_html: { rows: 5, data: { provide: 'markdown' } },
       hint: markdown_hint('[Tips to improve your presentations.](http://blog.hubspot.com/blog/tabid/6307/bid/5975/10-Rules-to-Instantly-Improve-Your-Presentations.aspx)')
 
     %p

--- a/app/views/proposals/new.html.haml
+++ b/app/views/proposals/new.html.haml
@@ -45,7 +45,7 @@
                 %span{ class: 'help-block event_event_type_id collapse', id: "#{event_type.id}-help" }
                   = event_type.description
 
-              = f.input :abstract, required: true, input_html: { rows: 5, data: { provide: 'markdown-editable' } },
+              = f.input :abstract, required: true, input_html: { rows: 5, data: { provide: 'markdown' } },
                 hint: markdown_hint('[Tips to improve your presentations.](http://blog.hubspot.com/blog/tabid/6307/bid/5975/10-Rules-to-Instantly-Improve-Your-Presentations.aspx)')
 
               %p

--- a/app/views/tracks/_form.html.haml
+++ b/app/views/tracks/_form.html.haml
@@ -15,6 +15,6 @@
         = f.input :color, input_html: {size: 6, type: 'color'}, required: true
         = f.input :start_date, as: :string, input_html: { id: 'registration-period-start-datepicker', start_date: @conference.start_date, end_date: @conference.end_date, readonly: 'readonly' }
         = f.input :end_date, as: :string, input_html: { id: 'registration-period-end-datepicker', readonly: 'readonly' }
-        = f.input :description, input_html: {rows: 2, data: { provide: 'markdown-editable' } }, required: true, hint: "This will be public #{markdown_hint}".html_safe
-        = f.input :relevance, input_html: {rows: 5, data: { provide: 'markdown-editable' } }, required: true, hint: "Please explain here how this track relates to the conference, how you are related to its content and why we should accept it. #{markdown_hint}".html_safe
+        = f.input :description, input_html: {rows: 2, data: { provide: 'markdown' } }, required: true, hint: "This will be public #{markdown_hint}".html_safe
+        = f.input :relevance, input_html: {rows: 5, data: { provide: 'markdown' } }, required: true, hint: "Please explain here how this track relates to the conference, how you are related to its content and why we should accept it. #{markdown_hint}".html_safe
         = f.action :submit, as: :button, button_html: { class: 'btn btn-primary' }

--- a/app/views/users/edit.html.haml
+++ b/app/views/users/edit.html.haml
@@ -14,7 +14,7 @@
         = link_to 'Change your avatar here', 'https://gravatar.com'
         = f.input :affiliation, as: :string,
           hint: 'This could be a company, a user group, or nothing at all.'
-        = f.input :biography, input_html: { rows: 5, data: { provide: 'markdown-editable' } },
+        = f.input :biography, input_html: { rows: 5, data: { provide: 'markdown' } },
           hint: markdown_hint
         You have used
         %span#bio_length


### PR DESCRIPTION
### Checklist

- [x] I have read the [Contribution & Best practices Guide](https://github.com/openSUSE/osem/blob/master/CONTRIBUTING.md).
- [x] My branch is up-to-date with the upstream `master` branch.
- [ ] The tests pass locally with my changes.
- [ ] I have added tests that prove my fix is effective or that my feature works (if appropriate).
- [ ] I have added necessary documentation (if appropriate).

### Short description of what this resolves

The Markdown editor offers [two modes](https://www.taufanaditya.com/bootstrap-markdown/) of loading, intended for either text fields or "inline" editing of page content.

OSEM is currently applying the inline mode to text fields, which has the effect that initially only the bare text field is displayed, and clicking it causes it to be replaced by the editor. This behavior is jarring, breaks focus (requiring a second click before typing), and is incompatible with keyboard navigation.

### Changes proposed in this pull request

Use the loading mode for text fields.