### PR TITLE
Order rooms by name in the schedule

### DIFF
--- a/app/controllers/schedules_controller.rb
+++ b/app/controllers/schedules_controller.rb
@@ -29,7 +29,7 @@ class SchedulesController < ApplicationController
       end
 
       format.html do
-        @rooms = @conference.venue.rooms if @conference.venue
+        @rooms = @conference.venue.rooms.order(:name) if @conference.venue
         @dates = @conference.start_date..@conference.end_date
         @step_minutes = @program.schedule_interval.minutes
         @conf_start = @conference.start_hour


### PR DESCRIPTION
### Checklist

- [x] I have read the [Contribution & Best practices Guide](https://github.com/openSUSE/osem/blob/master/CONTRIBUTING.md).
- [x] My branch is up-to-date with the upstream `master` branch.
- [x] The tests pass locally with my changes.
- [ ] I have added tests that prove my fix is effective or that my feature works (if appropriate).
- [ ] I have added necessary documentation (if appropriate).

### Short description of what this resolves

On the published schedule, rooms are listed in undefined order—in practice, usually the order of creation. This can make the schedule confusing to read.

### Changes proposed in this pull request

An explicit ordering feature would be useful, but for now it’s an improvement to just order by name.