### PR TITLE
Get rid of bin/osem-init.sh

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -89,39 +89,37 @@ override example file and in it, set your user id in the variable
 sed "s/13042/`id -u`/" docker-compose.override.yml.example > docker-compose.override.yml
 ```
 
-
-1. Set up the development environment:
-    ```bash
-    docker-compose run --rm osem bundle exec rake db:bootstrap
-    ```
-
+1. Build the development environment (only once)
+   ```bash
+   docker-compose build --no-cache --pull
+   ```
+1. Set up the development environment (only once)
+   ```bash
+   docker-compose run --rm osem bundle exec rake db:bootstrap
+   ```
 1. Start the development environment:
-    ```bash
-    docker-compose up --build
-    ```
+   ```bash
+   docker-compose up --build
+   ```
 
 1. Check out your OSEM rails app. You can access the app at http://localhost:3000. Whatever you change in your cloned repository will have effect in the development environment. Sign up, the first user will be automatically assigned the admin role.
 
 1. Changed something? Run the tests to verify your changes!
-    ```bash
-    docker-compose run --rm osem bundle exec rspec spec
-    ```
+   ```bash
+   docker-compose run --rm osem bundle exec rspec spec
+   ```
 
 1. Issue any standard `rails`/`rake`/`bundler` command
-    ```bash
-    docker-compose run --rm osem bundle exec rake db:version
-    ```
+   ```bash
+   docker-compose run --rm osem bundle exec rake db:version
+   ```
 
 1. Or explore the development environment:
-    ```bash
-    docker-compose exec osem /bin/bash -l
-    ```
+   ```bash
+   docker-compose exec osem /bin/bash -l
+   ```
 
-1. Want to know more?
-    In our wiki you can find more information about what is possible in our development environment,
-    how we work with each other on github or other topics of interest for OSEM developers.
-
-    https://github.com/openSUSE/osem/wiki
+1. Want to know more? In our [wiki](https://github.com/openSUSE/osem/wiki) you can find more information about what is possible in our development environment, how we work with each other on github or other topics of interest for OSEM developers.
 
 ## How to contribute translations
 

--- a/INSTALL.md
+++ b/INSTALL.md
@@ -1,7 +1,9 @@
 # Install Open Source Event Manager
-Here is what you need to install OSEM.
+
+Here is what you need to install OSEM for production usage.
 
 # 💥💥💥 WARNING 💥💥💥
+
 ![explosions](https://media.giphy.com/media/Yl5aO3gdVfsQ0/giphy.gif)
 
 OSEM is a Ruby on Rails server application for professional use, not some desktop app you run for yourself. If you deploy it, **YOU** are responsible for the data that users enter into it, this data includes personal information like email addresses and/or passwords that most likely can be used to harm them in some form (cracking, doxing, social engineering).
@@ -11,6 +13,7 @@ If you never deployed a Ruby on Rails app before we **strongly** suggest you see
 *You should know what you do and you have been warned*.
 
 ## Versions
+
 OSEM is an [semantic versioned](http://semver.org/) app. That means given a version number MAJOR.MINOR.PATCH we increment the:
 
 1. MAJOR version when we make incompatible changes,
@@ -18,9 +21,11 @@ OSEM is an [semantic versioned](http://semver.org/) app. That means given a vers
 3. PATCH version when we make backwards-compatible bug fixes
 
 ## Download
+
 You can find the latest OSEM releases on our [release page](https://github.com/openSUSE/osem/releases)
 
 ## Deploy to the cloud
+
 The easiest way to deploy OSEM is to use one of the many platform as a service providers that support ruby on rails. We have prepared OSEM to be used with [heroku](https://heroku.com). So if you have an account there, you can deploy OSEM by pressing this button:
 
 <a href="https://heroku.com/deploy?template=https://github.com/openSUSE/osem/tree/v1.0">
@@ -28,23 +33,27 @@ The easiest way to deploy OSEM is to use one of the many platform as a service p
 </a>
 
 ## Deploy to your own server
-We recommend to run OSEM in production with [mod_passenger](https://www.phusionpassenger.com/download/#open_source)
+
+We recommend to run OSEM in production with [mod\_passenger](https://www.phusionpassenger.com/download/#open_source)
 and the [apache web-server](https://www.apache.org/). There are tons of guides on how to deploy rails apps on various
 base operating systems. [Check Google](https://encrypted.google.com/search?hl=en&q=ruby%20on%20rails%20apache%20passenger). Of course there are also other options for the application server and reverse proxy, pick your poison.
 
 ## Deploy via docker/docker-compose
+
 There is a rudimentary docker-compose configuration for production usage (`docker-compose.yml.production-example`). It brings [OSEM up](http://0.0.0.0:8080) on port 8080. It uses persistent storage volumes for all the data users might create. You can start it with
 
-
-1. Configure OSEM
-   You have at least to set `SECRET_KEY_BASE`
+1. Configure OSEM (at least `SECRET_KEY_BASE`)
    ```
    cp dotenv.example .env.production
    vim .env.production
    ```
-1. Build the docker image (only once)
+1. Build the container image (every time you change code or config)
    ```
    docker-compose -f docker-compose.yml.production-example build
+   ```
+1. Setup the database (only once)
+   ```
+   docker-compose -f docker-compose.yml.production-example run --rm osem bundle exec rake db:bootstrap
    ```
 1. Start the services
    ```

--- a/bin/osem-init.sh
+++ b/bin/osem-init.sh
@@ -1,5 +1,0 @@
-#!/bin/bash
-# Setup the app if it isn't already setup
-bundle exec rake db:bootstrap
-# Start the app
-foreman start -p 3000

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -11,7 +11,7 @@ services:
       context: .
       args:
         CONTAINER_USERID: 1000
-    command: /osem/bin/osem-init.sh
+    command: foreman start -p 3000
     depends_on:
       - database
     ports:

--- a/docker-compose.yml.production-example
+++ b/docker-compose.yml.production-example
@@ -20,7 +20,7 @@ services:
     environment:
      OSEM_DB_HOST: production_database
      RAILS_SERVE_STATIC_FILES: 'true'
-    command: /osem/bin/osem-init.sh
+    command: foreman start -p 3000
     volumes:
       - osem_production_web_data:/osem/public/system
       - osem_production_web_assets:/osem/public/assets


### PR DESCRIPTION
Setting up the app if it isn't already setup should be some
concious step and not run every time we boot the containers.

This also fixes the problem that processes are not killed
if you stop the container with CTRL+C because the bash
script is not passing on signals.
