### PR TITLE
Update Docker Compose file format: 2.0 → 2.4 (minor)

### DIFF
--- a/docker-compose.override.yml.example
+++ b/docker-compose.override.yml.example
@@ -1,4 +1,5 @@
-version: '2'
+version: "2.4"
+
 services:
   osem:
     build:

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,4 +1,4 @@
-version: "2"
+version: "2.4"
 
 services:
   database:

--- a/docker-compose.yml.production-example
+++ b/docker-compose.yml.production-example
@@ -1,4 +1,4 @@
-version: "2"
+version: "2.4"
 
 services:
   production_database:


### PR DESCRIPTION
### Checklist

- [x] I have read the [Contribution & Best practices Guide](https://github.com/openSUSE/osem/blob/master/CONTRIBUTING.md).
- [x] My branch is up-to-date with the upstream `master` branch.
- [ ] The tests pass locally with my changes.
- [ ] I have added tests that prove my fix is effective or that my feature works (if appropriate).
- [ ] I have added necessary documentation (if appropriate).

### Short description of what this resolves

In my local development environment I'd like to limit resource usage, by setting in `docker-compose.override.yml` e.g.:

```yaml
services:
  osem:
    cpus: 2
    mem_limit: 2gb
```

The `cpus` parameter requires Compose file version ~> 2.2, but the provided files are currently using 2.0.

### Changes proposed in this pull request

Update to the latest version 2 format.