### PR TITLE
Remove datepicker date limits

### DIFF
--- a/app/assets/javascripts/osem-datepickers.js
+++ b/app/assets/javascripts/osem-datepickers.js
@@ -29,15 +29,11 @@ $(function () {
    var end_conference = $('form').data('end-conference');
 
    $('#registration-period-start-datepicker').datetimepicker({
-       format: 'YYYY-MM-DD',
-       minDate : today,
-       maxDate : end_conference
+       format: 'YYYY-MM-DD'
    });
 
    $('#registration-period-end-datepicker').datetimepicker({
-       format: 'YYYY-MM-DD',
-       minDate : today,
-       maxDate : end_conference
+       format: 'YYYY-MM-DD'
    });
 
   $("#conference-start-datepicker").on("dp.change",function (e) {


### PR DESCRIPTION
**Checklist**

- [x] I have read the [Contribution & Best practices Guide](https://github.com/openSUSE/osem/blob/master/CONTRIBUTING.md).
- [x] My branch is up-to-date with the upstream `master` branch.
- [ ] The tests pass locally with my changes.
- [ ] I have added tests that prove my fix is effective or that my feature works(if appropriate).
- [ ] I have added necessary documentation (if appropriate).

**Short description of what this resolves/which [issues](https://github.com/openSUSE/osem/issues) does this fix?:**

<!-- List the issue number resolved with this change; if there is no open issue, describe the problem this request solves -->

When the end_date is in the past, it wouldn't show up in the form (affects: admin/booths#edit, admin/tracks#edit).

We could live without those limits, showing the dates in UI is far more important.

**Changes proposed in this pull request:**

<!-- Summarize the changes, using declarative language. -->

- Remove date limits (`minDate` and `maxDate`) so that dates in the past still show as expected
