### PR TITLE
removed-gendered-terms

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -37,8 +37,8 @@ bundle exec rake data:set_conference_in_versions RAILS_ENV=production
 
 ### Organization admins
 
-We have a new role `organization admins` which allow a user to manage his the
-organization and create and manage conference within the organization. This
+We have a new role `organization admins` which allow a user to manage their
+organization and create and manage a conference within the organization. This
 needs the role to exist in the database, otherwise the application crashes
 as it is assumed to exist. For that, run the following rake task:
 

--- a/config/initializers/devise.rb
+++ b/config/initializers/devise.rb
@@ -98,10 +98,10 @@ Devise.setup do |config|
 
   # ==> Configuration for :confirmable
   # A period that the user is allowed to access the website even without
-  # confirming his account. For instance, if set to 2.days, the user will be
-  # able to access the website for two days without confirming his account,
+  # confirming their account. For instance, if set to 2.days, the user will be
+  # able to access the website for two days without confirming their account,
   # access will be blocked just in the third day. Default is 0.days, meaning
-  # the user cannot access the website without confirming his account.
+  # the user cannot access the website without confirming their account.
   config.allow_unconfirmed_access_for = 2.days
 
   # If true, requires any email changes to be confirmed (exactly the same way as

--- a/spec/features/base_controller_spec.rb
+++ b/spec/features/base_controller_spec.rb
@@ -30,31 +30,31 @@ feature 'BaseController' do
         expect(flash).to eq 'You are not authorized to access this page.'
       end
 
-      it 'an admin he can access the admin area' do
+      it 'an admin they can access the admin area' do
         user.is_admin = true
         visit admin_conferences_path
         expect(current_path).to eq admin_conferences_path
       end
 
-      it 'an organizer he can access the admin area' do
+      it 'an organizer they can access the admin area' do
         user.role_ids = organizer_role.id
         visit admin_conferences_path
         expect(current_path).to eq admin_conferences_path
       end
 
-      it 'a volunteers_coordinator he can access the admin area' do
+      it 'a volunteers_coordinator they can access the admin area' do
         user.role_ids = volunteers_coordinator_role.id
         visit admin_conferences_path
         expect(current_path).to eq admin_conferences_path
       end
 
-      it 'a cfp he can access the admin area' do
+      it 'a cfp they can access the admin area' do
         user.role_ids = cfp_role.id
         visit admin_conferences_path
         expect(current_path).to eq admin_conferences_path
       end
 
-      it 'an info_desk he can access the admin area' do
+      it 'an info_desk they can access the admin area' do
         user.role_ids = info_desk_role.id
         visit admin_conferences_path
         expect(current_path).to eq admin_conferences_path


### PR DESCRIPTION
**Checklist**

- [x] I have read the [Contribution & Best practices Guide](https://github.com/openSUSE/osem/blob/master/CONTRIBUTING.md).
- [x] My branch is up-to-date with the upstream `master` branch.
- [x] The tests pass locally with my changes.
- [x] I have added tests that prove my fix is effective or that my feature works(if appropriate).
- [x] I have added necessary documentation (if appropriate).

**Short description of what this resolves/which [issues](https://github.com/openSUSE/osem/issues) does this fix?:**

Replaces gendered terms (he, his, he/she, guy, etc), with gender-neutral terms (they, theirs, person, etc).

<!-- List the issue number resolved with this change; if there is no open issue, describe the problem this request solves -->

-

**Changes proposed in this pull request:**

Replaces gendered terms (he, his, he/she, guy, etc), with gender-neutral terms (they, theirs, person, etc).

<!-- Summarize the changes, using declarative language. -->

-
