### PR TITLE
Fix migration that fails on conferences without pictures

### DIFF
--- a/db/migrate/20171130172334_rebuild_conference_pictures.rb
+++ b/db/migrate/20171130172334_rebuild_conference_pictures.rb
@@ -2,7 +2,7 @@
 
 class RebuildConferencePictures < ActiveRecord::Migration
   def up
-    Conference.all.each do |conference|
+    Conference.where.not(picture: nil).each do |conference|
       conference.picture.recreate_versions!
     end
   end


### PR DESCRIPTION
### Checklist

- [x] I have read the [Contribution & Best practices Guide](https://github.com/openSUSE/osem/blob/master/CONTRIBUTING.md).
- [x] My branch is up-to-date with the upstream `master` branch.
- [ ] The tests pass locally with my changes.
- [ ] I have added tests that prove my fix is effective or that my feature works (if appropriate).
- [ ] I have added necessary documentation (if appropriate).

### Short description of what this resolves

Migration `RebuildConferencePictures` fails to run if any conference doesn't have a picture (#1976):

    NoMethodError: undefined method `read' for nil:NilClass
    …/carrierwave-1.3.1/lib/carrierwave/uploader/cache.rb:81:in `sanitized_file'
    …/carrierwave-1.3.1/lib/carrierwave/uploader/cache.rb:118:in `cache!'
    …/carrierwave-1.3.1/lib/carrierwave/uploader/versions.rb:234:in `recreate_versions!'
    db/migrate/20171130172334_rebuild_conference_pictures.rb:4:in `block in up'

This is consistent with CarrierWave's [documentation](https://github.com/carrierwaveuploader/carrierwave/tree/v1.3.1#recreating-versions):

> Note: `recreate_versions!` will throw an exception on records without an image. To avoid this, scope the records to those with images or check if an image exists within the block.

### Changes proposed in this pull request

Restrict to conferences that have pictures.