### PR TITLE
Remove the slash between city and country name if either is empty

### DIFF
--- a/app/views/conferences/_conference_details.html.haml
+++ b/app/views/conferences/_conference_details.html.haml
@@ -12,7 +12,10 @@
               = date_string(conference.start_date, conference.end_date)
           - if conference.venue
             %p
-              = "#{conference.city}/#{conference.country_name}"
+              >= conference.city
+              - if conference.city and conference.country_name
+                \/
+              >= conference.country_name
           - unless conference.description.blank?
             %p
               = markdown(conference.description)


### PR DESCRIPTION
**Checklist**

- [x] I have read the [Contribution & Best practices Guide](https://github.com/openSUSE/osem/blob/master/CONTRIBUTING.md).
- [x] My branch is up-to-date with the upstream `master` branch.
- [x] The tests pass locally with my changes.
- [x] I have added tests that prove my fix is effective or that my feature works(if appropriate).
- [x] I have added necessary documentation (if appropriate).

**Short description of what this resolves/which [issues](https://github.com/openSUSE/osem/issues) does this fix?:**
- There's a detached slash if city or country is empty

**Changes proposed in this pull request:**
- Removes the slash if either the city or country is empty
