### PR TITLE
Setting to disable email notifications of comments

### DIFF
--- a/app/controllers/admin/emails_controller.rb
+++ b/app/controllers/admin/emails_controller.rb
@@ -29,6 +29,7 @@ module Admin
                                              :send_on_accepted, :send_on_rejected, :send_on_confirmed_without_registration,
                                              :send_on_submitted_proposal,
                                              :submitted_proposal_subject, :submitted_proposal_body,
+                                             :send_on_event_comment,
                                              :registration_subject, :accepted_subject, :rejected_subject, :confirmed_without_registration_subject,
                                              :registration_body, :accepted_body, :rejected_body, :confirmed_without_registration_body,
                                              :send_on_conference_dates_updated, :conference_dates_updated_subject, :conference_dates_updated_body,

--- a/app/jobs/event_comment_mail_job.rb
+++ b/app/jobs/event_comment_mail_job.rb
@@ -4,9 +4,7 @@ class EventCommentMailJob < ApplicationJob
   queue_as :default
 
   def perform(comment)
-    conference = comment.commentable.program.conference
-
-    User.comment_notifiable(conference).each do |user|
+    User.comment_notifiable(comment.conference_id).each do |user|
       Mailbot.event_comment_mail(comment, user).deliver_now
     end
   end

--- a/app/models/comment.rb
+++ b/app/models/comment.rb
@@ -63,7 +63,13 @@ class Comment < ApplicationRecord
 
   private
 
+  def conference
+    commentable.program.conference
+  end
+
   def send_notification
+    return unless conference.email_settings.send_on_event_comment?
+
     EventCommentMailJob.perform_later(self)
   end
 end

--- a/app/models/comment.rb
+++ b/app/models/comment.rb
@@ -57,13 +57,13 @@ class Comment < ApplicationRecord
     commentable_str.constantize.find(commentable_id)
   end
 
+  def conference_id
+    commentable.program.conference_id
+  end
+
   private
 
   def send_notification
     EventCommentMailJob.perform_later(self)
-  end
-
-  def conference_id
-    commentable.program.conference_id
   end
 end

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -37,7 +37,7 @@ class User < ApplicationRecord
   after_save :touch_events
 
   # add scope
-  scope :comment_notifiable, ->(conference) {joins(:roles).where('roles.name IN (?)', [:organizer, :cfp]).where('roles.resource_type = ? AND roles.resource_id = ?', 'Conference', conference.id)}
+  scope :comment_notifiable, ->(conference_id) {joins(:roles).where('roles.name IN (?)', [:organizer, :cfp]).where('roles.resource_type = ? AND roles.resource_id = ?', 'Conference', conference_id)}
 
   # scopes for user distributions
   scope :recent, lambda {

--- a/app/views/admin/emails/index.html.haml
+++ b/app/views/admin/emails/index.html.haml
@@ -37,6 +37,10 @@
               #proposal.tab-pane{ role: 'tabpanel' }
                 .checkbox
                   %label
+                    = f.check_box :send_on_event_comment
+                    Send an email to all organizers and CfP team members when a comment is added?
+                .checkbox
+                  %label
                     = f.check_box :send_on_submitted_proposal, data: { name: 'email_settings_proposal_submited_subject'}, class: 'send_on_radio'
                     Send an email when the proposal is submitted?
                 .form-group

--- a/db/migrate/20220401000955_add_send_on_event_comment_to_email_settings.rb
+++ b/db/migrate/20220401000955_add_send_on_event_comment_to_email_settings.rb
@@ -1,0 +1,5 @@
+class AddSendOnEventCommentToEmailSettings < ActiveRecord::Migration[7.0]
+  def change
+    add_column :email_settings, :send_on_event_comment, :boolean, default: true
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 20181229233811) do
+ActiveRecord::Schema.define(version: 2022_04_01_000955) do
 
   create_table "answers", force: :cascade do |t|
     t.string "title"
@@ -192,6 +192,7 @@ ActiveRecord::Schema.define(version: 20181229233811) do
     t.boolean "send_on_submitted_proposal", default: false
     t.string "submitted_proposal_subject"
     t.text "submitted_proposal_body"
+    t.boolean "send_on_event_comment", default: true
   end
 
   create_table "event_schedules", force: :cascade do |t|

--- a/spec/models/user_spec.rb
+++ b/spec/models/user_spec.rb
@@ -88,11 +88,11 @@ describe User do
       let(:cfp_user) { create(:user, role_ids: [cfp_role.id]) }
 
       it 'includes organizer and cfp user' do
-        expect(User.comment_notifiable(conference)).to include(organizer, cfp_user)
+        expect(User.comment_notifiable(conference.id)).to include(organizer, cfp_user)
       end
 
       it 'excludes ordinary user' do
-        expect(User.comment_notifiable(conference)).not_to include(user)
+        expect(User.comment_notifiable(conference.id)).not_to include(user)
       end
     end
 


### PR DESCRIPTION
### Checklist

- [x] I have read the [Contribution & Best practices Guide](https://github.com/openSUSE/osem/blob/master/CONTRIBUTING.md).
- [x] My branch is up-to-date with the upstream `master` branch.
- [x] The tests pass locally with my changes.
- [ ] I have added tests that prove my fix is effective or that my feature works (if appropriate).
- [ ] I have added necessary documentation (if appropriate).

### Short description of what this resolves

[SeaGL](https://seagl.org/) uses comments heavily during a specific review process in which email notifications aren’t appropriate. Previously we’d simply disabled notifications by [removing](https://github.com/SeaGL/osem/commit/a09eb20cfa6f5ad75de8ace295672521e6bdf111) that code, but a runtime setting for this would be more convenient.

### Changes proposed in this pull request

Add a new setting, defaulting to enabled:

  - *E-Mails → Proposal → Send an email to all organizers and CfP team members when a comment is added?*

### Concerns

- Is *Proposal* the right place to put this, or should there be a *Comments* tab?
- This was the simplest solution to implement, but it might be preferable to instead allow more fine-grained control over which roles get notified, or to expose separate notification settings to each user.