### PR TITLE
Fix `min` method in `delete_event_schedules`

### DIFF
--- a/app/models/conference.rb
+++ b/app/models/conference.rb
@@ -119,7 +119,7 @@ class Conference < ApplicationRecord
       event_schedules = program.event_schedules.select do |event_schedule|
         event_schedule.start_time.hour < start_hour ||
         event_schedule.end_time.hour > end_hour ||
-        (event_schedule.end_time.hour == end_hour && event_schedule.end_time.minute > 0)
+        (event_schedule.end_time.hour == end_hour && event_schedule.end_time.min > 0)
       end
       event_schedules.each(&:destroy)
     end


### PR DESCRIPTION
**Checklist**

- [x] I have read the [Contribution & Best practices Guide](https://github.com/openSUSE/osem/blob/master/CONTRIBUTING.md).
- [x] My branch is up-to-date with the upstream `master` branch.
- [x] The tests pass locally with my changes.
- [ ] I have added tests that prove my fix is effective or that my feature works(if appropriate).
- [ ] I have added necessary documentation (if appropriate).

**Short description of what this resolves/which [issues](https://github.com/openSUSE/osem/issues) does this fix?:**

`minute` is no longer a method. There's a 500 error if you try to edit the end time of a conference.

