### PR TITLE
Fix docker setup for newer or updated image builds

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -89,6 +89,9 @@ override example file and in it, set your user id in the variable
 sed "s/13042/`id -u`/" docker-compose.override.yml.example > docker-compose.override.yml
 ```
 
+Another use of the override example file, is to overwrite the variable *OSEM_RUBY_VERSION*,
+which defines in what's the Ruby version to be used for the container. This argument is only
+read during the container build time.
 
 1. Set up the development environment:
     ```bash

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,5 +1,6 @@
 FROM osem/base
 ARG CONTAINER_USERID
+ARG OSEM_RUBY_VERSION
 
 # Configure our user
 RUN usermod -u $CONTAINER_USERID osem

--- a/docker-compose.override.yml.example
+++ b/docker-compose.override.yml.example
@@ -4,3 +4,4 @@ services:
     build:
       args:
         CONTAINER_USERID: 13042
+        OSEM_RUBY_VERSION: 2.5.8

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -10,6 +10,7 @@ services:
       context: .
       args:
         CONTAINER_USERID: 1000
+        OSEM_RUBY_VERSION: 2.5.0
     command: /osem/bin/osem-init.sh
     depends_on:
       - database


### PR DESCRIPTION
**Checklist**

- [x] I have read the [Contribution & Best practices Guide](https://github.com/openSUSE/osem/blob/master/CONTRIBUTING.md).
- [x] My branch is up-to-date with the upstream `master` branch.
- [x] The tests pass locally with my changes.
- [ ] I have added tests that prove my fix is effective or that my feature works(if appropriate).
- [x] I have added necessary documentation (if appropriate).

**Short description of what this resolves/which [issues](https://github.com/openSUSE/osem/issues) does this fix?:**

<!-- List the issue number resolved with this change; if there is no open issue, describe the problem this request solves -->

- #2511 

**Changes proposed in this pull request:**

<!-- Summarize the changes, using declarative language. -->

- Add `OSEM_RUBY_VERSION` as build argument to Docker setup
