### PR TITLE
Fix selectize input defaults

### DIFF
--- a/app/views/booths/_form.html.haml
+++ b/app/views/booths/_form.html.haml
@@ -25,7 +25,7 @@
     = f.text_field :website_url, class: 'form-control', required: true, placeholder: 'URL'
   .form-group
     = f.label :responsible_ids, 'Responsibles'
-    = f.select :responsible_ids, [], {}, { multiple: true, class: 'form-control', id: 'users_selectize', placeholder: 'Responsibles' }
+    = f.select :responsible_ids, @booth.responsibles.pluck(:username, :id), {}, { multiple: true, class: 'form-control', id: 'users_selectize', placeholder: 'Responsibles' }
     %span.help-block
       The people responsible for the `t('booth')`. You can only select existing users.
   .form-group

--- a/app/views/proposals/_proposal_form.html.haml
+++ b/app/views/proposals/_proposal_form.html.haml
@@ -11,11 +11,7 @@
     = f.text_field :subtitle, class: 'form-control'
   .form-group
     = f.label :speaker_ids, 'Speakers'
-    - if f.object.speakers.any?
-      %p
-        Current:
-        = f.object.speakers.pluck(:username).join(', ')
-    = f.select :speaker_ids, [], {}, {  multiple: true, class: "form-control", id: "users_selectize", placeholder: "Speakers" }
+    = f.select :speaker_ids, f.object.speakers.pluck(:username, :id), {}, {  multiple: true, class: "form-control", id: "users_selectize", placeholder: "Speakers" }
     %span.help-block
       The people responsible for the event, beside you. You can only select existing users.
   - if @program.tracks.confirmed.cfp_active.any?


### PR DESCRIPTION
Not pre-filling those with existing associations lead to them being
removed on any update.

Fixes #2988

