### PR TITLE
Update venue country name for Countries 4.2

### DIFF
--- a/app/models/venue.rb
+++ b/app/models/venue.rb
@@ -21,7 +21,7 @@ class Venue < ApplicationRecord
 
   def country_name
     name = ISO3166::Country[country]
-    name&.name
+    name&.iso_short_name
   end
 
   def location?


### PR DESCRIPTION
### Checklist

- [x] I have read the [Contribution & Best practices Guide](https://github.com/openSUSE/osem/blob/master/CONTRIBUTING.md).
- [x] My branch is up-to-date with the upstream `master` branch.
- [x] The tests pass locally with my changes.
- [ ] I have added tests that prove my fix is effective or that my feature works (if appropriate).
- [ ] I have added necessary documentation (if appropriate).

### Short description of what this resolves

Countries 4.2 has [deprecated](https://github.com/countries/countries/blob/v4.2.2/README.markdown#upgrading-to-42-and-5x) `#name` and OSEM currently emits a warning:

> DEPRECATION WARNING: The `Country#name` method has been deprecated. Please use `Country#iso_short_name` instead or refer to the README file for more information on this change.

### Changes proposed in this pull request

Use `#iso_short_name` instead.