### PR TITLE
Update datatables for ajax-datatables-rails 1

### DIFF
--- a/app/controllers/admin/registrations_controller.rb
+++ b/app/controllers/admin/registrations_controller.rb
@@ -20,7 +20,7 @@ module Admin
       respond_to do |format|
         format.html
         format.json do
-          render json: RegistrationDatatable.new({}, conference: @conference, view_context: view_context)
+          render json: RegistrationDatatable.new(params, conference: @conference, view_context: view_context)
         end
         format.pdf { render 'index', layout: false }
         format.xlsx do

--- a/app/controllers/admin/users_controller.rb
+++ b/app/controllers/admin/users_controller.rb
@@ -23,7 +23,7 @@ module Admin
       respond_to do |format|
         format.html
         format.json do
-          render json: UserDatatable.new({}, view_context: view_context)
+          render json: UserDatatable.new(params, view_context: view_context)
         end
       end
     end

--- a/app/datatables/registration_datatable.rb
+++ b/app/datatables/registration_datatable.rb
@@ -51,7 +51,7 @@ class RegistrationDatatable < AjaxDatatablesRails::ActiveRecord
   end
 
   # override upstream santitation, which converts everything to strings
-  def sanitize(records)
+  def sanitize_data(records)
     records
   end
 end

--- a/app/datatables/registration_datatable.rb
+++ b/app/datatables/registration_datatable.rb
@@ -14,7 +14,6 @@ class RegistrationDatatable < AjaxDatatablesRails::ActiveRecord
     @view_columns ||= {
       id:                       { source: 'Registration.id', cond: :eq },
       name:                     { source: 'User.name' },
-      roles:                    { source: 'Role.name' },
       email:                    { source: 'User.email' },
       accepted_code_of_conduct: { source: 'Registration.accepted_code_of_conduct', searchable: false },
       actions:                  { source: 'Registration.id', searchable: false, orderable: false }
@@ -41,7 +40,6 @@ class RegistrationDatatable < AjaxDatatablesRails::ActiveRecord
         roles:                    conference_role_titles(record.user),
         email:                    record.email,
         accepted_code_of_conduct: !!record.accepted_code_of_conduct, # rubocop:disable Style/DoubleNegation
-        questions:                {},
         edit_url:                 edit_admin_conference_registration_path(conference, record),
         DT_RowId:                 record.id
       }

--- a/app/datatables/user_datatable.rb
+++ b/app/datatables/user_datatable.rb
@@ -21,7 +21,8 @@ class UserDatatable < AjaxDatatablesRails::ActiveRecord
       email:        { source: 'User.email' },
       name:         { source: 'User.name' },
       attended:     { source: 'attended_count', searchable: false },
-      roles:        { source: 'Role.name' }
+      roles:        { source: 'Role.name' },
+      actions:      { source: 'User.id', searchable: false, orderable: false }
     }
   end
 

--- a/app/datatables/user_datatable.rb
+++ b/app/datatables/user_datatable.rb
@@ -21,9 +21,7 @@ class UserDatatable < AjaxDatatablesRails::ActiveRecord
       email:        { source: 'User.email' },
       name:         { source: 'User.name' },
       attended:     { source: 'attended_count', searchable: false },
-      roles:        { source: 'Role.name' },
-      view_url:     { source: 'User.id', searchable: false, orderable: false },
-      edit_url:     { source: 'User.id', searchable: false, orderable: false }
+      roles:        { source: 'Role.name' }
     }
   end
 

--- a/app/views/admin/registrations/index.html.haml
+++ b/app/views/admin/registrations/index.html.haml
@@ -71,13 +71,13 @@
           "searchable": false
         },
         {
-          "data": null,
+          "data": "actions",
           "className": "actions",
           "searchable": false,
           "sortable": false,
           "render":    function (data, type, row, meta) {
             return '<div class="btn-group">'+
-                   '<a class="btn-primary" href="'+data.edit_url+'">Edit</a>'+
+                   '<a class="btn-primary" href="'+row.edit_url+'">Edit</a>'+
                    '</div>';
           }
         }

--- a/app/views/admin/registrations/index.html.haml
+++ b/app/views/admin/registrations/index.html.haml
@@ -26,7 +26,6 @@
           %tr
             %th{ width: '0' } ID#
             %th{ width: '25%' } Name
-            %th{ width: '0' } Roles
             %th{ width: '0' } E-Mail
             %th{ width: '0' }
               %abbr{ title: 'Code of Conduct' } CoC
@@ -64,14 +63,6 @@
           }
         },
         {
-          "name": "roles",
-          "data": "roles",
-          "className": "truncate",
-          "render": function(data, type, row) {
-            return data.join(', ');
-          }
-        },
-        {
           "data": "email"
         },
         {
@@ -94,5 +85,4 @@
     });
 
     registrationsDataTable.columns(3).visible(codeOfConductPresent);
-    registrationsDataTable.columns(2).visible(false);
   });

--- a/app/views/admin/users/index.html.haml
+++ b/app/views/admin/users/index.html.haml
@@ -61,13 +61,13 @@
           }
         },
         {
-          "data": null,
+          "data": "actions",
           "className": "actions",
           "sortable": false,
           "render":    function (data, type, row, meta) {
             return '<div class="btn-group">'+
-                   '<a class="btn-info" href="'+data.view_url+'">View</a>'+
-                   '<a class="btn-primary" href="'+data.edit_url+'">Edit</a>'+
+                   '<a class="btn-info" href="'+row.view_url+'">View</a>'+
+                   '<a class="btn-primary" href="'+row.edit_url+'">Edit</a>'+
                    '</div>';
           }
         }


### PR DESCRIPTION
### Checklist

- [x] I have read the [Contribution & Best practices Guide](https://github.com/openSUSE/osem/blob/master/CONTRIBUTING.md).
- [x] My branch is up-to-date with the upstream `master` branch.
- [x] The tests pass locally with my changes.
- [ ] I have added tests that prove my fix is effective or that my feature works (if appropriate).
- [ ] I have added necessary documentation (if appropriate).

### Short description of what this resolves

#2963 resolved some issues that were detected by the tests, but there are a few more:

1. The controls for pagination, ordering, and filtering have no effect; the same ten records are always displayed.

2. Responses to data requests fail with:

        AjaxDatatablesRails::Error::InvalidSearchColumn: Unknown column. Check that `data` field is filled on JS side with the column name

3. The registration datatable fails to render with:

        Uncaught TypeError: cannot use 'in' operator to search for "length" in "[&quot;…"

### Changes proposed in this pull request

1. Connect the data request parameters to the datatable back end.
2. Name the actions column.
3. Update the data sanitization opt-out in accordance with jbox-web/ajax-datatables-rails#326.

To make these updates easier I first removed data and columns that were unused.