### PR TITLE
Restore `colors` parameter of donut chart partial

### DIFF
--- a/app/views/application/_donut_chart.haml
+++ b/app/views/application/_donut_chart.haml
@@ -1,8 +1,9 @@
 :ruby
   combined_data ||= {}
   data ||= chart_values(combined_data)
+  colors ||= chart_colors(combined_data)
 
 .text-center
   %h4
     = title
-  = pie_chart data, donut: true, legend: 'bottom', download: true, messages: { empty: 'No data' }, colors: chart_colors(combined_data)
+  = pie_chart data, donut: true, legend: 'bottom', download: true, messages: { empty: 'No data' }, colors: colors


### PR DESCRIPTION
### Checklist

- [x] I have read the [Contribution & Best practices Guide](https://github.com/openSUSE/osem/blob/master/CONTRIBUTING.md).
- [x] My branch is up-to-date with the upstream `master` branch.
- [x] The tests pass locally with my changes.
- [ ] I have added tests that prove my fix is effective or that my feature works (if appropriate).
- [ ] I have added necessary documentation (if appropriate).

### Short description of what this resolves

Some donut charts are all black:

- Administration → Events
- Administration → Users
- Manage conference → Events → Events state

### Changes proposed in this pull request

Pass the `colors` parameter of the donut chart partial to Chartkick.