### PR TITLE
Update UserDatatable for ajax-datatables-rails 1

### DIFF
--- a/app/controllers/admin/users_controller.rb
+++ b/app/controllers/admin/users_controller.rb
@@ -23,7 +23,7 @@ module Admin
       respond_to do |format|
         format.html
         format.json do
-          render json: UserDatatable.new(view_context: view_context)
+          render json: UserDatatable.new({}, view_context: view_context)
         end
       end
     end

--- a/app/datatables/user_datatable.rb
+++ b/app/datatables/user_datatable.rb
@@ -1,11 +1,16 @@
 # frozen_string_literal: true
 
-class UserDatatable < AjaxDatatablesRails::Base
+class UserDatatable < AjaxDatatablesRails::ActiveRecord
   extend Forwardable
 
   def_delegator :@view, :show_roles
   def_delegator :@view, :admin_user_path
   def_delegator :@view, :edit_admin_user_path
+
+  def initialize(params, opts = {})
+    @view = opts[:view_context]
+    super
+  end
 
   def view_columns
     # Declare strings in this format: ModelName.column_name

--- a/spec/datatables/user_datatable_spec.rb
+++ b/spec/datatables/user_datatable_spec.rb
@@ -4,7 +4,7 @@ require 'spec_helper'
 
 describe UserDatatable do
   subject! do
-    described_class.new(view)
+    described_class.new({}, view_context: view)
   end
 
   let(:data_cols) do


### PR DESCRIPTION
### Checklist

- [x] I have read the [Contribution & Best practices Guide](https://github.com/openSUSE/osem/blob/master/CONTRIBUTING.md).
- [x] My branch is up-to-date with the upstream `master` branch.
- [x] The tests pass locally with my changes.
- [ ] I have added tests that prove my fix is effective or that my feature works (if appropriate).
- [ ] I have added necessary documentation (if appropriate).

### Short description of what this resolves

`UserDatatable` hasn’t been [migrated](https://github.com/jbox-web/ajax-datatables-rails/blob/v1.3.1/doc/migrate.md#to-migrate-from-v04x-to-v100) to ajax-datatables-rails v1 and fails to load data with `NotImplementedError`:

> ```console
> 1) UserDatatable outputs recordsTotal
>    Failure/Error: filter_records(fetch_records).unscope(:group, :select).count(:all)
>
>    NotImplementedError:
>      NotImplementedError
>    # ./app/datatables/user_datatable.rb:59:in `records_filtered_count'
>    # ./spec/datatables/user_datatable_spec.rb:95:in `block (3 levels) in <top (required)>'
>    # ./spec/datatables/user_datatable_spec.rb:98:in `block (3 levels) in <top (required)>'
> ```

### Changes proposed in this pull request

Update `UserDatatable` as `RegistrationDatatable` was in 81853d1ef91c2328e28ea676079428adbba33765.