### PR TITLE
Use openSUSE Registry in production Dockerfile

### DIFF
--- a/Dockerfile.production
+++ b/Dockerfile.production
@@ -1,4 +1,4 @@
-FROM opensuse/infrastructure/osem/containers/osem/base
+FROM registry.opensuse.org/opensuse/infrastructure/osem/containers/osem/base
 
 # Add our files
 COPY --chown=1000:1000 . /osem/


### PR DESCRIPTION
### Checklist

- [x] I have read the [Contribution & Best practices Guide](https://github.com/openSUSE/osem/blob/master/CONTRIBUTING.md).
- [x] My branch is up-to-date with the upstream `master` branch.
- [ ] The tests pass locally with my changes.
- [ ] I have added tests that prove my fix is effective or that my feature works (if appropriate).
- [ ] I have added necessary documentation (if appropriate).

### Short description of what this resolves

As of 6648082 the Docker base image is hosted in the openSUSE Registry. The development Dockerfile was updated to use this registry—

https://github.com/openSUSE/osem/blob/3c2a0826c9f2580d4c7f00e71dd035364a67fd8e/Dockerfile#L1

—but the production Dockerfile still uses Docker Hub by default:

https://github.com/openSUSE/osem/blob/3c2a0826c9f2580d4c7f00e71dd035364a67fd8e/Dockerfile.production#L1

This causes builds to fail with:

```
pull access denied for opensuse/infrastructure/osem/containers/osem/base, repository does not exist or may require 'docker login'
```

### Changes proposed in this pull request

Use the openSUSE Registry in the production Dockerfile.