### PR TITLE
Don't include speaker information if it's nil

### DIFF
--- a/app/views/conferences/_highlights.haml
+++ b/app/views/conferences/_highlights.haml
@@ -16,6 +16,6 @@
                 class: ['img-responsive', 'img-circle'],
                 title: speaker.name
             .caption
-              - unless speaker.nil?
+              - if speaker
                 %h3.text-center= speaker.name
               %h4.text-center= event.title

--- a/app/views/conferences/_highlights.haml
+++ b/app/views/conferences/_highlights.haml
@@ -11,7 +11,7 @@
           = link_to(conference_program_proposal_path(conference_id,
             event),
             class: 'thumbnail') do
-            - unless speaker.nil?
+            - if speaker
               = image_tag speaker.gravatar_url(size: 300),
                 class: ['img-responsive', 'img-circle'],
                 title: speaker.name

--- a/app/views/conferences/_highlights.haml
+++ b/app/views/conferences/_highlights.haml
@@ -11,9 +11,11 @@
           = link_to(conference_program_proposal_path(conference_id,
             event),
             class: 'thumbnail') do
-            = image_tag speaker.gravatar_url(size: 300),
-              class: ['img-responsive', 'img-circle'],
-              title: speaker.name
+            - unless speaker.nil?
+              = image_tag speaker.gravatar_url(size: 300),
+                class: ['img-responsive', 'img-circle'],
+                title: speaker.name
             .caption
-              %h3.text-center= speaker.name
+              - unless speaker.nil?
+                %h3.text-center= speaker.name
               %h4.text-center= event.title


### PR DESCRIPTION
**Checklist**

- [x] I have read the [Contribution & Best practices Guide](https://github.com/openSUSE/osem/blob/master/CONTRIBUTING.md).
- [x] My branch is up-to-date with the upstream `master` branch.
- [x] The tests pass locally with my changes.
- [x] I have added tests that prove my fix is effective or that my feature works(if appropriate).
- [x] I have added necessary documentation (if appropriate).

**Short description of what this resolves/which [issues](https://github.com/openSUSE/osem/issues) does this fix?:**

- Speaker can be nil if there is only a submitter for the talk

**Changes proposed in this pull request:**

- Don't display speaker info if that's the case
