### PR TITLE
Use `be_successful` instead of `be_success`

### DIFF
--- a/spec/controllers/admin/conferences_controller_spec.rb
+++ b/spec/controllers/admin/conferences_controller_spec.rb
@@ -242,7 +242,7 @@ describe Admin::ConferencesController do
         it 're-renders the new template' do
           post :create, params: { conference:
                                               attributes_for(:conference, short_title: nil, organization_id: organization.id) }
-          expect(response).to be_success
+          expect(response).to be_successful
         end
       end
 
@@ -259,7 +259,7 @@ describe Admin::ConferencesController do
         it 're-renders the new template' do
           conference
           post :create, params: { conference: attributes_for(:conference, short_title: conference.short_title, organization_id: organization.id) }
-          expect(response).to be_success
+          expect(response).to be_successful
         end
       end
     end

--- a/spec/controllers/admin/event_schedules_controller_spec.rb
+++ b/spec/controllers/admin/event_schedules_controller_spec.rb
@@ -33,7 +33,7 @@ describe Admin::EventSchedulesController do
 
         it 'has 200 status code' do
           create_action
-          expect(response).to be_success
+          expect(response).to be_successful
         end
       end
 
@@ -80,7 +80,7 @@ describe Admin::EventSchedulesController do
         end
 
         it 'has 200 status code' do
-          expect(response).to be_success
+          expect(response).to be_successful
         end
       end
 
@@ -115,7 +115,7 @@ describe Admin::EventSchedulesController do
 
       it 'has 200 status code' do
         destroy_action
-        expect(response).to be_success
+        expect(response).to be_successful
       end
     end
   end

--- a/spec/controllers/admin/registration_periods_controller_spec.rb
+++ b/spec/controllers/admin/registration_periods_controller_spec.rb
@@ -104,7 +104,7 @@ describe Admin::RegistrationPeriodsController do
                                                 start_date: nil,
                                                 end_date:   nil)
           }
-          expect(response).to be_success
+          expect(response).to be_successful
         end
       end
     end

--- a/spec/controllers/api/v1/conferences_controller_spec.rb
+++ b/spec/controllers/api/v1/conferences_controller_spec.rb
@@ -13,7 +13,7 @@ describe Api::V1::ConferencesController do
     end
 
     it 'returns successful response' do
-      expect(response).to be_success
+      expect(response).to be_successful
     end
 
     it 'returns all conferences' do
@@ -32,7 +32,7 @@ describe Api::V1::ConferencesController do
     end
 
     it 'returns successful response' do
-      expect(response).to be_success
+      expect(response).to be_successful
     end
 
     it 'returns only one conference' do

--- a/spec/controllers/api/v1/events_controller_spec.rb
+++ b/spec/controllers/api/v1/events_controller_spec.rb
@@ -13,7 +13,7 @@ describe Api::V1::EventsController do
 
         get :index, params: { format: :json }
         json = JSON.parse(response.body)['events']
-        expect(response).to be_success
+        expect(response).to be_successful
 
         expect(json.pluck('title')).to contain_exactly('Conference Event', 'Example Event')
       end
@@ -25,7 +25,7 @@ describe Api::V1::EventsController do
         get :index, params: { conference_id: conference.short_title, format: :json }
         json = JSON.parse(response.body)['events']
 
-        expect(response).to be_success
+        expect(response).to be_successful
 
         expect(json.length).to eq(1)
         expect(json[0]['title']).to eq('Conference Event')

--- a/spec/controllers/api/v1/rooms_controller_spec.rb
+++ b/spec/controllers/api/v1/rooms_controller_spec.rb
@@ -15,7 +15,7 @@ describe Api::V1::RoomsController do
         get :index, params: { format: :json }
         json = JSON.parse(response.body)['rooms']
 
-        expect(response).to be_success
+        expect(response).to be_successful
 
         expect(json.pluck('name')).to contain_exactly('Conference Room', 'Test Room')
       end
@@ -27,7 +27,7 @@ describe Api::V1::RoomsController do
         get :index, params: { conference_id: conference.short_title, format: :json }
         json = JSON.parse(response.body)['rooms']
 
-        expect(response).to be_success
+        expect(response).to be_successful
 
         expect(json.length).to eq(1)
         expect(json[0]['name']).to eq('Conference Room')

--- a/spec/controllers/api/v1/speakers_controller_spec.rb
+++ b/spec/controllers/api/v1/speakers_controller_spec.rb
@@ -21,7 +21,7 @@ describe Api::V1::SpeakersController do
 
         get :index, params: { format: :json }
         json = JSON.parse(response.body)['speakers']
-        expect(response).to be_success
+        expect(response).to be_successful
         expect(json.pluck('name')).to contain_exactly('Conf_Speaker', 'Speaker')
       end
     end
@@ -32,7 +32,7 @@ describe Api::V1::SpeakersController do
         get :index, params: { conference_id: conference.short_title, format: :json }
         json = JSON.parse(response.body)['speakers']
 
-        expect(response).to be_success
+        expect(response).to be_successful
 
         expect(json.length).to eq(1)
         expect(json[0]['name']).to eq('Conf_Speaker')

--- a/spec/controllers/api/v1/tracks_controller_spec.rb
+++ b/spec/controllers/api/v1/tracks_controller_spec.rb
@@ -14,7 +14,7 @@ describe Api::V1::TracksController do
         get :index, params: { format: :json }
         json = JSON.parse(response.body)['tracks']
 
-        expect(response).to be_success
+        expect(response).to be_successful
 
         expect(json.pluck('name')).to contain_exactly('Conference Track', 'Test Track')
       end
@@ -26,7 +26,7 @@ describe Api::V1::TracksController do
         get :index, params: { conference_id: conference.short_title, format: :json }
         json = JSON.parse(response.body)['tracks']
 
-        expect(response).to be_success
+        expect(response).to be_successful
 
         expect(json.length).to eq(1)
         expect(json[0]['name']).to eq('Conference Track')

--- a/spec/controllers/schedules_controller_spec.rb
+++ b/spec/controllers/schedules_controller_spec.rb
@@ -23,7 +23,7 @@ describe SchedulesController do
       end
 
       it 'has 200 status code' do
-        expect(response).to be_success
+        expect(response).to be_successful
       end
     end
   end


### PR DESCRIPTION
### Checklist

- [x] I have read the [Contribution & Best practices Guide](https://github.com/openSUSE/osem/blob/master/CONTRIBUTING.md).
- [x] My branch is up-to-date with the upstream `master` branch.
- [x] The tests pass locally with my changes.
- [ ] I have added tests that prove my fix is effective or that my feature works (if appropriate).
- [ ] I have added necessary documentation (if appropriate).

### Short description of what this resolves

Rails 5.2 [warns](https://github.com/rails/rails/issues/30072):

> The `success?` predicate is deprecated and will be removed in Rails 6.0. Please use `successful?` as provided by Rack::Response::Helpers.

RSpec [correspondingly](https://github.com/rspec/rspec-rails/issues/1857) provides `be_successful`.

### Changes proposed in this pull request

Use `be_successful` instead of `be_success`.