### PR TITLE
Basic feature test of survey creation and response

### DIFF
--- a/.rubocop_todo.yml
+++ b/.rubocop_todo.yml
@@ -426,7 +426,7 @@ Lint/UriRegexp:
 # Offense count: 127
 # Configuration parameters: IgnoredMethods, CountRepeatedAttributes.
 Metrics/AbcSize:
-  Max: 71
+  Max: 72
 
 # Offense count: 313
 # Configuration parameters: CountComments, CountAsOne, ExcludedMethods, IgnoredMethods.

--- a/app/controllers/surveys_controller.rb
+++ b/app/controllers/surveys_controller.rb
@@ -40,6 +40,6 @@ class SurveysController < ApplicationController
       end
     end
 
-    redirect_back(fallback_location: root_path)
+    redirect_back(fallback_location: root_path, notice: 'Successfully responded to survey.')
   end
 end

--- a/app/models/ability.rb
+++ b/app/models/ability.rb
@@ -122,9 +122,7 @@ class Ability
     # if not, do not allow replies.
 
     # do not allow replies before the start_date or after the end_date of survey
-    cannot :reply, Survey do |survey|
-      survey.start_date > Time.current || survey.end_date < Time.current
-    end
+    cannot :reply, Survey, &:closed?
 
     can [:destroy], Openid
 

--- a/app/models/admin_ability.rb
+++ b/app/models/admin_ability.rb
@@ -142,6 +142,10 @@ class AdminAbility
     can :manage, Room, venue: { conference_id: conf_ids }
     can :manage, Sponsor, conference_id: conf_ids
     can :manage, SponsorshipLevel, conference_id: conf_ids
+    can :manage, Survey, surveyable_type: 'Conference',
+                         surveyable_id:   conf_ids
+    can :manage, SurveyQuestion, survey: { surveyable_type: 'Conference',
+                                           surveyable_id:   conf_ids }
     can :manage, Ticket, conference_id: conf_ids
     can :create, TicketScanning do |ticket_scanning|
       conf_id = ticket_scanning.physical_ticket.ticket_purchase.conference_id

--- a/app/models/survey.rb
+++ b/app/models/survey.rb
@@ -32,4 +32,8 @@ class Survey < ActiveRecord::Base
       now <= end_date
     end
   end
+
+  def closed?
+    !active?
+  end
 end

--- a/app/views/admin/survey_questions/_form.html.haml
+++ b/app/views/admin/survey_questions/_form.html.haml
@@ -30,7 +30,7 @@
           = f.label :max_choices
           = f.number_field :max_choices, class: 'form-control'
       .form-group
-        %label{ required: 'required' }
+        %label{ for: 'survey_question_kind', required: 'required' }
           Type of Question:
         .form-group
           %select.selectpicker.form-control{ id: 'survey_question_kind', name: 'survey_question[kind]' }

--- a/app/views/admin/survey_questions/new.html.haml
+++ b/app/views/admin/survey_questions/new.html.haml
@@ -1,0 +1,1 @@
+= render partial: 'form'

--- a/app/views/admin/surveys/_form.html.haml
+++ b/app/views/admin/surveys/_form.html.haml
@@ -22,7 +22,7 @@
         = f.select :target, Survey.targets.keys, class: 'form-control'
       .form-group
         = f.label :start_date
-        = f.text_field :start_date, class: 'datetimepicker', class: 'form-control'
+        = f.text_field :start_date, class: 'datetimepicker form-control'
         = f.label :end_date
-        = f.text_field :end_date, class: 'datetimepicker', class: 'form-control'
+        = f.text_field :end_date, class: 'datetimepicker form-control'
       = f.submit nil, class: 'btn btn-primary'

--- a/spec/factories/surveys.rb
+++ b/spec/factories/surveys.rb
@@ -3,8 +3,6 @@
 FactoryBot.define do
   factory :survey do
     title { 'This is my survey' }
-    start_date { Date.current - 1.day }
-    end_date { Date.current + 1.day }
 
     factory :conference_survey do
       association :surveyable, factory: :conference

--- a/spec/features/surveys_spec.rb
+++ b/spec/features/surveys_spec.rb
@@ -1,0 +1,55 @@
+# frozen_string_literal: true
+
+require 'spec_helper'
+
+feature Survey do
+  let(:conference) { create(:conference) }
+
+  context 'as an organizer' do
+    let(:organizer) { create(:organizer, resource: conference) }
+
+    before :each do
+      sign_in organizer
+    end
+
+    scenario 'create a survey', feature: true, js: true do
+      visit admin_conference_path(conference)
+      click_link 'Surveys'
+      click_link 'New'
+      fill_in 'Title', with: 'Example Survey'
+      click_button 'Create Survey'
+      expect(flash).to eq('Successfully created survey')
+
+      fill_in :survey_question_title, with: 'Example question'
+      select 'boolean', from: 'Type of Question:', visible: false # Hidden by bootstrap-select
+      click_button 'Create Survey question'
+      expect(flash).to eq('Successfully created Survey Question.')
+    end
+  end
+
+  context 'as an attendee' do
+    let(:attendee) { create(:user) }
+
+    before :each do
+      sign_in attendee
+    end
+
+    scenario 'respond to a survey during registration', feature: true, js: true do
+      create :registration_period, conference: conference
+      create :registration, conference: conference, user: attendee
+      survey = create(:survey, surveyable: conference, target: :during_registration)
+      create :boolean_mandatory, survey: survey
+
+      visit conference_conference_registration_path(conference)
+      expect(find(:link, survey.title).sibling('.fa')[:title]).to eq('Please fill out the survey')
+
+      click_link survey.title
+      choose 'Yes'
+      click_button 'Submit'
+      expect(flash).to eq('Successfully responded to survey.')
+
+      visit conference_conference_registration_path(conference)
+      expect(find(:link, survey.title).sibling('.fa')[:title]).to eq('Thank you for filling out the survey')
+    end
+  end
+end


### PR DESCRIPTION
### Checklist

- [x] I have read the [Contribution & Best practices Guide](https://github.com/openSUSE/osem/blob/master/CONTRIBUTING.md).
- [x] My branch is up-to-date with the upstream `master` branch.
- [x] The tests pass locally with my changes.
- [x] I have added tests that prove my fix is effective or that my feature works (if appropriate).
- [ ] I have added necessary documentation (if appropriate).

### Short description of what this resolves

I tried using surveys for the first time and ran into a few issues:

1. When I click *Surveys → New* I get a permissions error.
2. When I click *Create Survey* I get an error about a missing view.
3. When I click a date field the date picker doesn’t appear. 
4. When I click *Type of Question* the form control isn’t focused.
5. When I view an undated survey I get an error about a failure to determine permissions.
6. When I respond to a survey nothing appears to happen.

### Changes proposed in this pull request

1. Grant conference organizers permission to manage surveys.
2. Add the missing view for survey question creation.
3. Correct the markup of the date pickers.
4. Associate the form label with its control.
5. Correct an assumption that surveys always have start and end dates.
6. Show feedback upon survey response.