### PR TITLE
Annotate past migrations with Rails version

### DIFF
--- a/db/migrate/20160627122446_create_surveys.rb
+++ b/db/migrate/20160627122446_create_surveys.rb
@@ -1,6 +1,6 @@
 # frozen_string_literal: true
 
-class CreateSurveys < ActiveRecord::Migration
+class CreateSurveys < ActiveRecord::Migration[5.0]
   def change
     create_table :surveys do |t|
       t.datetime :start_date

--- a/db/migrate/20160628093634_create_survey_questions.rb
+++ b/db/migrate/20160628093634_create_survey_questions.rb
@@ -1,6 +1,6 @@
 # frozen_string_literal: true
 
-class CreateSurveyQuestions < ActiveRecord::Migration
+class CreateSurveyQuestions < ActiveRecord::Migration[5.0]
   def change
     create_table :survey_questions do |t|
       t.references :survey

--- a/db/migrate/20160629145954_add_target_to_surveys.rb
+++ b/db/migrate/20160629145954_add_target_to_surveys.rb
@@ -1,6 +1,6 @@
 # frozen_string_literal: true
 
-class AddTargetToSurveys < ActiveRecord::Migration
+class AddTargetToSurveys < ActiveRecord::Migration[5.0]
   def change
     add_column :surveys, :target, :integer, default: 0
   end

--- a/db/migrate/20160630094850_create_survey_replies.rb
+++ b/db/migrate/20160630094850_create_survey_replies.rb
@@ -1,6 +1,6 @@
 # frozen_string_literal: true
 
-class CreateSurveyReplies < ActiveRecord::Migration
+class CreateSurveyReplies < ActiveRecord::Migration[5.0]
   def change
     create_table :survey_replies do |t|
       t.integer :survey_question_id

--- a/db/migrate/20160630130731_create_survey_submissions.rb
+++ b/db/migrate/20160630130731_create_survey_submissions.rb
@@ -1,6 +1,6 @@
 # frozen_string_literal: true
 
-class CreateSurveySubmissions < ActiveRecord::Migration
+class CreateSurveySubmissions < ActiveRecord::Migration[5.0]
   def change
     create_table :survey_submissions do |t|
       t.integer :user_id

--- a/db/migrate/20161229080315_add_comments_count_to_events.rb
+++ b/db/migrate/20161229080315_add_comments_count_to_events.rb
@@ -1,6 +1,6 @@
 # frozen_string_literal: true
 
-class AddCommentsCountToEvents < ActiveRecord::Migration
+class AddCommentsCountToEvents < ActiveRecord::Migration[4.2]
   def change
     add_column :events, :comments_count, :integer, default: 0, null: false
 

--- a/db/migrate/20170108053041_add_default_to_revision_in_conference.rb
+++ b/db/migrate/20170108053041_add_default_to_revision_in_conference.rb
@@ -1,6 +1,6 @@
 # frozen_string_literal: true
 
-class AddDefaultToRevisionInConference < ActiveRecord::Migration
+class AddDefaultToRevisionInConference < ActiveRecord::Migration[4.2]
   def change
     change_column :conferences, :revision, :integer, default: 0, null: false
   end

--- a/db/migrate/20170212145523_add_enabled_to_event_schedules.rb
+++ b/db/migrate/20170212145523_add_enabled_to_event_schedules.rb
@@ -1,6 +1,6 @@
 # frozen_string_literal: true
 
-class AddEnabledToEventSchedules < ActiveRecord::Migration
+class AddEnabledToEventSchedules < ActiveRecord::Migration[5.0]
   def change
     add_column :event_schedules, :enabled, :boolean, default: true
   end

--- a/db/migrate/20170516190048_create_booths.rb
+++ b/db/migrate/20170516190048_create_booths.rb
@@ -1,6 +1,6 @@
 # frozen_string_literal: true
 
-class CreateBooths < ActiveRecord::Migration
+class CreateBooths < ActiveRecord::Migration[4.2]
   def change
     create_table :booths do |t|
       t.string :title

--- a/db/migrate/20170530072155_add_type_to_cfps.rb
+++ b/db/migrate/20170530072155_add_type_to_cfps.rb
@@ -1,6 +1,6 @@
 # frozen_string_literal: true
 
-class AddTypeToCfps < ActiveRecord::Migration
+class AddTypeToCfps < ActiveRecord::Migration[4.2]
   class TmpCfp < ActiveRecord::Base
     self.table_name = 'cfps'
   end

--- a/db/migrate/20170530112510_create_booth_requests.rb
+++ b/db/migrate/20170530112510_create_booth_requests.rb
@@ -1,6 +1,6 @@
 # frozen_string_literal: true
 
-class CreateBoothRequests < ActiveRecord::Migration
+class CreateBoothRequests < ActiveRecord::Migration[4.2]
   def change
     create_table :booth_requests do |t|
       t.references :booth, index: true, foreign_key: true

--- a/db/migrate/20170603095900_create_physical_tickets.rb
+++ b/db/migrate/20170603095900_create_physical_tickets.rb
@@ -1,6 +1,6 @@
 # frozen_string_literal: true
 
-class CreatePhysicalTickets < ActiveRecord::Migration
+class CreatePhysicalTickets < ActiveRecord::Migration[4.2]
   def change
     create_table :physical_tickets do |t|
       t.integer :ticket_purchase_id, null: false

--- a/db/migrate/20170629162450_add_short_name_to_tracks.rb
+++ b/db/migrate/20170629162450_add_short_name_to_tracks.rb
@@ -1,6 +1,6 @@
 # frozen_string_literal: true
 
-class AddShortNameToTracks < ActiveRecord::Migration
+class AddShortNameToTracks < ActiveRecord::Migration[4.2]
   class TmpProgram < ActiveRecord::Base
     self.table_name = 'programs'
   end

--- a/db/migrate/20170629232817_add_ticket_layout_to_conferences.rb
+++ b/db/migrate/20170629232817_add_ticket_layout_to_conferences.rb
@@ -1,6 +1,6 @@
 # frozen_string_literal: true
 
-class AddTicketLayoutToConferences < ActiveRecord::Migration
+class AddTicketLayoutToConferences < ActiveRecord::Migration[4.2]
   def change
     add_column :conferences, :ticket_layout, :integer, default: 0
   end

--- a/db/migrate/20170705075039_add_state_cfp_active_and_submitter_reference_to_tracks.rb
+++ b/db/migrate/20170705075039_add_state_cfp_active_and_submitter_reference_to_tracks.rb
@@ -1,6 +1,6 @@
 # frozen_string_literal: true
 
-class AddStateCfpActiveAndSubmitterReferenceToTracks < ActiveRecord::Migration
+class AddStateCfpActiveAndSubmitterReferenceToTracks < ActiveRecord::Migration[4.2]
   def change
     add_column :tracks, :state, :string
     add_column :tracks, :cfp_active, :boolean

--- a/db/migrate/20170711102511_create_ticket_scannings.rb
+++ b/db/migrate/20170711102511_create_ticket_scannings.rb
@@ -1,6 +1,6 @@
 # frozen_string_literal: true
 
-class CreateTicketScannings < ActiveRecord::Migration
+class CreateTicketScannings < ActiveRecord::Migration[4.2]
   def change
     create_table :ticket_scannings do |t|
       t.integer :physical_ticket_id, null: false

--- a/db/migrate/20170712120556_add_room_and_dates_to_tracks.rb
+++ b/db/migrate/20170712120556_add_room_and_dates_to_tracks.rb
@@ -1,6 +1,6 @@
 # frozen_string_literal: true
 
-class AddRoomAndDatesToTracks < ActiveRecord::Migration
+class AddRoomAndDatesToTracks < ActiveRecord::Migration[4.2]
   def change
     add_reference :tracks, :room, index: true, foreign_key: true
     add_column :tracks, :start_date, :date

--- a/db/migrate/20170715131706_make_track_state_not_null_and_add_default_value.rb
+++ b/db/migrate/20170715131706_make_track_state_not_null_and_add_default_value.rb
@@ -1,6 +1,6 @@
 # frozen_string_literal: true
 
-class MakeTrackStateNotNullAndAddDefaultValue < ActiveRecord::Migration
+class MakeTrackStateNotNullAndAddDefaultValue < ActiveRecord::Migration[4.2]
   class TmpTrack < ActiveRecord::Base
     self.table_name = 'tracks'
   end

--- a/db/migrate/20170720134353_make_track_cfp_active_not_null.rb
+++ b/db/migrate/20170720134353_make_track_cfp_active_not_null.rb
@@ -1,6 +1,6 @@
 # frozen_string_literal: true
 
-class MakeTrackCfpActiveNotNull < ActiveRecord::Migration
+class MakeTrackCfpActiveNotNull < ActiveRecord::Migration[4.2]
   class TmpTrack < ActiveRecord::Base
     self.table_name = 'tracks'
   end

--- a/db/migrate/20170721001700_add_index_to_physical_tickets.rb
+++ b/db/migrate/20170721001700_add_index_to_physical_tickets.rb
@@ -1,6 +1,6 @@
 # frozen_string_literal: true
 
-class AddIndexToPhysicalTickets < ActiveRecord::Migration
+class AddIndexToPhysicalTickets < ActiveRecord::Migration[4.2]
   def change
     add_column :physical_tickets, :token, :string
     add_index :physical_tickets, :token, unique: true

--- a/db/migrate/20170721184810_add_custom_domain_to_conferences.rb
+++ b/db/migrate/20170721184810_add_custom_domain_to_conferences.rb
@@ -1,6 +1,6 @@
 # frozen_string_literal: true
 
-class AddCustomDomainToConferences < ActiveRecord::Migration
+class AddCustomDomainToConferences < ActiveRecord::Migration[4.2]
   def change
     add_column :conferences, :custom_domain, :string
   end

--- a/db/migrate/20170726065629_add_relevance_to_tracks.rb
+++ b/db/migrate/20170726065629_add_relevance_to_tracks.rb
@@ -1,6 +1,6 @@
 # frozen_string_literal: true
 
-class AddRelevanceToTracks < ActiveRecord::Migration
+class AddRelevanceToTracks < ActiveRecord::Migration[4.2]
   def change
     add_column :tracks, :relevance, :text
   end

--- a/db/migrate/20170727081731_add_include_booths_to_splashpages.rb
+++ b/db/migrate/20170727081731_add_include_booths_to_splashpages.rb
@@ -1,6 +1,6 @@
 # frozen_string_literal: true
 
-class AddIncludeBoothsToSplashpages < ActiveRecord::Migration
+class AddIncludeBoothsToSplashpages < ActiveRecord::Migration[4.2]
   def change
     add_column :splashpages, :include_booths, :boolean
   end

--- a/db/migrate/20170728182033_add_booth_limit_to_conferences.rb
+++ b/db/migrate/20170728182033_add_booth_limit_to_conferences.rb
@@ -1,6 +1,6 @@
 # frozen_string_literal: true
 
-class AddBoothLimitToConferences < ActiveRecord::Migration
+class AddBoothLimitToConferences < ActiveRecord::Migration[4.2]
   def change
     add_column :conferences, :booth_limit, :integer, default: 0
   end

--- a/db/migrate/20170731161207_add_booths_to_email_settings.rb
+++ b/db/migrate/20170731161207_add_booths_to_email_settings.rb
@@ -1,6 +1,6 @@
 # frozen_string_literal: true
 
-class AddBoothsToEmailSettings < ActiveRecord::Migration
+class AddBoothsToEmailSettings < ActiveRecord::Migration[4.2]
   def change
     add_column :email_settings, :send_on_booths_acceptance, :boolean, default: false
     add_column :email_settings, :booths_acceptance_subject, :string

--- a/db/migrate/20170807092805_add_registration_ticket_to_tickets.rb
+++ b/db/migrate/20170807092805_add_registration_ticket_to_tickets.rb
@@ -1,6 +1,6 @@
 # frozen_string_literal: true
 
-class AddRegistrationTicketToTickets < ActiveRecord::Migration
+class AddRegistrationTicketToTickets < ActiveRecord::Migration[4.2]
   def change
     add_column :tickets, :registration_ticket, :boolean, default: false
   end

--- a/db/migrate/20170809120927_add_track_reference_to_schedule.rb
+++ b/db/migrate/20170809120927_add_track_reference_to_schedule.rb
@@ -1,6 +1,6 @@
 # frozen_string_literal: true
 
-class AddTrackReferenceToSchedule < ActiveRecord::Migration
+class AddTrackReferenceToSchedule < ActiveRecord::Migration[4.2]
   def change
     add_reference :schedules, :track, index: true, foreign_key: true
   end

--- a/db/migrate/20170814174637_add_selected_schedule_to_tracks.rb
+++ b/db/migrate/20170814174637_add_selected_schedule_to_tracks.rb
@@ -1,6 +1,6 @@
 # frozen_string_literal: true
 
-class AddSelectedScheduleToTracks < ActiveRecord::Migration
+class AddSelectedScheduleToTracks < ActiveRecord::Migration[4.2]
   def change
     add_column :tracks, :selected_schedule_id, :integer
     add_index :tracks, :selected_schedule_id

--- a/db/migrate/20170905110034_add_description_to_cfps.rb
+++ b/db/migrate/20170905110034_add_description_to_cfps.rb
@@ -1,6 +1,6 @@
 # frozen_string_literal: true
 
-class AddDescriptionToCfps < ActiveRecord::Migration
+class AddDescriptionToCfps < ActiveRecord::Migration[4.2]
   def change
     add_column :cfps, :description, :text
   end

--- a/db/migrate/20170924190528_add_amount_paid_to_ticket_purchases.rb
+++ b/db/migrate/20170924190528_add_amount_paid_to_ticket_purchases.rb
@@ -1,6 +1,6 @@
 # frozen_string_literal: true
 
-class AddAmountPaidToTicketPurchases < ActiveRecord::Migration
+class AddAmountPaidToTicketPurchases < ActiveRecord::Migration[4.2]
   def change
     add_column :ticket_purchases, :amount_paid, :float, default: 0
   end

--- a/db/migrate/20171130172334_rebuild_conference_pictures.rb
+++ b/db/migrate/20171130172334_rebuild_conference_pictures.rb
@@ -1,6 +1,6 @@
 # frozen_string_literal: true
 
-class RebuildConferencePictures < ActiveRecord::Migration
+class RebuildConferencePictures < ActiveRecord::Migration[5.0]
   def up
     Conference.all.each do |conference|
       conference.picture.recreate_versions!

--- a/db/migrate/20171201163628_add_mastodon_to_contact.rb
+++ b/db/migrate/20171201163628_add_mastodon_to_contact.rb
@@ -1,6 +1,6 @@
 # frozen_string_literal: true
 
-class AddMastodonToContact < ActiveRecord::Migration
+class AddMastodonToContact < ActiveRecord::Migration[5.0]
   def change
     add_column :contacts, :mastodon, :string
   end


### PR DESCRIPTION
### Checklist

- [x] I have read the [Contribution & Best practices Guide](https://github.com/openSUSE/osem/blob/master/CONTRIBUTING.md).
- [x] My branch is up-to-date with the upstream `master` branch.
- [ ] The tests pass locally with my changes.
- [ ] I have added tests that prove my fix is effective or that my feature works (if appropriate).
- [ ] I have added necessary documentation (if appropriate).

### Short description of what this resolves

Many migrations currently fail to run with:

> Directly inheriting from `ActiveRecord::Migration` is not supported. Please specify the Rails release the migration was written for:
>
>     class Example < ActiveRecord::Migration[4.2]

### Changes proposed in this pull request

Annotate migrations with the Rails version at the time that they were committed.

I've provisionally limited this to just the migrations that I actually need to run.