### PR TITLE
Exclude additional files from Docker images

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,2 +1,10 @@
+.bundle/cache
+.git/
+coverage/
+db/*.sqlite3
 Dockerfile
 docker-compose.*
+log/
+public/assets/
+public/system/
+tmp/

--- a/Dockerfile.production
+++ b/Dockerfile.production
@@ -10,7 +10,7 @@ WORKDIR /osem/
 RUN export NOKOGIRI_USE_SYSTEM_LIBRARIES=1; bundle install --jobs=3 --retry=3 --without test development
 
 # Generate assets
-RUN export RAILS_ENV=production; bundle exec rake assets:clobber assets:precompile
+RUN export RAILS_ENV=production; bundle exec rake assets:precompile
 
 ENV RAILS_ENV=production
 


### PR DESCRIPTION
### Checklist

- [x] I have read the [Contribution & Best practices Guide](https://github.com/openSUSE/osem/blob/master/CONTRIBUTING.md).
- [x] My branch is up-to-date with the upstream `master` branch.
- [ ] The tests pass locally with my changes.
- [ ] I have added tests that prove my fix is effective or that my feature works (if appropriate).
- [ ] I have added necessary documentation (if appropriate).

### Short description of what this resolves

The production Dockerfile copies the entire project root—

https://github.com/openSUSE/osem/blob/3c2a0826c9f2580d4c7f00e71dd035364a67fd8e/Dockerfile.production#L4

—including files that are temporary,

  - `/.bundle/cache`
  - `/tmp/`

build artifacts,

- `/public/assets/`
- `/public/system/`

test artifacts,

- `/coverage/`

runtime artifacts,

  - `/db/*.sqlite3`
  - `/log/`

or not used by the application:

- `/.git/`

This is inefficient and risks the unintended leaking of data across environments.

### Changes proposed in this pull request

Exclude the above examples from Docker images.

This list is incomplete and an allowlist (i.e. `COPY …`) might be more appropriate, but maintaining a more complete list probably isn’t worth the effort at this time.