### PR TITLE
Remove excessive word counts

### DIFF
--- a/app/assets/javascripts/osem.js
+++ b/app/assets/javascripts/osem.js
@@ -133,7 +133,7 @@ function get_color() {
 function word_count(text, divId, maxcount) {
     var area = document.getElementById(text.id)
 
-    Countable.live(area, function(counter) {
+    Countable.once(area, function(counter) {
         $('#' + divId).text(counter.words);
         if (counter.words > maxcount)
             $('#' + divId).css('color', 'red');
@@ -157,7 +157,7 @@ $( document ).ready(function() {
         .trigger('change');
 
     /* Count the proposal abstract length */
-    $("#event_abstract").bind('change keyup paste input', function() {
+    $("#event_abstract").on('input', function() {
         var $selected = $("#event_event_type_id option:selected")
         var max = $selected.data("max-words");
         word_count(this, 'abstract-count', max);


### PR DESCRIPTION
### Checklist

- [x] I have read the [Contribution & Best practices Guide](https://github.com/openSUSE/osem/blob/master/CONTRIBUTING.md).
- [x] My branch is up-to-date with the upstream `master` branch.
- [x] The tests pass locally with my changes.
- [ ] I have added tests that prove my fix is effective or that my feature works (if appropriate).
- [ ] I have added necessary documentation (if appropriate).

### Short description of what this resolves

Typing in the proposal’s abstract field gradually causes the browser to slow down and eventually become unresponsive. This is caused by duplicate event listeners being registered during every count, increasing the number of counts that take place every time the user types.

### Changes proposed in this pull request

- OSEM already handles setup of the event listener, so use [`Countable#once`](https://github.com/RadLikeWhoa/Countable/blob/v2.0.1/README.md#countableonceelements-callback-options) instead of [`Countable#live`](https://github.com/RadLikeWhoa/Countable/blob/v2.0.1/README.md#countableliveelements-callback-options).
- The `input` event is [widely supported](https://caniuse.com/input-event) now, so remove the redundant alternatives.