### PR TITLE
Fix Frozen String Error in Commercials Controller

### DIFF
--- a/app/controllers/admin/commercials_controller.rb
+++ b/app/controllers/admin/commercials_controller.rb
@@ -65,8 +65,8 @@ module Admin
         flash[:notice] = 'Successfully added commercials.'
       else
         errors_text = ''
-        errors_text << 'Unable to find event with ID: ' + errors[:no_event].join(', ') + '. ' if errors[:no_event].any?
-        errors_text << 'There were some errors: ' + errors[:validation_errors].join('. ') if errors[:validation_errors].any?
+        errors_text += 'Unable to find event with ID: ' + errors[:no_event].join(', ') + '. ' if errors[:no_event].any?
+        errors_text += 'There were some errors: ' + errors[:validation_errors].join('. ') if errors[:validation_errors].any?
 
         flash[:error] = errors_text
       end


### PR DESCRIPTION
`errors_text` is a frozen string, so `<<` leads to an exception when trying to generate the error message.

**Checklist**

- [X] I have read the [Contribution & Best practices Guide](https://github.com/openSUSE/osem/blob/master/CONTRIBUTING.md).
- [X] My branch is up-to-date with the upstream `master` branch.
- [X] The tests pass locally with my changes.
- [ ] I have added tests that prove my fix is effective or that my feature works(if appropriate).
- [ ] I have added necessary documentation (if appropriate).

**Short description of what this resolves/which [issues](https://github.com/openSUSE/osem/issues) does this fix?:**

We cannot use `<<` on frozen strings

https://sentry.cs10.org/share/issue/7867fdaf8eba4387ae2789fd5f1cff3b/
if you want a production example. :)


**Changes proposed in this pull request:**

<!-- Summarize the changes, using declarative language. -->

Using `+=` is sufficient as a fix.
