### PR TITLE
Add missing dependencies to production Docker image

### DIFF
--- a/Dockerfile.production
+++ b/Dockerfile.production
@@ -1,5 +1,8 @@
 FROM opensuse/infrastructure/osem/containers/osem/base
 
+# Install bundler & foreman
+RUN gem install bundler:1.17.3 foreman
+
 # Add our files
 COPY --chown=1000:1000 . /osem/
 


### PR DESCRIPTION
### Checklist

- [x] I have read the [Contribution & Best practices Guide](https://github.com/openSUSE/osem/blob/master/CONTRIBUTING.md).
- [x] My branch is up-to-date with the upstream `master` branch.
- [ ] The tests pass locally with my changes.
- [ ] I have added tests that prove my fix is effective or that my feature works(if appropriate).
- [ ] I have added necessary documentation (if appropriate).

### Short description of what this resolves

As of 6648082 the [Docker base image][base] no longer includes Bundler and Foreman:

```diff
@@ -25,11 +26,7 @@
 # Disable versioned gem binary names
 RUN echo 'install: --no-format-executable' >> /etc/gemrc
 
-# Install bundler & foreman
-RUN gem install bundler:1.17.3 foreman
-
 # Create our user
 RUN useradd -m --user-group osem
```

These dependencies are installed in the application image instead:

https://github.com/openSUSE/osem/blob/3c2a0826c9f2580d4c7f00e71dd035364a67fd8e/Dockerfile#L19-L20

The production Dockerfile is missing them, causing its build to fail:

```
bundle: command not found
```

### Changes proposed in this pull request

Add the dependencies to the production Dockerfile as well.


[base]: https://build.opensuse.org/package/view_file/openSUSE:infrastructure:osem/docker-base/Dockerfile