### PR TITLE
Constrain Docker base image to openSUSE Leap 15.1

### DIFF
--- a/Dockerfile.base
+++ b/Dockerfile.base
@@ -1,4 +1,4 @@
-FROM opensuse/leap:15
+FROM opensuse/leap:15.1
 
 # Install our requirements
 RUN zypper -n install --no-recommends \


### PR DESCRIPTION
### Checklist

- [x] I have read the [Contribution & Best practices Guide](https://github.com/openSUSE/osem/blob/master/CONTRIBUTING.md).
- [x] My branch is up-to-date with the upstream `master` branch.
- [ ] The tests pass locally with my changes.
- [ ] I have added tests that prove my fix is effective or that my feature works (if appropriate).
- [ ] I have added necessary documentation (if appropriate).

### Short description of what this resolves

[`osem/base`](https://github.com/openSUSE/osem/blob/master/Dockerfile.base) is built from [`opensuse/leap:15`](https://hub.docker.com/r/opensuse/leap/tags), which now resolves to openSUSE Leap 15.2, in which the [`postgresql-devel`](https://software.opensuse.org/package/postgresql-devel) package no longer provides all of the dependencies required by the [`pg`](https://github.com/ged/ruby-pg) gem:

```console
$ docker build --file 'Dockerfile.base' --tag 'osem/base' '.'
…
Successfully tagged osem/base:latest
$ docker-compose build osem
…
Gem::Ext::BuildError: ERROR: Failed to build gem native extension.

    current directory: /tmp/bundler20201028-7-1wexcckpg-1.1.4/gems/pg-1.1.4/ext
/usr/bin/ruby.ruby2.5 -r ./siteconf20201028-7-1niy3x1.rb extconf.rb
checking for pg_config... no
No pg_config... trying anyway. If building fails, please try again with
 --with-pg-config=/path/to/pg_config
checking for libpq-fe.h... no
Can't find the 'libpq-fe.h header
*** extconf.rb failed ***
```

I'm not familiar with openSUSE and after a brief web search was unable to find an explanation for the change or discern which additional package(s) would fulfill the missing dependencies.

### Changes proposed in this pull request

Keep using openSUSE Leap 15.1.