### PR TITLE
Remove race condition in test of splash page versioning

### DIFF
--- a/spec/features/versions_spec.rb
+++ b/spec/features/versions_spec.rb
@@ -250,6 +250,7 @@ feature 'Version' do
 
     click_link 'Delete'
     page.accept_alert
+    expect(page).to have_text('Splashpage was successfully destroyed')
 
     visit admin_revision_history_path
     expect(page).to have_text("#{organizer.name} created new splashpage with ID #{splashpage_id} in conference #{conference.short_title}")


### PR DESCRIPTION
### Checklist

- [x] I have read the [Contribution & Best practices Guide](https://github.com/openSUSE/osem/blob/master/CONTRIBUTING.md).
- [x] My branch is up-to-date with the upstream `master` branch.
- [ ] The tests pass locally with my changes.
- [ ] I have added tests that prove my fix is effective or that my feature works (if appropriate).
- [ ] I have added necessary documentation (if appropriate).

### Short description of what this resolves

[A feature test](https://github.com/openSUSE/osem/blob/ae98ac1430baa690f744d850a985f63e5e9bd3cc/spec/features/versions_spec.rb#L234) currently fails intermittently due to a race condition in which the version history is viewed prior to the completion of a versioned change:

https://github.com/openSUSE/osem/blob/ae98ac1430baa690f744d850a985f63e5e9bd3cc/spec/features/versions_spec.rb#L251-L255

```console
$ rspec 'spec/features/versions_spec.rb:234'
…
Failures:

1) Version display changes in splashpages
    Failure/Error: expect(page).to have_text("#{organizer.name} created new splashpage with ID #{splashpage_id} in conference #{conference.short_title}")
    expected to find text "name50 created new splashpage with ID 1 in conference yvXgaw" in "…name50 created new splashpage in conference yvXgaw less than a minute ago…'
```

Note that the missing text "with ID" is rendered [only for deleted items](https://github.com/openSUSE/osem/blob/ae98ac1430baa690f744d850a985f63e5e9bd3cc/app/helpers/versions_helper.rb#L8).

### Changes proposed in this pull request

Wait for the change to complete.