### PR TITLE
Surveys during proposal submission

### DIFF
--- a/app/controllers/proposals_controller.rb
+++ b/app/controllers/proposals_controller.rb
@@ -12,6 +12,7 @@ class ProposalsController < ApplicationController
     @event = @program.events.new
     @event.event_users.new(user: current_user, event_role: 'submitter')
     @events = current_user.proposals(@conference)
+    @surveys = @conference.surveys.during_proposal.select(&:active?)
   end
 
   def show

--- a/app/models/conference.rb
+++ b/app/models/conference.rb
@@ -57,6 +57,10 @@ class Conference < ApplicationRecord
   has_many :event_types, through: :program
 
   has_many :surveys, as: :surveyable, dependent: :destroy do
+    def during_proposal
+      where(target: targets[:during_proposal])
+    end
+
     def for_registration
       where(target: targets[:during_registration])
     end

--- a/app/models/survey.rb
+++ b/app/models/survey.rb
@@ -5,7 +5,7 @@ class Survey < ActiveRecord::Base
   has_many :survey_questions, dependent: :destroy
   has_many :survey_submissions, dependent: :destroy
 
-  enum target: [:after_conference, :during_registration, :after_event]
+  enum target: [:after_conference, :during_registration, :after_event, :during_proposal]
   validates :title, presence: true
 
   ##

--- a/app/views/proposals/index.html.haml
+++ b/app/views/proposals/index.html.haml
@@ -117,3 +117,10 @@
     .col-md-12
       - if can? :create, @event
         = link_to "New Proposal", new_conference_program_proposal_path(@conference.short_title), class: 'btn btn-success pull-right'
+
+  - if @surveys.any?
+    .row
+      .col-md-12
+        %h2 Surveys
+
+        = render partial: 'surveys/list', locals: { surveys: @surveys, conference: @conference }

--- a/spec/features/surveys_spec.rb
+++ b/spec/features/surveys_spec.rb
@@ -52,4 +52,30 @@ feature Survey do
       expect(find(:link, survey.title).sibling('.fa-solid')[:title]).to eq('Thank you for filling out the survey')
     end
   end
+
+  context 'as a speaker' do
+    let(:speaker) { create(:user) }
+
+    before :each do
+      sign_in speaker
+    end
+
+    scenario 'respond to a survey during proposal submission', feature: true, js: true do
+      create :cfp, program: conference.program
+      create :event, program: conference.program, submitter: speaker
+      survey = create(:survey, surveyable: conference, target: :during_proposal)
+      create :boolean_mandatory, survey: survey
+
+      visit conference_program_proposals_path(conference.short_title)
+      expect(find(:link, survey.title).sibling('.fa-solid')[:title]).to eq('Please fill out the survey')
+
+      click_link survey.title
+      choose 'Yes'
+      click_button 'Submit'
+      expect(flash).to eq('Successfully responded to survey.')
+
+      visit conference_program_proposals_path(conference.short_title)
+      expect(find(:link, survey.title).sibling('.fa-solid')[:title]).to eq('Thank you for filling out the survey')
+    end
+  end
 end


### PR DESCRIPTION
### Checklist

- [x] I have read the [Contribution & Best practices Guide](https://github.com/openSUSE/osem/blob/master/CONTRIBUTING.md).
- [x] My branch is up-to-date with the upstream `master` branch.
- [x] The tests pass locally with my changes.
- [x] I have added tests that prove my fix is effective or that my feature works (if appropriate).
- [ ] I have added necessary documentation (if appropriate).

### Short description of what this resolves

[SeaGL](https://seagl.org/) would like to collect some information from each speaker at the time of proposal submission. The information is per speaker (not per submission), per conference (might change each year), and specific to our needs (not appropriate for upstreaming). Previously we’d been hard-coding questions into the proposal form—

  - SeaGL/osem#4
  - SeaGL/osem#24

—but it was [suggested](https://github.com/SeaGL/osem/issues/8#issuecomment-423080064) that we use the surveys feature for this instead. That would fit our needs well, but “during proposal submission” isn’t one of the available targets.

### Changes proposed in this pull request

Add the `during_proposal` survey target,

> <img alt="screenshot" src="https://user-images.githubusercontent.com/1844746/174414689-973a2c0f-7ac1-471c-a1b3-0350661c2719.png" width="600" />

and list available surveys on the speaker’s Proposals screen:

> <img alt="screenshot" src="https://user-images.githubusercontent.com/1844746/174414726-e6b97724-2b63-4882-bfa6-f41233a48cb1.png" width="600" />

### Concerns

- Like `during_registration`, this isn’t actually *during* proposal submission but immediately *after* it. Is there a better place or time to display the surveys?
- The list of surveys is currently sparse, has no instructions or explanation, and might be easily overlooked. Can the design be improved?
- This adds a fork in the proposal submission flow, competing with the “complete your proposal” prompt. Which path should we encourage first? Can/should they be combined? After completing one path, is the submitter guided back to the remaining one?
- While our needs are to ask questions of each *speaker*, this implementation actually asks each *submitter*. Typically the submitter is the speaker, but this fails to handle the edge cases of multiple speakers or submissions on behalf of a speaker. How might a true per-speaker survey work?