### PR TITLE
Update Ruby dependency: 2.5.8 → 2.5.9 (patch)

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -2,7 +2,7 @@
 
 source 'https://rubygems.org'
 
-ruby ENV['OSEM_RUBY_VERSION'] || '2.5.8'
+ruby ENV['OSEM_RUBY_VERSION'] || '2.5.9'
 
 # rails-assets requires >= 1.8.4
 if Gem::Version.new(Bundler::VERSION) < Gem::Version.new('1.8.4')


### PR DESCRIPTION
### Checklist

- [x] I have read the [Contribution & Best practices Guide](https://github.com/openSUSE/osem/blob/master/CONTRIBUTING.md).
- [x] My branch is up-to-date with the upstream `master` branch.
- [ ] The tests pass locally with my changes.
    - [x] The tests pass in [AndrewKvalheim:future](https://github.com/AndrewKvalheim/osem/tree/future#readme).
- [ ] I have added tests that prove my fix is effective or that my feature works (if appropriate).
- [ ] I have added necessary documentation (if appropriate).

### Short description of what this resolves

The [Ruby dependency](https://bundler.io/gemfile_ruby.html) is set to an exact version (#2646)—

https://github.com/openSUSE/osem/blob/3c2a0826c9f2580d4c7f00e71dd035364a67fd8e/Gemfile#L5

—and is no longer satisfied by `osem/base`:

```console
$ docker run --rm 'registry.opensuse.org/opensuse/infrastructure/osem/containers/osem/base' ruby --version
ruby 2.5.9p229 (2021-04-05 revision 67939) [x86_64-linux-gnu]
$ docker-compose build osem
…
Your Ruby version is 2.5.9, but your Gemfile specified 2.5.8
```

There is almost a mechanism for locally overriding the dependency but the Dockerfile doesn’t accommodate it (#2680).

### Changes proposed in this pull request

Update the dependency.