### PR TITLE
Use CSS-compatible row IDs in datatables

### DIFF
--- a/app/datatables/registration_datatable.rb
+++ b/app/datatables/registration_datatable.rb
@@ -3,6 +3,7 @@
 class RegistrationDatatable < AjaxDatatablesRails::ActiveRecord
   extend Forwardable
 
+  def_delegator :@view, :dom_id
   def_delegator :@view, :edit_admin_conference_registration_path
 
   def initialize(params, opts = {})
@@ -41,7 +42,7 @@ class RegistrationDatatable < AjaxDatatablesRails::ActiveRecord
         email:                    record.email,
         accepted_code_of_conduct: !!record.accepted_code_of_conduct, # rubocop:disable Style/DoubleNegation
         edit_url:                 edit_admin_conference_registration_path(conference, record),
-        DT_RowId:                 record.id
+        DT_RowId:                 dom_id(record)
       }
     end
   end

--- a/app/datatables/user_datatable.rb
+++ b/app/datatables/user_datatable.rb
@@ -3,6 +3,7 @@
 class UserDatatable < AjaxDatatablesRails::ActiveRecord
   extend Forwardable
 
+  def_delegator :@view, :dom_id
   def_delegator :@view, :show_roles
   def_delegator :@view, :admin_user_path
   def_delegator :@view, :edit_admin_user_path
@@ -39,7 +40,7 @@ class UserDatatable < AjaxDatatablesRails::ActiveRecord
         roles:        record.roles.any? ? show_roles(record.get_roles) : 'None',
         view_url:     admin_user_path(record),
         edit_url:     edit_admin_user_path(record),
-        DT_RowId:     record.id
+        DT_RowId:     dom_id(record)
       }
     end
   end

--- a/spec/datatables/user_datatable_spec.rb
+++ b/spec/datatables/user_datatable_spec.rb
@@ -76,6 +76,9 @@ describe UserDatatable do
     allow(view).to receive(:admin_user_path) do |arg|
       "/admin/users/#{arg.to_param}"
     end
+    allow(view).to receive(:dom_id) do |user|
+      "user_#{user.id}"
+    end
     allow(view).to receive(:edit_admin_user_path) do |arg|
       "/admin/users/#{arg.to_param}/edit"
     end


### PR DESCRIPTION
### Checklist

- [x] I have read the [Contribution & Best practices Guide](https://github.com/openSUSE/osem/blob/master/CONTRIBUTING.md).
- [x] My branch is up-to-date with the upstream `master` branch.
- [x] The tests pass locally with my changes.
- [ ] I have added tests that prove my fix is effective or that my feature works (if appropriate).
- [ ] I have added necessary documentation (if appropriate).

### Short description of what this resolves

The IDs of datatable rows consist only of numbers, e.g. `<tr id="123"`. CSS ID selectors [may not begin with a number](https://www.w3.org/TR/CSS21/syndata.html#value-def-identifier) so using e.g. `#123` in tests results in:

```plain
Selenium::WebDriver::Error::InvalidSelectorError:
  invalid selector: An invalid or illegal selector was specified
```

### Changes proposed in this pull request

Namespace the IDs with the class name, e.g. `#user-123`.