### PR TITLE
Work around bug in migrations to non-null columns

### DIFF
--- a/db/migrate/20170715131706_make_track_state_not_null_and_add_default_value.rb
+++ b/db/migrate/20170715131706_make_track_state_not_null_and_add_default_value.rb
@@ -6,6 +6,8 @@ class MakeTrackStateNotNullAndAddDefaultValue < ActiveRecord::Migration
   end
 
   def change
+    TmpTrack.reset_column_information
+
     TmpTrack.where(state: nil).each do |track|
       track.state = 'confirmed'
       track.save!

--- a/db/migrate/20170720134353_make_track_cfp_active_not_null.rb
+++ b/db/migrate/20170720134353_make_track_cfp_active_not_null.rb
@@ -6,11 +6,13 @@ class MakeTrackCfpActiveNotNull < ActiveRecord::Migration
   end
 
   def change
+    TmpTrack.reset_column_information
+
     TmpTrack.where(cfp_active: nil).each do |track|
       track.cfp_active = true
       track.save!
     end
 
-    change_column_null :tracks, :cfp_active, false
+    change_column :tracks, :cfp_active, :boolean, null: false, default: false
   end
 end


### PR DESCRIPTION
### Checklist

- [x] I have read the [Contribution & Best practices Guide](https://github.com/openSUSE/osem/blob/master/CONTRIBUTING.md).
- [x] My branch is up-to-date with the upstream `master` branch.
- [ ] The tests pass locally with my changes.
- [ ] I have added tests that prove my fix is effective or that my feature works(if appropriate).
- [ ] I have added necessary documentation (if appropriate).

### Short description of what this resolves

When running migration [`AddStateCfpActive…`] followed by [`MakeTrackStateNotNull…`], the latter fails to convert existing null values before making the column non-null, resulting in e.g.:

```
Mysql2::Error: Invalid use of NULL value: ALTER TABLE `tracks` CHANGE `state` `state` varchar(255) DEFAULT 'new' NOT NULL
db/migrate/20170715131706_make_track_state_not_null_and_add_default_value.rb:17:in `change'
```

This is surprising, since the migration *appears* to perform a conversion:

https://github.com/openSUSE/osem/blob/dfb159a0e1de6bf09a21d7d3df88ccf4f7d93ffa/db/migrate/20170715131706_make_track_state_not_null_and_add_default_value.rb#L9-L12

Investigation reveals that actually this has had no effect; the null values remain. I don't fully understand why, but clearing ActiveRecord internal caches between migrations seems to make it work as intended:

```ruby
connection.schema_cache.clear_data_source_cache! 'tracks'
```

The same problem also affects [`MakeTrackCfpActiveNotNull`], but in that case leads to silent data corruption as `change_column_null` automatically cleans up the unconverted null values.

### Changes proposed in this pull request

- Work around the problem by clearing ActiveRecord internal caches.
    - While `clear_data_source_cache!` is sufficient, `reset_column_information` is probably more future-proof as it has been [recommended](https://guides.rubyonrails.org/v4.0/migrations.html#using-models-in-your-migrations) in documentation.
- Be more defensive by using `change_column` instead of `change_column_null` when no automatic conversion is intended.

[`AddStateCfpActive…`]: https://github.com/openSUSE/osem/blob/dfb159a0e1de6bf09a21d7d3df88ccf4f7d93ffa/db/migrate/20170705075039_add_state_cfp_active_and_submitter_reference_to_tracks.rb
[`MakeTrackStateNotNull…`]: https://github.com/openSUSE/osem/blob/dfb159a0e1de6bf09a21d7d3df88ccf4f7d93ffa/db/migrate/20170715131706_make_track_state_not_null_and_add_default_value.rb
[`MakeTrackCfpActiveNotNull`]: https://github.com/openSUSE/osem/blob/dfb159a0e1de6bf09a21d7d3df88ccf4f7d93ffa/db/migrate/20170720134353_make_track_cfp_active_not_null.rb