### PR TITLE
Fix restart during deploy

### DIFF
--- a/config/deploy.rb
+++ b/config/deploy.rb
@@ -36,7 +36,7 @@ task :deploy do
 
     on :launch do
       in_path(fetch(:current_path)) do
-        command %{bundle exec pumactl restart -e production}
+        command %{sudo systemctl restart osem}
         command %{sudo systemctl restart osem-dj}
       end
     end


### PR DESCRIPTION
pumactl restart does not make the worker re-read their
working directory. Hence new code is never used...

Use stop/start via systemd again.

