### PR TITLE
Serve precompiled assets in example Docker Compose configuration

### DIFF
--- a/docker-compose.yml.production-example
+++ b/docker-compose.yml.production-example
@@ -18,6 +18,7 @@ services:
     env_file: .env.production # see dotenv.example file
     environment:
      OSEM_DB_HOST: production_database
+     RAILS_SERVE_STATIC_FILES: 'true'
     command: /osem/bin/osem-init.sh
     volumes:
       - osem_production_web_data:/osem/public/system


### PR DESCRIPTION
### Checklist

- [x] I have read the [Contribution & Best practices Guide](https://github.com/openSUSE/osem/blob/master/CONTRIBUTING.md).
- [x] My branch is up-to-date with the upstream `master` branch.
- [ ] The tests pass locally with my changes.
- [ ] I have added tests that prove my fix is effective or that my feature works (if appropriate).
- [ ] I have added necessary documentation (if appropriate).

### Short description of what this resolves

When using the example [Docker Compose configuration for production](https://github.com/openSUSE/osem/blob/a89201ff829eb14c4c26e1ec9d5aa2dccbfeec6b/docker-compose.yml.production-example), static assets aren't served.

### Changes proposed in this pull request

Continue 959d5af by setting `RAILS_SERVE_STATIC_FILES`.