### PR TITLE
Fix JS error when saving survey_question

### DIFF
--- a/app/models/survey_question.rb
+++ b/app/models/survey_question.rb
@@ -11,8 +11,8 @@ class SurveyQuestion < ActiveRecord::Base
 
   validates :title, presence: true
   validates :possible_answers, :max_choices, :min_choices, presence: true, if: :choice?
-  validates :min_choices, numericality: { greater_than_or_equal_to: 1 }, allow_blank: true
-  validates :max_choices, numericality: { greater_than_or_equal_to: 1 }, allow_blank: true
+  validates :min_choices, numericality: { greater_than_or_equal_to: 1 }, allow_blank: true, if: :choice?
+  validates :max_choices, numericality: { greater_than_or_equal_to: 1 }, allow_blank: true, if: :choice?
 
   validate :max_choices_greater_than_min
 

--- a/app/views/admin/survey_questions/_form.html.haml
+++ b/app/views/admin/survey_questions/_form.html.haml
@@ -15,7 +15,7 @@
 
       .row
         .col-md-12
-          = f.input :title
+          = f.input :title, input_html: { autofocus: true }
           = f.input :mandatory
           .survey-possible-answers{ class: @survey_question.choice? ? '' : 'hidden' }
             = f.input :possible_answers, hint: 'Comma separated', input_html: { rows: 3 }


### PR DESCRIPTION
**Checklist**

- [ ] I have read the [Contribution & Best practices Guide](https://github.com/openSUSE/osem/blob/master/CONTRIBUTING.md).
- [x] My branch is up-to-date with the upstream `master` branch.
- [ ] The tests pass locally with my changes.
- [ ] I have added tests that prove my fix is effective or that my feature works(if appropriate).
- [ ] I have added necessary documentation (if appropriate).

**Short description of what this resolves/which [issues](https://github.com/openSUSE/osem/issues) does this fix?:**

<!-- List the issue number resolved with this change; if there is no open issue, describe the problem this request solves -->
Creating a new question for a survey shows an error, when `kind` of question is **not** choice
`An invalid form control with name='survey_question[min_choices]' is not focusable`

This seems to be triggered by the validation that ran but could not focus on the field to show the validation error (there shouldn't be a validation to begin with, since the validation refers to question kind **choice** and this was for a boolean question.

**Changes proposed in this pull request:**

<!-- Summarize the changes, using declarative language. -->

- Validate fields related to questions with multiple answers (question kind _choice_) only if our question is of kind choice
