### PR TITLE
Allow leaving OSEM_SMTP_DOMAIN unset

### DIFF
--- a/config/environments/production.rb
+++ b/config/environments/production.rb
@@ -97,7 +97,7 @@ Osem::Application.configure do
     domain:               ENV['OSEM_SMTP_DOMAIN'],
     enable_starttls_auto: ENV['OSEM_SMTP_ENABLE_STARTTLS_AUTO'],
     openssl_verify_mode:  ENV['OSEM_SMTP_OPENSSL_VERIFY_MODE']
-  }
+  }.compact
 
   # Set the secret_key_base from the env, if not set by any other means
   config.secret_key_base ||= ENV["SECRET_KEY_BASE"]

--- a/lib/tasks/migrate_config.rake
+++ b/lib/tasks/migrate_config.rake
@@ -34,7 +34,7 @@ namespace :data do
       dot_env.puts "OSEM_SMTP_USERNAME=\"#{CONFIG['mail_username']}\""
       dot_env.puts "OSEM_SMTP_PASSWORD=\"#{CONFIG['mail_password']}\""
       dot_env.puts "OSEM_SMTP_AUTHENTICATION=\"#{CONFIG['mail_authentication']}\""
-      dot_env.puts 'OSEM_SMTP_DOMAIN=""'
+      dot_env.puts '# OSEM_SMTP_DOMAIN="example.com"'
       dot_env.close
 
       puts "Migrated config/config.yml to .env.#{Rails.env}"


### PR DESCRIPTION
### Checklist

- [x] I have read the [Contribution & Best practices Guide](https://github.com/openSUSE/osem/blob/master/CONTRIBUTING.md).
- [x] My branch is up-to-date with the upstream `master` branch.
- [ ] The tests pass locally with my changes.
- [ ] I have added tests that prove my fix is effective or that my feature works (if appropriate).
- [ ] I have added necessary documentation (if appropriate).

### Short description of what this resolves

The SMTP setting [`:domain`](https://guides.rubyonrails.org/v5.2/action_mailer_basics.html#action-mailer-configuration) (i.e. [HELO domain](https://ruby-doc.org/stdlib-2.5.8/libdoc/net/smtp/rdoc/Net/SMTP.html#class-Net::SMTP-label-HELO+domain)) is [often unnecessary](https://stackoverflow.com/a/8439535) and falls back to a reasonable [default](https://github.com/mikel/mail/blob/2.7.1/lib/mail/network/delivery_methods/smtp.rb#L82).

Leaving [`OSEM_SMTP_DOMAIN`](https://github.com/openSUSE/osem/blob/ae98ac1430baa690f744d850a985f63e5e9bd3cc/config/environments/production.rb#L97) unset, however, currently causes `:domain` to be explicitly set to `nil`, which in our case caused mail delivery to fail with `EOFError`.

### Changes proposed in this pull request

Omit `nil` values from the Action Mailer configuration.