### PR TITLE
Switch to fenced code blocks in markdown

### DIFF
--- a/app/helpers/format_helper.rb
+++ b/app/helpers/format_helper.rb
@@ -191,9 +191,11 @@ module FormatHelper
     return '' if text.nil?
 
     options = {
-      autolink:            true,
-      space_after_headers: true,
-      no_intra_emphasis:   true
+      autolink:                     true,
+      space_after_headers:          true,
+      no_intra_emphasis:            true,
+      fenced_code_blocks:           true,
+      disable_indented_code_blocks: true
     }
     markdown = Redcarpet::Markdown.new(Redcarpet::Render::HTML.new(escape_html: escape_html), options)
     markdown.render(text).html_safe

--- a/spec/helpers/format_helper_spec.rb
+++ b/spec/helpers/format_helper_spec.rb
@@ -11,7 +11,7 @@ describe FormatHelper, type: :helper do
 
     it 'should return HTML for header markdown' do
       expect(Redcarpet::Markdown).to receive(:new)
-      .with(Redcarpet::Render::HTML, autolink: true, space_after_headers: true, no_intra_emphasis: true)
+      .with(Redcarpet::Render::HTML, autolink: true, space_after_headers: true, no_intra_emphasis: true, fenced_code_blocks: true, disable_indented_code_blocks: true)
       .and_call_original
 
       expect(markdown('# this is my header')).to eq "<h1>this is my header</h1>\n"


### PR DESCRIPTION
:fenced_code_blocks: Blocks delimited with 3 or more ~ or backticks will be considered as code, without the need to be indented. An optional language name may be added at the end of the opening fence for the code block.

:disable_indented_code_blocks: do not parse usual markdown code blocks. Markdown converts text with four spaces at the front of each line to code blocks. This option prevents it from doing so. Recommended to use with fenced_code_blocks: true.

Fixes #2764
