### PR TITLE
Fix bug in logging of screenshots of failed tests

### DIFF
--- a/spec/support/save_feature_failures.rb
+++ b/spec/support/save_feature_failures.rb
@@ -9,7 +9,7 @@ RSpec.configure do |config|
     example_filename += '.html'
     if RSpec.current_example.exception.present?
       save_page(example_filename)
-      save_page(example_screenshotname)
+      save_screenshot(example_screenshotname)
     # remove the file if the test starts working again
     else
       File.unlink(example_filename) if File.exist?(example_filename)

--- a/spec/support/save_feature_failures.rb
+++ b/spec/support/save_feature_failures.rb
@@ -9,7 +9,7 @@ RSpec.configure do |config|
     example_filename += '.html'
     if RSpec.current_example.exception.present?
       save_page(example_filename)
-      save_screenshot(example_screenshotname)
+      save_screenshot(example_screenshotname) # rubocop:disable Lint/Debugger
     # remove the file if the test starts working again
     else
       File.unlink(example_filename) if File.exist?(example_filename)


### PR DESCRIPTION
### Checklist

- [x] I have read the [Contribution & Best practices Guide](https://github.com/openSUSE/osem/blob/master/CONTRIBUTING.md).
- [x] My branch is up-to-date with the upstream `master` branch.
- [ ] The tests pass locally with my changes.
- [ ] I have added tests that prove my fix is effective or that my feature works (if appropriate).
- [ ] I have added necessary documentation (if appropriate).

### Short description of what this resolves

The test suite is configured to log the source and screenshot of failed feature tests, but a typo is preventing the screenshot from being logged.

### Changes proposed in this pull request

Fix the typo.