### PR TITLE
`frozen_string_literal` is ignored after any tokens

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -1,7 +1,8 @@
+# frozen_string_literal: true
+
 def next?
   File.basename(__FILE__) == "Gemfile.next"
 end
-# frozen_string_literal: true
 
 source 'https://rubygems.org'
 


### PR DESCRIPTION
### Checklist

- [x] I have read the [Contribution & Best practices Guide](https://github.com/openSUSE/osem/blob/master/CONTRIBUTING.md).
- [x] My branch is up-to-date with the upstream `master` branch.
- [x] The tests pass locally with my changes.
- [ ] I have added tests that prove my fix is effective or that my feature works (if appropriate).
- [ ] I have added necessary documentation (if appropriate).

### Short description of what this resolves

Ruby warns:

```console
$ RUBYOPT='-w' bundle --version
Gemfile:4: warning: `frozen_string_literal' is ignored after any tokens
````

(encountered [when using bundix](https://github.com/nix-community/bundix/blob/2.5.1/lib/bundix/commandline.rb#L95))

### Changes proposed in this pull request

Move the magic comment to the top.