### PR TITLE
Restore test of splashpage revision history

### DIFF
--- a/spec/features/versions_spec.rb
+++ b/spec/features/versions_spec.rb
@@ -231,7 +231,7 @@ feature 'Version' do
     expect(page).to have_text("Someone (probably via the console) deleted difficulty level Expert with ID #{difficulty_level_id} in conference #{conference.short_title}")
   end
 
-  xscenario 'display changes in splashpages', feature: true, versioning: true, js: true do
+  scenario 'display changes in splashpages', feature: true, versioning: true, js: true do
     visit admin_conference_splashpage_path(conference.short_title)
     click_link 'Create Splashpage'
     click_button 'Save'
@@ -246,15 +246,16 @@ feature 'Version' do
     check('Display the social media links?')
     check('Make splash page public?')
     click_button 'Save'
+    splashpage_id = conference.splashpage.id
 
     click_link 'Delete'
     page.accept_alert
     expect(page).to have_text('Splashpage was successfully destroyed')
 
     visit admin_revision_history_path
-    expect(page).to have_text("#{organizer.name} created new splashpage in conference #{conference.short_title}")
-    expect(page).to have_text("#{organizer.name} updated public, include program, include social media, include venue, include tickets, include sponsors, include lodgings and include cfp of splashpage in conference #{conference.short_title}")
-    expect(page).to have_text("#{organizer.name} deleted splashpage in conference #{conference.short_title}")
+    expect(page).to have_text("#{organizer.name} created new splashpage with ID #{splashpage_id} in conference #{conference.short_title}")
+    expect(page).to have_text("#{organizer.name} updated public, include program, include social media, include venue, include tickets, include sponsors, include lodgings and include cfp of splashpage with ID #{splashpage_id} in conference #{conference.short_title}")
+    expect(page).to have_text("#{organizer.name} deleted splashpage with ID #{splashpage_id} in conference #{conference.short_title}")
   end
 
   scenario 'displays users subscribe/unsubscribe to conferences', feature: true, versioning: true, js: true do


### PR DESCRIPTION
### Checklist

- [x] I have read the [Contribution & Best practices Guide](https://github.com/openSUSE/osem/blob/master/CONTRIBUTING.md).
- [x] My branch is up-to-date with the upstream `master` branch.
- [x] The tests pass locally with my changes.
- [ ] I have added tests that prove my fix is effective or that my feature works (if appropriate).
- [ ] I have added necessary documentation (if appropriate).

### Short description of what this resolves

b688d353ac7db7e1070436354b968bf2a503da2c makes three changes to the test of splashpage revision history:

- Change the test’s expectations
- Apply #2703
- Disable the test

The changed expectations cause a false negative.

### Changes proposed in this pull request

Revert the changed expectations and re-enable the test.