### PR TITLE
Resolve warning about testing only for spefic errors

### DIFF
--- a/spec/pdfs/ticket_pdf_spec.rb
+++ b/spec/pdfs/ticket_pdf_spec.rb
@@ -50,6 +50,6 @@ describe TicketPdf do
       .to_return(status: 404, body: '', headers: {})
 
     pdf = described_class.new(conference, participant, physical_ticket, layout, file_name)
-    expect{ PDF::Inspector::Page.analyze(pdf.render) }.to_not raise_error(OpenURI::HTTPError)
+    expect{ PDF::Inspector::Page.analyze(pdf.render) }.to_not raise_error
   end
 end


### PR DESCRIPTION
### Checklist

- [x] I have read the [Contribution & Best practices Guide](https://github.com/openSUSE/osem/blob/master/CONTRIBUTING.md).
- [x] My branch is up-to-date with the upstream `master` branch.
- [ ] The tests pass locally with my changes.
    - [x] The tests pass in [AndrewKvalheim:future](https://github.com/AndrewKvalheim/osem/tree/future#readme).
- [ ] I have added tests that prove my fix is effective or that my feature works (if appropriate).
- [ ] I have added necessary documentation (if appropriate).

### Short description of what this resolves

RSpec warns that this test—

https://github.com/openSUSE/osem/blob/3c2a0826c9f2580d4c7f00e71dd035364a67fd8e/spec/pdfs/ticket_pdf_spec.rb#L53

—risks false passes:

> WARNING: Using `expect { }.not_to raise_error(SpecificErrorClass)` risks false positives, since literally any other error would cause the expectation to pass, including those raised by Ruby (e.g. NoMethodError, NameError and ArgumentError), meaning the code you are intending to test may not even get reached. Instead consider using `expect { }.not_to raise_error` or `expect { }.to raise_error(DifferentSpecificErrorClass)`.

### Changes proposed in this pull request

Test for any error, not just HTTP errors.