### PR TITLE
Update tests of splashpage forms

### DIFF
--- a/spec/features/versions_spec.rb
+++ b/spec/features/versions_spec.rb
@@ -234,18 +234,18 @@ feature 'Version' do
   xscenario 'display changes in splashpages', feature: true, versioning: true, js: true do
     visit admin_conference_splashpage_path(conference.short_title)
     click_link 'Create Splashpage'
-    click_button 'Save Changes'
+    click_button 'Save'
 
-    click_link 'Edit'
-    uncheck('Display the program')
-    uncheck('Display call for papers and call for tracks, while open')
-    uncheck('Display the venue')
-    uncheck('Display tickets')
-    uncheck('Display the lodgings')
-    uncheck('Display sponsors')
-    uncheck('Display social media links')
+    click_link 'Configure'
+    check('Display the program?')
+    check('Display call for papers and call for tracks?')
+    check('Display the venue?')
+    check('Display the tickets?')
+    check('Display the lodgings?')
+    check('Display the sponsors?')
+    check('Display the social media links?')
     check('Make splash page public?')
-    click_button 'Save Changes'
+    click_button 'Save'
 
     click_link 'Delete'
     page.accept_alert
@@ -253,7 +253,7 @@ feature 'Version' do
 
     visit admin_revision_history_path
     expect(page).to have_text("#{organizer.name} created new splashpage in conference #{conference.short_title}")
-    expect(page).to have_text("#{organizer.name} updated public, include program, include cfp, include venue, include tickets, include lodgings, include sponsors and include social media of splashpage in conference #{conference.short_title}")
+    expect(page).to have_text("#{organizer.name} updated public, include program, include social media, include venue, include tickets, include sponsors, include lodgings and include cfp of splashpage in conference #{conference.short_title}")
     expect(page).to have_text("#{organizer.name} deleted splashpage in conference #{conference.short_title}")
   end
 


### PR DESCRIPTION
### Checklist

- [x] I have read the [Contribution & Best practices Guide](https://github.com/openSUSE/osem/blob/master/CONTRIBUTING.md).
- [x] My branch is up-to-date with the upstream `master` branch.
- [ ] The tests pass locally with my changes.
    - For the tests to pass:
        - Revert changes to `spec/features/versions_spec.rb` in b688d353ac7db7e1070436354b968bf2a503da2c
        - Apply #2703
- [ ] I have added tests that prove my fix is effective or that my feature works (if appropriate).
- [ ] I have added necessary documentation (if appropriate).

### Short description of what this resolves

The splashpage forms and default configuration changed in 81853d1ef91c2328e28ea676079428adbba33765, but the tests haven’t been updated to reflect that.

### Changes proposed in this pull request

Update the test’s form labels, check box changes, and version change description.