### PR TITLE
Correct use of Redcarpet’s `safe_links_only` flag

### DIFF
--- a/.rubocop_todo.yml
+++ b/.rubocop_todo.yml
@@ -457,7 +457,7 @@ Metrics/MethodLength:
 # Offense count: 5
 # Configuration parameters: CountComments, CountAsOne.
 Metrics/ModuleLength:
-  Max: 173
+  Max: 174
 
 # Offense count: 26
 # Configuration parameters: IgnoredMethods.

--- a/app/helpers/format_helper.rb
+++ b/app/helpers/format_helper.rb
@@ -190,15 +190,18 @@ module FormatHelper
   def markdown(text, escape_html=true)
     return '' if text.nil?
 
-    options = {
+    markdown_options = {
       autolink:                     true,
       space_after_headers:          true,
       no_intra_emphasis:            true,
       fenced_code_blocks:           true,
-      disable_indented_code_blocks: true,
-      safe_links_only:              true
+      disable_indented_code_blocks: true
     }
-    markdown = Redcarpet::Markdown.new(Redcarpet::Render::HTML.new(escape_html: escape_html), options)
+    render_options = {
+      escape_html:     escape_html,
+      safe_links_only: true
+    }
+    markdown = Redcarpet::Markdown.new(Redcarpet::Render::HTML.new(render_options), markdown_options)
     sanitize(markdown.render(text))
   end
 

--- a/spec/helpers/format_helper_spec.rb
+++ b/spec/helpers/format_helper_spec.rb
@@ -9,8 +9,8 @@ describe FormatHelper, type: :helper do
       expect(markdown(nil)).to eq ''
     end
 
-    it "doesn't render unsafe URI schemes" do
-      expect(markdown('[a](javascript:b)')).to eq "<p><a>a</a></p>\n"
+    it "doesn't render links with unsafe URI schemes" do
+      expect(markdown('[a](javascript:b)')).to eq "<p>[a](javascript:b)</p>\n"
     end
 
     it 'should return HTML for header markdown' do

--- a/spec/helpers/format_helper_spec.rb
+++ b/spec/helpers/format_helper_spec.rb
@@ -9,6 +9,10 @@ describe FormatHelper, type: :helper do
       expect(markdown(nil)).to eq ''
     end
 
+    it "doesn't render unsafe URI schemes" do
+      expect(markdown('[a](javascript:b)')).to eq "<p><a>a</a></p>\n"
+    end
+
     it 'should return HTML for header markdown' do
       expect(markdown('# this is my header')).to eq "<h1>this is my header</h1>\n"
     end

--- a/spec/helpers/format_helper_spec.rb
+++ b/spec/helpers/format_helper_spec.rb
@@ -10,10 +10,6 @@ describe FormatHelper, type: :helper do
     end
 
     it 'should return HTML for header markdown' do
-      expect(Redcarpet::Markdown).to receive(:new)
-      .with(Redcarpet::Render::HTML, autolink: true, space_after_headers: true, no_intra_emphasis: true, fenced_code_blocks: true, disable_indented_code_blocks: true, safe_links_only: true)
-      .and_call_original
-
       expect(markdown('# this is my header')).to eq "<h1>this is my header</h1>\n"
     end
   end


### PR DESCRIPTION
### Checklist

- [x] I have read the [Contribution & Best practices Guide](https://github.com/openSUSE/osem/blob/master/CONTRIBUTING.md).
- [x] My branch is up-to-date with the upstream `master` branch.
- [x] The tests pass locally with my changes.
- [x] I have added tests that prove my fix is effective or that my feature works (if appropriate).
- [ ] I have added necessary documentation (if appropriate).

### Short description of what this resolves

The [`:safe_links_only`](https://github.com/vmg/redcarpet/blob/v3.5.1/README.markdown#darling-i-packed-you-a-couple-renderers-for-lunch) flag of `Redcarpet::Render` is being passed to `Redcarpet::Markdown`, which has no effect.

### Changes proposed in this pull request

Pass the flag to `Redcarpet::Render` instead.