### PR TITLE
Add URLs to API responses

### DIFF
--- a/app/serializers/conference_serializer.rb
+++ b/app/serializers/conference_serializer.rb
@@ -2,7 +2,9 @@
 
 class ConferenceSerializer < ActiveModel::Serializer
   include ApplicationHelper
-  attributes :short_title, :title, :description, :start_date, :end_date, :picture_url,
+  include Rails.application.routes.url_helpers
+
+  attributes :short_title, :url, :title, :description, :start_date, :end_date, :picture_url,
              :difficulty_levels, :event_types, :rooms, :tracks,
              :date_range, :revision
 
@@ -54,6 +56,10 @@ class ConferenceSerializer < ActiveModel::Serializer
                                            'description' => track.description
                                          }
     end
+  end
+
+  def url
+    url_for(object)
   end
 
   def revision

--- a/app/serializers/event_serializer.rb
+++ b/app/serializers/event_serializer.rb
@@ -2,8 +2,13 @@
 
 class EventSerializer < ActiveModel::Serializer
   include ActionView::Helpers::TextHelper
+  include Rails.application.routes.url_helpers
 
-  attributes :guid, :title, :length, :scheduled_date, :language, :abstract, :speaker_ids, :type, :room, :track
+  attributes :guid, :url, :title, :length, :scheduled_date, :language, :abstract, :speaker_ids, :type, :room, :track
+
+  def url
+    conference_program_proposal_url(object.conference.short_title, object.id)
+  end
 
   def scheduled_date
     t = object.time

--- a/app/serializers/speaker_serializer.rb
+++ b/app/serializers/speaker_serializer.rb
@@ -2,8 +2,13 @@
 
 class SpeakerSerializer < ActiveModel::Serializer
   include ActionView::Helpers::TextHelper
+  include Rails.application.routes.url_helpers
 
-  attributes :name, :affiliation, :biography
+  attributes :url, :name, :affiliation, :biography
 
   delegate :name, to: :object
+
+  def url
+    url_for(object)
+  end
 end

--- a/config/environments/development.rb
+++ b/config/environments/development.rb
@@ -54,8 +54,10 @@ Rails.application.configure do
   # Annotate rendered view with file names.
   # config.action_view.annotate_rendered_view_with_filenames = true
 
-  # Set the detault url for action mailer
-  config.action_mailer.default_url_options = { host: ENV.fetch('OSEM_HOSTNAME', 'localhost:3000') }
+  # Provide a default host for URLs
+  Rails.application.routes.default_url_options[:host] = ENV.fetch('OSEM_HOSTNAME', 'localhost:3000')
+  config.action_controller.default_url_options = Rails.application.routes.default_url_options
+  config.action_mailer.default_url_options = Rails.application.routes.default_url_options
 
   # Access all mails sent at http://localhost:3000/letter_opener
   config.action_mailer.delivery_method = :letter_opener

--- a/config/environments/production.rb
+++ b/config/environments/production.rb
@@ -73,7 +73,12 @@ Rails.application.configure do
     config.logger    = ActiveSupport::TaggedLogging.new(logger)
   end
 
-  config.action_mailer.default_url_options = { host: ENV.fetch('OSEM_HOSTNAME', 'localhost:3000') }
+  # Provide a default host for URLs
+  Rails.application.routes.default_url_options[:host] = ENV.fetch('OSEM_HOSTNAME', 'localhost:3000')
+  config.action_controller.default_url_options = Rails.application.routes.default_url_options
+  config.action_mailer.default_url_options = Rails.application.routes.default_url_options
+
+  # Configure outgoing mail
   config.action_mailer.smtp_settings = {
     address:              ENV.fetch('OSEM_SMTP_ADDRESS', 'localhost'),
     port:                 ENV.fetch('OSEM_SMTP_PORT', 25),

--- a/config/environments/test.rb
+++ b/config/environments/test.rb
@@ -43,8 +43,12 @@ Rails.application.configure do
   # Tell Active Support which deprecation messages to disallow.
   config.active_support.disallowed_deprecation_warnings = []
 
-  # Set the detault url for action mailer
-  config.action_mailer.default_url_options = { host: 'localhost:3000' }
+  # Provide a default host for URLs
+  Rails.application.routes.default_url_options[:host] = 'localhost:3000'
+  config.action_controller.default_url_options = Rails.application.routes.default_url_options
+  config.action_mailer.default_url_options = Rails.application.routes.default_url_options
+
+  # Configure outgoing mail
   config.action_mailer.delivery_method = :test
 
   config.after_initialize do

--- a/spec/serializers/event_serializer_spec.rb
+++ b/spec/serializers/event_serializer_spec.rb
@@ -9,6 +9,7 @@ describe EventSerializer, type: :serializer do
     it 'sets guid, title, length, abstract and type' do
       expected_json = {
         guid:           event.guid,
+        url:            "http://localhost:3000/conferences/#{event.conference.short_title}/program/proposals/#{event.id}",
         title:          'Some Talk',
         length:         30,
         scheduled_date: '',
@@ -39,6 +40,7 @@ describe EventSerializer, type: :serializer do
     it 'sets guid, title, length, abstract, type, date, language, speakers, room and track' do
       expected_json = {
         guid:           event.guid,
+        url:            "http://localhost:3000/conferences/#{event.conference.short_title}/program/proposals/#{event.id}",
         title:          'Some Talk',
         length:         30,
         scheduled_date: ' 2014-03-04T09:00:00+0000 ',

--- a/spec/serializers/speaker_serializer_spec.rb
+++ b/spec/serializers/speaker_serializer_spec.rb
@@ -8,6 +8,7 @@ describe SpeakerSerializer, type: :serializer do
   context 'speaker does not have biography' do
     it 'sets name and affiliation' do
       expected_json = {
+        url:         "http://localhost:3000/users/#{speaker.id}",
         name:        'John Doe',
         affiliation: 'JohnDoesInc',
         biography:   nil
@@ -22,6 +23,7 @@ describe SpeakerSerializer, type: :serializer do
 
     it 'sets name, affiliation and biography' do
       expected_json = {
+        url:         "http://localhost:3000/users/#{speaker.id}",
         name:        'John Doe',
         affiliation: 'JohnDoesInc',
         biography:   'Doest of all Jon Does'

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -117,6 +117,11 @@ RSpec.configure do |config|
   #   end
   # end
 
+  # Expect configured host instead of `test.host` (see https://stackoverflow.com/q/15414847)
+  config.before(:each, type: :controller) do
+    @request.host = Rails.application.routes.default_url_options[:host]
+  end
+
   # use the config to use
   # t('some.locale.key') instead of always having to type I18n.t
   config.include AbstractController::Translation

--- a/spec/support/schemas/conference.json
+++ b/spec/support/schemas/conference.json
@@ -3,6 +3,7 @@
     "type" : "object",
     "required" : [
       "short_title",
+      "url",
       "title",
       "description",
       "start_date",
@@ -17,6 +18,9 @@
     ],
     "properties" : {
       "short_title": {
+        "type": "string"
+      },
+      "url": {
         "type": "string"
       },
       "title": {


### PR DESCRIPTION
### Checklist

- [x] I have read the [Contribution & Best practices Guide](https://github.com/openSUSE/osem/blob/master/CONTRIBUTING.md).
- [x] My branch is up-to-date with the upstream `master` branch.
- [x] The tests pass locally with my changes.
- [x] I have added tests that prove my fix is effective or that my feature works (if appropriate).
- [ ] I have added necessary documentation (if appropriate).

### Short description of what this resolves

Currently API consumers have no way to link back to OSEM, e.g. given a serialized event—

```console
$ http get 'https://osem.seagl.org/api/v1/conferences/seagl2022/events' | jq '.events[0]'
{
  "guid": "T3TQZtt26U7jzY8G78FDSw",
  "title": "The Fediverse @ Your Library",
  "length": 30,
  "scheduled_date": "2022-11-04T11:55:00.000-07:00",
  "language": "English",
  "abstract": "…",
  "speaker_ids": [1415],
  "type": "20-Minute Talk",
  "room": "d4B72ujoKiehHYox4WkrPw",
  "track": "Gq4SGqx6by4Pp-2R4Vifzw"
}
```

—produce a link to [`https://osem.seagl.org/conferences/seagl2022/program/proposals/880`](https://osem.seagl.org/conferences/seagl2022/program/proposals/880).

### Changes proposed in this pull request

Add a `url` field to serialized conferences, speakers, and events.