### PR TITLE
Move cache to file

### DIFF
--- a/config/initializers/carrierwave.rb
+++ b/config/initializers/carrierwave.rb
@@ -1,5 +1,6 @@
 CarrierWave.configure do |config|
   config.storage = :file
+  config.cache_storage = :file
   config.cache_dir = "#{Rails.root}/tmp/uploads"
   config.enable_processing = false if Rails.env.test?
 end


### PR DESCRIPTION
No need to store caches in the cloud.

