### PR TITLE
Fix bug in which role assignments aren’t tracked in version history

### DIFF
--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -23,8 +23,8 @@ class User < ApplicationRecord
   end
 
   has_many :users_roles
-  has_many :roles, through: :users_roles, dependent: :destroy
   rolify
+  has_many :roles, through: :users_roles, dependent: :destroy
 
   has_paper_trail on: [:create, :update], ignore: [:sign_in_count, :remember_created_at, :current_sign_in_at, :last_sign_in_at, :current_sign_in_ip, :last_sign_in_ip, :unconfirmed_email,
                                                    :avatar_content_type, :avatar_file_size, :avatar_updated_at, :updated_at, :confirmation_sent_at, :confirmation_token, :reset_password_token]

--- a/spec/features/versions_spec.rb
+++ b/spec/features/versions_spec.rb
@@ -344,7 +344,6 @@ feature 'Version' do
   end
 
   scenario 'display changes in users_role for conference role', feature: true, versioning: true, js: true do
-    skip('fails since paper_trail 12.2.0')
     user = create(:user)
     role = Role.find_by(name: 'cfp', resource_id: conference.id, resource_type: 'Conference')
     user.add_role :cfp, conference


### PR DESCRIPTION
### Checklist

- [x] I have read the [Contribution & Best practices Guide](https://github.com/openSUSE/osem/blob/master/CONTRIBUTING.md).
- [x] My branch is up-to-date with the upstream `master` branch.
- [x] The tests pass locally with my changes.
- [ ] I have added tests that prove my fix is effective or that my feature works (if appropriate).
- [ ] I have added necessary documentation (if appropriate).

### Short description of what this resolves

Role assignments (i.e. `UsersRole` creation/deletion) managed via Rolify aren’t tracked in the PaperTrail version history. Tests fail with:

> ```console
> Failures:
>
>   1) Version display changes in users_role for conference role
>      Failure/Error: expect(page).to have_text("added role cfp with ID #{user_role.id} to user #{user.name} in conference #{conference.short_title}")
>        expected to find text "added role cfp with ID 2 to user name2 in conference fr_GAQ" in […]
>      # ./spec/features/versions_spec.rb:350:in `block (2 levels) in <top (required)>'
>
> Finished in 16.47 seconds (files took 3.45 seconds to load)
> 1 example, 1 failure
>
> Failed examples:
>
> rspec ./spec/features/versions_spec.rb:342 # Version display changes in users_role for conference role
> ```

### Changes proposed in this pull request

Deferring the `has_many :through` until after `rolify` seems to resolve the problem, but I don’t understand why.