### PR TITLE
Avoid bug in which switches always display “No”

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -184,7 +184,7 @@ gem 'money-rails'
 gem 'acts_as_list'
 
 # for switch checkboxes
-gem 'bootstrap-switch-rails', '~> 3.3.5'
+gem 'bootstrap-switch-rails', '3.3.3' # Locked pending Bttstrp/bootstrap-switch#707
 
 # for parsing OEmbed data
 gem 'ruby-oembed'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -120,7 +120,7 @@ GEM
     bootstrap-sass (3.4.1)
       autoprefixer-rails (>= 5.2.1)
       sassc (>= 2.0.0)
-    bootstrap-switch-rails (3.3.5)
+    bootstrap-switch-rails (3.3.3)
     bootstrap3-datetimepicker-rails (4.17.47)
       momentjs-rails (>= 2.8.1)
     builder (3.2.4)
@@ -639,7 +639,7 @@ DEPENDENCIES
   autoprefixer-rails
   awesome_nested_set
   bootstrap-sass (~> 3.4.0)
-  bootstrap-switch-rails (~> 3.3.5)
+  bootstrap-switch-rails (= 3.3.3)
   bootstrap3-datetimepicker-rails (~> 4.17.47)
   byebug
   cancancan


### PR DESCRIPTION
### Checklist

- [x] I have read the [Contribution & Best practices Guide](https://github.com/openSUSE/osem/blob/master/CONTRIBUTING.md).
- [x] My branch is up-to-date with the upstream `master` branch.
- [x] The tests pass locally with my changes.
- [ ] I have added tests that prove my fix is effective or that my feature works (if appropriate).
- [ ] I have added necessary documentation (if appropriate).

### Short description of what this resolves

Since #2812, switches always begin in the “No” state regardless of their underlying value. (Bttstrp/bootstrap-switch#707)

### Changes proposed in this pull request

Lock the dependency to the latest unaffected version.