### PR TITLE
fix migration version and updated old rails methods into rails migrat…

### DIFF
--- a/db/migrate/20121223110942_devise_create_users.rb
+++ b/db/migrate/20121223110942_devise_create_users.rb
@@ -1,6 +1,6 @@
 # frozen_string_literal: true
 
-class DeviseCreateUsers < ActiveRecord::Migration
+class DeviseCreateUsers < ActiveRecord::Migration[4.2]
   def up
     create_table(:users) do |t|
       ## Database authenticatable

--- a/db/migrate/20121223115038_create_conferences_table.rb
+++ b/db/migrate/20121223115038_create_conferences_table.rb
@@ -1,6 +1,6 @@
 # frozen_string_literal: true
 
-class CreateConferencesTable < ActiveRecord::Migration
+class CreateConferencesTable < ActiveRecord::Migration[4.2]
   def up
     create_table :conferences do |t|
       t.string :guid, null: false

--- a/db/migrate/20121223115106_create_people_table.rb
+++ b/db/migrate/20121223115106_create_people_table.rb
@@ -1,6 +1,6 @@
 # frozen_string_literal: true
 
-class CreatePeopleTable < ActiveRecord::Migration
+class CreatePeopleTable < ActiveRecord::Migration[5.0]
   def up
     create_table :people do |t|
       t.string :guid, null: false

--- a/db/migrate/20121223115117_create_rooms_table.rb
+++ b/db/migrate/20121223115117_create_rooms_table.rb
@@ -1,6 +1,6 @@
 # frozen_string_literal: true
 
-class CreateRoomsTable < ActiveRecord::Migration
+class CreateRoomsTable < ActiveRecord::Migration[5.0]
   def up
     create_table :rooms do |t|
       t.string :guid, null: false

--- a/db/migrate/20121223115125_create_tracks_table.rb
+++ b/db/migrate/20121223115125_create_tracks_table.rb
@@ -1,6 +1,6 @@
 # frozen_string_literal: true
 
-class CreateTracksTable < ActiveRecord::Migration
+class CreateTracksTable < ActiveRecord::Migration[5.0]
   def up
     create_table :tracks do |t|
       t.string :guid, null: false

--- a/db/migrate/20121223115135_create_events_table.rb
+++ b/db/migrate/20121223115135_create_events_table.rb
@@ -1,6 +1,6 @@
 # frozen_string_literal: true
 
-class CreateEventsTable < ActiveRecord::Migration
+class CreateEventsTable < ActiveRecord::Migration[5.0]
   def up
     create_table :events do |t|
       t.string :guid, null: false

--- a/db/migrate/20121223120413_create_event_types.rb
+++ b/db/migrate/20121223120413_create_event_types.rb
@@ -1,6 +1,6 @@
 # frozen_string_literal: true
 
-class CreateEventTypes < ActiveRecord::Migration
+class CreateEventTypes < ActiveRecord::Migration[5.0]
   def up
     create_table :event_types do |t|
       t.references :conference

--- a/db/migrate/20121223122307_create_event_people_table.rb
+++ b/db/migrate/20121223122307_create_event_people_table.rb
@@ -1,6 +1,6 @@
 # frozen_string_literal: true
 
-class CreateEventPeopleTable < ActiveRecord::Migration
+class CreateEventPeopleTable < ActiveRecord::Migration[5.0]
   def self.up
     create_table :event_people do |t|
       t.references :proposal

--- a/db/migrate/20121223122842_create_venue_table.rb
+++ b/db/migrate/20121223122842_create_venue_table.rb
@@ -1,6 +1,6 @@
 # frozen_string_literal: true
 
-class CreateVenueTable < ActiveRecord::Migration
+class CreateVenueTable < ActiveRecord::Migration[5.0]
   def up
     create_table :venues do |t|
       t.string :guid

--- a/db/migrate/20121223135240_create_roles_table.rb
+++ b/db/migrate/20121223135240_create_roles_table.rb
@@ -1,6 +1,6 @@
 # frozen_string_literal: true
 
-class CreateRolesTable < ActiveRecord::Migration
+class CreateRolesTable < ActiveRecord::Migration[5.0]
   def self.up
     create_table :roles do |t|
       t.string :name

--- a/db/migrate/20121223135447_user_roles_table.rb
+++ b/db/migrate/20121223135447_user_roles_table.rb
@@ -1,6 +1,6 @@
 # frozen_string_literal: true
 
-class UserRolesTable < ActiveRecord::Migration
+class UserRolesTable < ActiveRecord::Migration[5.0]
   def self.up
     create_table :roles_users, id: false do |t|
       t.references :role, :user

--- a/db/migrate/20121224144728_create_cfp_table.rb
+++ b/db/migrate/20121224144728_create_cfp_table.rb
@@ -1,6 +1,6 @@
 # frozen_string_literal: true
 
-class CreateCfpTable < ActiveRecord::Migration
+class CreateCfpTable < ActiveRecord::Migration[5.0]
   def up
     create_table :call_for_papers do |t|
       t.date :start_date, null: false

--- a/db/migrate/20130103134212_create_registrations_table.rb
+++ b/db/migrate/20130103134212_create_registrations_table.rb
@@ -1,6 +1,6 @@
 # frozen_string_literal: true
 
-class CreateRegistrationsTable < ActiveRecord::Migration
+class CreateRegistrationsTable < ActiveRecord::Migration[5.0]
   def up
     create_table :registrations do |t|
       t.references :person

--- a/db/migrate/20130104142209_create_comments.rb
+++ b/db/migrate/20130104142209_create_comments.rb
@@ -1,6 +1,6 @@
 # frozen_string_literal: true
 
-class CreateComments < ActiveRecord::Migration
+class CreateComments < ActiveRecord::Migration[4.2]
   def self.up
     create_table :comments do |t|
       t.string :title, limit: 50, default: ''

--- a/db/migrate/20130104142839_acts_as_commentable_upgrade_migration.rb
+++ b/db/migrate/20130104142839_acts_as_commentable_upgrade_migration.rb
@@ -1,6 +1,6 @@
 # frozen_string_literal: true
 
-class ActsAsCommentableUpgradeMigration < ActiveRecord::Migration
+class ActsAsCommentableUpgradeMigration < ActiveRecord::Migration[4.2]
   def self.up
     rename_column :comments, :comment, :body
     add_column :comments, :subject, :string

--- a/db/migrate/20130105115603_create_event_attachments_table.rb
+++ b/db/migrate/20130105115603_create_event_attachments_table.rb
@@ -1,6 +1,6 @@
 # frozen_string_literal: true
 
-class CreateEventAttachmentsTable < ActiveRecord::Migration
+class CreateEventAttachmentsTable < ActiveRecord::Migration[4.2]
   def up
     create_table :event_attachments do |t|
       t.references :event

--- a/db/migrate/20130107112833_add_registration_dates_to_conferences_table.rb
+++ b/db/migrate/20130107112833_add_registration_dates_to_conferences_table.rb
@@ -1,6 +1,6 @@
 # frozen_string_literal: true
 
-class AddRegistrationDatesToConferencesTable < ActiveRecord::Migration
+class AddRegistrationDatesToConferencesTable < ActiveRecord::Migration[4.2]
   def change
     add_column :conferences, :registration_start_date, :date
     add_column :conferences, :registration_end_date, :date

--- a/db/migrate/20130107113653_remove_cfp_and_reg_booleans_from_conferences.rb
+++ b/db/migrate/20130107113653_remove_cfp_and_reg_booleans_from_conferences.rb
@@ -1,6 +1,6 @@
 # frozen_string_literal: true
 
-class RemoveCfpAndRegBooleansFromConferences < ActiveRecord::Migration
+class RemoveCfpAndRegBooleansFromConferences < ActiveRecord::Migration[4.2]
   def up
     remove_column :conferences, :cfp_open
     remove_column :conferences, :registration_open

--- a/db/migrate/20130107114930_create_versions.rb
+++ b/db/migrate/20130107114930_create_versions.rb
@@ -1,6 +1,6 @@
 # frozen_string_literal: true
 
-class CreateVersions < ActiveRecord::Migration
+class CreateVersions < ActiveRecord::Migration[4.2]
   def self.up
     create_table :versions do |t|
       t.string   :item_type, null: false

--- a/db/migrate/20130113105652_create_email_table.rb
+++ b/db/migrate/20130113105652_create_email_table.rb
@@ -1,6 +1,6 @@
 # frozen_string_literal: true
 
-class CreateEmailTable < ActiveRecord::Migration
+class CreateEmailTable < ActiveRecord::Migration[4.2]
   def up
     create_table :email_settings do |t|
       t.references :conference

--- a/db/migrate/20130113132225_add_subjects_to_email_settings.rb
+++ b/db/migrate/20130113132225_add_subjects_to_email_settings.rb
@@ -1,6 +1,6 @@
 # frozen_string_literal: true
 
-class AddSubjectsToEmailSettings < ActiveRecord::Migration
+class AddSubjectsToEmailSettings < ActiveRecord::Migration[4.2]
   def change
     add_column :email_settings, :registration_subject, :string
     add_column :email_settings, :accepted_subject, :string

--- a/db/migrate/20130117130949_add_logo_to_conferences_table.rb
+++ b/db/migrate/20130117130949_add_logo_to_conferences_table.rb
@@ -1,6 +1,6 @@
 # frozen_string_literal: true
 
-class AddLogoToConferencesTable < ActiveRecord::Migration
+class AddLogoToConferencesTable < ActiveRecord::Migration[4.2]
   def change
     add_column :conferences, :logo_file_name, :string
     add_column :conferences, :logo_content_type, :string

--- a/db/migrate/20130120104029_change_arrival_registrations_date_to_datetime.rb
+++ b/db/migrate/20130120104029_change_arrival_registrations_date_to_datetime.rb
@@ -1,6 +1,6 @@
 # frozen_string_literal: true
 
-class ChangeArrivalRegistrationsDateToDatetime < ActiveRecord::Migration
+class ChangeArrivalRegistrationsDateToDatetime < ActiveRecord::Migration[4.2]
   def up
     change_column :registrations, :arrival, :datetime
     change_column :registrations, :departure, :datetime

--- a/db/migrate/20130131100257_add_minimum_and_maximum_abstract_lengths_to_event_types.rb
+++ b/db/migrate/20130131100257_add_minimum_and_maximum_abstract_lengths_to_event_types.rb
@@ -1,6 +1,6 @@
 # frozen_string_literal: true
 
-class AddMinimumAndMaximumAbstractLengthsToEventTypes < ActiveRecord::Migration
+class AddMinimumAndMaximumAbstractLengthsToEventTypes < ActiveRecord::Migration[4.2]
   def change
     add_column :event_types, :minimum_abstract_length, :integer, default: 0
     add_column :event_types, :maximum_abstract_length, :integer, default: 500

--- a/db/migrate/20130202091022_add_dietary_choice_to_conferences.rb
+++ b/db/migrate/20130202091022_add_dietary_choice_to_conferences.rb
@@ -1,6 +1,6 @@
 # frozen_string_literal: true
 
-class AddDietaryChoiceToConferences < ActiveRecord::Migration
+class AddDietaryChoiceToConferences < ActiveRecord::Migration[4.2]
   def change
     add_column :conferences, :use_dietary_choices, :boolean, default: false
   end

--- a/db/migrate/20130202091051_create_dietary_choices_table.rb
+++ b/db/migrate/20130202091051_create_dietary_choices_table.rb
@@ -1,6 +1,6 @@
 # frozen_string_literal: true
 
-class CreateDietaryChoicesTable < ActiveRecord::Migration
+class CreateDietaryChoicesTable < ActiveRecord::Migration[4.2]
   def up
     create_table :dietary_choices do |t|
       t.references :conference

--- a/db/migrate/20130202091229_add_dietary_choice_to_registration.rb
+++ b/db/migrate/20130202091229_add_dietary_choice_to_registration.rb
@@ -1,6 +1,6 @@
 # frozen_string_literal: true
 
-class AddDietaryChoiceToRegistration < ActiveRecord::Migration
+class AddDietaryChoiceToRegistration < ActiveRecord::Migration[4.2]
   def change
     add_column :registrations, :dietary_choice_id, :integer
   end

--- a/db/migrate/20130202093137_add_dietary_text_to_registration.rb
+++ b/db/migrate/20130202093137_add_dietary_text_to_registration.rb
@@ -1,6 +1,6 @@
 # frozen_string_literal: true
 
-class AddDietaryTextToRegistration < ActiveRecord::Migration
+class AddDietaryTextToRegistration < ActiveRecord::Migration[4.2]
   def change
     add_column :registrations, :other_dietary_choice, :text
   end

--- a/db/migrate/20130202102024_add_handicapped_access_to_registrations.rb
+++ b/db/migrate/20130202102024_add_handicapped_access_to_registrations.rb
@@ -1,6 +1,6 @@
 # frozen_string_literal: true
 
-class AddHandicappedAccessToRegistrations < ActiveRecord::Migration
+class AddHandicappedAccessToRegistrations < ActiveRecord::Migration[4.2]
   def change
     add_column :registrations, :handicapped_access_required, :boolean, default: false
   end

--- a/db/migrate/20130202130737_create_supporter_level_table.rb
+++ b/db/migrate/20130202130737_create_supporter_level_table.rb
@@ -1,6 +1,6 @@
 # frozen_string_literal: true
 
-class CreateSupporterLevelTable < ActiveRecord::Migration
+class CreateSupporterLevelTable < ActiveRecord::Migration[4.2]
   def up
     create_table :supporter_levels do |t|
       t.references :conference

--- a/db/migrate/20130202130923_create_table_supporter_registrations.rb
+++ b/db/migrate/20130202130923_create_table_supporter_registrations.rb
@@ -1,6 +1,6 @@
 # frozen_string_literal: true
 
-class CreateTableSupporterRegistrations < ActiveRecord::Migration
+class CreateTableSupporterRegistrations < ActiveRecord::Migration[4.2]
   def up
     create_table :supporter_registrations do |t|
       t.references :registration

--- a/db/migrate/20130202131932_add_use_supporter_levels_to_conferences.rb
+++ b/db/migrate/20130202131932_add_use_supporter_levels_to_conferences.rb
@@ -1,6 +1,6 @@
 # frozen_string_literal: true
 
-class AddUseSupporterLevelsToConferences < ActiveRecord::Migration
+class AddUseSupporterLevelsToConferences < ActiveRecord::Migration[4.2]
   def change
     add_column :conferences, :use_supporter_levels, :boolean, default: false
   end

--- a/db/migrate/20130206192339_rename_attending_social_events_with_partner.rb
+++ b/db/migrate/20130206192339_rename_attending_social_events_with_partner.rb
@@ -1,6 +1,6 @@
 # frozen_string_literal: true
 
-class RenameAttendingSocialEventsWithPartner < ActiveRecord::Migration
+class RenameAttendingSocialEventsWithPartner < ActiveRecord::Migration[4.2]
   def up
     rename_column :registrations, :attending_social_events_with_partner, :attending_with_partner
   end

--- a/db/migrate/20130211170728_add_irc_nick_to_people_table.rb
+++ b/db/migrate/20130211170728_add_irc_nick_to_people_table.rb
@@ -1,6 +1,6 @@
 # frozen_string_literal: true
 
-class AddIrcNickToPeopleTable < ActiveRecord::Migration
+class AddIrcNickToPeopleTable < ActiveRecord::Migration[4.2]
   def change
     add_column :people, :irc_nickname, :string
   end

--- a/db/migrate/20130216070725_create_social_events_table.rb
+++ b/db/migrate/20130216070725_create_social_events_table.rb
@@ -1,6 +1,6 @@
 # frozen_string_literal: true
 
-class CreateSocialEventsTable < ActiveRecord::Migration
+class CreateSocialEventsTable < ActiveRecord::Migration[4.2]
   def up
     create_table :social_events do |t|
       t.references :conference

--- a/db/migrate/20130216120112_create_registrations_social_events_table.rb
+++ b/db/migrate/20130216120112_create_registrations_social_events_table.rb
@@ -1,6 +1,6 @@
 # frozen_string_literal: true
 
-class CreateRegistrationsSocialEventsTable < ActiveRecord::Migration
+class CreateRegistrationsSocialEventsTable < ActiveRecord::Migration[4.2]
   def up
     create_table :registrations_social_events, id: false do |t|
       t.references :registration, :social_event

--- a/db/migrate/20130216122155_set_registration_defaults_to_false.rb
+++ b/db/migrate/20130216122155_set_registration_defaults_to_false.rb
@@ -1,6 +1,6 @@
 # frozen_string_literal: true
 
-class SetRegistrationDefaultsToFalse < ActiveRecord::Migration
+class SetRegistrationDefaultsToFalse < ActiveRecord::Migration[4.2]
   def up
     change_column :registrations, :using_affiliated_lodging, :boolean, default: false
   end

--- a/db/migrate/20130216122417_add_special_needs_field_to_registrations.rb
+++ b/db/migrate/20130216122417_add_special_needs_field_to_registrations.rb
@@ -1,6 +1,6 @@
 # frozen_string_literal: true
 
-class AddSpecialNeedsFieldToRegistrations < ActiveRecord::Migration
+class AddSpecialNeedsFieldToRegistrations < ActiveRecord::Migration[4.2]
   def change
     add_column :registrations, :other_special_needs, :text
   end

--- a/db/migrate/20130515125823_change_attachment_default.rb
+++ b/db/migrate/20130515125823_change_attachment_default.rb
@@ -1,6 +1,6 @@
 # frozen_string_literal: true
 
-class ChangeAttachmentDefault < ActiveRecord::Migration
+class ChangeAttachmentDefault < ActiveRecord::Migration[4.2]
   def up
     change_column_default(:event_attachments, :public, true)
   end

--- a/db/migrate/20130515131420_change_venue_types.rb
+++ b/db/migrate/20130515131420_change_venue_types.rb
@@ -1,6 +1,6 @@
 # frozen_string_literal: true
 
-class ChangeVenueTypes < ActiveRecord::Migration
+class ChangeVenueTypes < ActiveRecord::Migration[4.2]
   def up
     change_column :venues, :name, :text
     change_column :venues, :address, :text

--- a/db/migrate/20130626095459_add_video_id_to_events.rb
+++ b/db/migrate/20130626095459_add_video_id_to_events.rb
@@ -1,6 +1,6 @@
 # frozen_string_literal: true
 
-class AddVideoIdToEvents < ActiveRecord::Migration
+class AddVideoIdToEvents < ActiveRecord::Migration[4.2]
   def change
     add_column :events, :video_id, :string
     add_column :events, :video_type, :string

--- a/db/migrate/20130705055128_add_revision_to_conference.rb
+++ b/db/migrate/20130705055128_add_revision_to_conference.rb
@@ -1,6 +1,6 @@
 # frozen_string_literal: true
 
-class AddRevisionToConference < ActiveRecord::Migration
+class AddRevisionToConference < ActiveRecord::Migration[4.2]
   def change
     add_column :conferences, :revision, :integer
   end

--- a/db/migrate/20130711043459_create_events_registrations_table.rb
+++ b/db/migrate/20130711043459_create_events_registrations_table.rb
@@ -1,6 +1,6 @@
 # frozen_string_literal: true
 
-class CreateEventsRegistrationsTable < ActiveRecord::Migration
+class CreateEventsRegistrationsTable < ActiveRecord::Migration[4.2]
   def up
     create_table :events_registrations, id: false do |t|
       t.references :registration, :event

--- a/db/migrate/20130711044247_add_require_registration_to_events.rb
+++ b/db/migrate/20130711044247_add_require_registration_to_events.rb
@@ -1,6 +1,6 @@
 # frozen_string_literal: true
 
-class AddRequireRegistrationToEvents < ActiveRecord::Migration
+class AddRequireRegistrationToEvents < ActiveRecord::Migration[4.2]
   def change
     add_column :events, :require_registration, :boolean
   end

--- a/db/migrate/20130712072609_add_attended_to_registrations.rb
+++ b/db/migrate/20130712072609_add_attended_to_registrations.rb
@@ -1,6 +1,6 @@
 # frozen_string_literal: true
 
-class AddAttendedToRegistrations < ActiveRecord::Migration
+class AddAttendedToRegistrations < ActiveRecord::Migration[4.2]
   def change
     add_column :registrations, :attended, :boolean, default: 0
   end

--- a/db/migrate/20130728055450_add_schedule_changes_to_call_for_papers.rb
+++ b/db/migrate/20130728055450_add_schedule_changes_to_call_for_papers.rb
@@ -1,6 +1,6 @@
 # frozen_string_literal: true
 
-class AddScheduleChangesToCallForPapers < ActiveRecord::Migration
+class AddScheduleChangesToCallForPapers < ActiveRecord::Migration[4.2]
   def change
     add_column :call_for_papers, :schedule_changes, :boolean, default: 0
   end

--- a/db/migrate/20130815085420_create_votes.rb
+++ b/db/migrate/20130815085420_create_votes.rb
@@ -1,6 +1,6 @@
 # frozen_string_literal: true
 
-class CreateVotes < ActiveRecord::Migration
+class CreateVotes < ActiveRecord::Migration[4.2]
   def up
     create_table :votes do |t|
       t.references :person

--- a/db/migrate/20130815201317_add_rating_to_call_for_papers.rb
+++ b/db/migrate/20130815201317_add_rating_to_call_for_papers.rb
@@ -1,6 +1,6 @@
 # frozen_string_literal: true
 
-class AddRatingToCallForPapers < ActiveRecord::Migration
+class AddRatingToCallForPapers < ActiveRecord::Migration[4.2]
   def change
     add_column :call_for_papers, :rating, :integer, null: 1
   end

--- a/db/migrate/20130815201511_add_rating_desc_to_call_for_papers.rb
+++ b/db/migrate/20130815201511_add_rating_desc_to_call_for_papers.rb
@@ -1,6 +1,6 @@
 # frozen_string_literal: true
 
-class AddRatingDescToCallForPapers < ActiveRecord::Migration
+class AddRatingDescToCallForPapers < ActiveRecord::Migration[4.2]
   def change
     add_column :call_for_papers, :rating_desc, :text
   end

--- a/db/migrate/20130821094246_add_volunteer_to_registrations.rb
+++ b/db/migrate/20130821094246_add_volunteer_to_registrations.rb
@@ -1,6 +1,6 @@
 # frozen_string_literal: true
 
-class AddVolunteerToRegistrations < ActiveRecord::Migration
+class AddVolunteerToRegistrations < ActiveRecord::Migration[4.2]
   def change
     add_column :registrations, :volunteer, :boolean
   end

--- a/db/migrate/20130821102003_add_volunteer_experience_to_registrations.rb
+++ b/db/migrate/20130821102003_add_volunteer_experience_to_registrations.rb
@@ -1,6 +1,6 @@
 # frozen_string_literal: true
 
-class AddVolunteerExperienceToRegistrations < ActiveRecord::Migration
+class AddVolunteerExperienceToRegistrations < ActiveRecord::Migration[4.2]
   def change
     add_column :people, :volunteer_experience, :text
   end

--- a/db/migrate/20130821102047_add_tshirt_to_people.rb
+++ b/db/migrate/20130821102047_add_tshirt_to_people.rb
@@ -1,6 +1,6 @@
 # frozen_string_literal: true
 
-class AddTshirtToPeople < ActiveRecord::Migration
+class AddTshirtToPeople < ActiveRecord::Migration[4.2]
   def change
     add_column :people, :tshirt, :string
   end

--- a/db/migrate/20130821102108_add_mobile_to_people.rb
+++ b/db/migrate/20130821102108_add_mobile_to_people.rb
@@ -1,6 +1,6 @@
 # frozen_string_literal: true
 
-class AddMobileToPeople < ActiveRecord::Migration
+class AddMobileToPeople < ActiveRecord::Migration[4.2]
   def change
     add_column :people, :mobile, :string
   end

--- a/db/migrate/20130821102404_add_languages_to_people.rb
+++ b/db/migrate/20130821102404_add_languages_to_people.rb
@@ -1,6 +1,6 @@
 # frozen_string_literal: true
 
-class AddLanguagesToPeople < ActiveRecord::Migration
+class AddLanguagesToPeople < ActiveRecord::Migration[4.2]
   def change
     add_column :people, :languages, :string
   end

--- a/db/migrate/20130821102543_add_use_vpositions_to_conferences.rb
+++ b/db/migrate/20130821102543_add_use_vpositions_to_conferences.rb
@@ -1,6 +1,6 @@
 # frozen_string_literal: true
 
-class AddUseVpositionsToConferences < ActiveRecord::Migration
+class AddUseVpositionsToConferences < ActiveRecord::Migration[4.2]
   def change
     add_column :conferences, :use_vpositions, :boolean
   end

--- a/db/migrate/20130821102618_add_use_vdays_to_conferences.rb
+++ b/db/migrate/20130821102618_add_use_vdays_to_conferences.rb
@@ -1,6 +1,6 @@
 # frozen_string_literal: true
 
-class AddUseVdaysToConferences < ActiveRecord::Migration
+class AddUseVdaysToConferences < ActiveRecord::Migration[4.2]
   def change
     add_column :conferences, :use_vdays, :boolean
   end

--- a/db/migrate/20130821133651_create_vpositions.rb
+++ b/db/migrate/20130821133651_create_vpositions.rb
@@ -1,6 +1,6 @@
 # frozen_string_literal: true
 
-class CreateVpositions < ActiveRecord::Migration
+class CreateVpositions < ActiveRecord::Migration[4.2]
   def up
     create_table :vpositions do |t|
       t.references :conference

--- a/db/migrate/20130821133850_create_vdays.rb
+++ b/db/migrate/20130821133850_create_vdays.rb
@@ -1,6 +1,6 @@
 # frozen_string_literal: true
 
-class CreateVdays < ActiveRecord::Migration
+class CreateVdays < ActiveRecord::Migration[4.2]
   def up
     create_table :vdays do |t|
       t.references :conference

--- a/db/migrate/20131022131450_add_created_at_to_supporter_registrations.rb
+++ b/db/migrate/20131022131450_add_created_at_to_supporter_registrations.rb
@@ -1,6 +1,6 @@
 # frozen_string_literal: true
 
-class AddCreatedAtToSupporterRegistrations < ActiveRecord::Migration
+class AddCreatedAtToSupporterRegistrations < ActiveRecord::Migration[4.2]
   def change
     add_column :supporter_registrations, :created_at, :datetime
   end

--- a/db/migrate/20131228132353_change_default_rating_in_call_for_papers.rb
+++ b/db/migrate/20131228132353_change_default_rating_in_call_for_papers.rb
@@ -1,6 +1,6 @@
 # frozen_string_literal: true
 
-class ChangeDefaultRatingInCallForPapers < ActiveRecord::Migration
+class ChangeDefaultRatingInCallForPapers < ActiveRecord::Migration[4.2]
   def up
     change_column :call_for_papers, :rating, :integer, default: 3
   end

--- a/db/migrate/20131228214532_create_vchoices.rb
+++ b/db/migrate/20131228214532_create_vchoices.rb
@@ -1,6 +1,6 @@
 # frozen_string_literal: true
 
-class CreateVchoices < ActiveRecord::Migration
+class CreateVchoices < ActiveRecord::Migration[4.2]
   def change
     create_table :vchoices do |t|
       t.references :vday

--- a/db/migrate/20131229072532_registrations_vchoices.rb
+++ b/db/migrate/20131229072532_registrations_vchoices.rb
@@ -1,6 +1,6 @@
 # frozen_string_literal: true
 
-class RegistrationsVchoices < ActiveRecord::Migration
+class RegistrationsVchoices < ActiveRecord::Migration[4.2]
   def up
     create_table :registrations_vchoices, id: false do |t|
       t.references :registration, :vchoice

--- a/db/migrate/20140109190643_create_questions.rb
+++ b/db/migrate/20140109190643_create_questions.rb
@@ -1,6 +1,6 @@
 # frozen_string_literal: true
 
-class CreateQuestions < ActiveRecord::Migration
+class CreateQuestions < ActiveRecord::Migration[4.2]
   def change
     create_table :questions do |t|
       t.string :title

--- a/db/migrate/20140109190844_create_question_types.rb
+++ b/db/migrate/20140109190844_create_question_types.rb
@@ -1,6 +1,6 @@
 # frozen_string_literal: true
 
-class CreateQuestionTypes < ActiveRecord::Migration
+class CreateQuestionTypes < ActiveRecord::Migration[4.2]
   def change
     create_table :question_types do |t|
       t.string :title

--- a/db/migrate/20140109191042_create_answers.rb
+++ b/db/migrate/20140109191042_create_answers.rb
@@ -1,6 +1,6 @@
 # frozen_string_literal: true
 
-class CreateAnswers < ActiveRecord::Migration
+class CreateAnswers < ActiveRecord::Migration[4.2]
   def change
     create_table :answers do |t|
       t.string :title

--- a/db/migrate/20140109191145_create_qanswers.rb
+++ b/db/migrate/20140109191145_create_qanswers.rb
@@ -1,6 +1,6 @@
 # frozen_string_literal: true
 
-class CreateQanswers < ActiveRecord::Migration
+class CreateQanswers < ActiveRecord::Migration[4.2]
   def change
     create_table :qanswers do |t|
       t.references :question

--- a/db/migrate/20140109191321_create_conferences_questions.rb
+++ b/db/migrate/20140109191321_create_conferences_questions.rb
@@ -1,6 +1,6 @@
 # frozen_string_literal: true
 
-class CreateConferencesQuestions < ActiveRecord::Migration
+class CreateConferencesQuestions < ActiveRecord::Migration[4.2]
   def change
     create_table :conferences_questions, id: false do |t|
       t.references :conference

--- a/db/migrate/20140112192801_create_qanswers_registrations.rb
+++ b/db/migrate/20140112192801_create_qanswers_registrations.rb
@@ -1,6 +1,6 @@
 # frozen_string_literal: true
 
-class CreateQanswersRegistrations < ActiveRecord::Migration
+class CreateQanswersRegistrations < ActiveRecord::Migration[4.2]
   def change
     create_table :qanswers_registrations, id: false do |t|
       t.references :registration, null: false

--- a/db/migrate/20140212172244_create_difficulty_levels.rb
+++ b/db/migrate/20140212172244_create_difficulty_levels.rb
@@ -1,6 +1,6 @@
 # frozen_string_literal: true
 
-class CreateDifficultyLevels < ActiveRecord::Migration
+class CreateDifficultyLevels < ActiveRecord::Migration[4.2]
   def change
     create_table :difficulty_levels do |t|
       t.references :conference

--- a/db/migrate/20140212175251_add_use_difficulty_levels_to_conference.rb
+++ b/db/migrate/20140212175251_add_use_difficulty_levels_to_conference.rb
@@ -1,6 +1,6 @@
 # frozen_string_literal: true
 
-class AddUseDifficultyLevelsToConference < ActiveRecord::Migration
+class AddUseDifficultyLevelsToConference < ActiveRecord::Migration[4.2]
   def change
     add_column :conferences, :use_difficulty_levels, :boolean, default: false
   end

--- a/db/migrate/20140213122424_add_difficulty_level_id_to_events.rb
+++ b/db/migrate/20140213122424_add_difficulty_level_id_to_events.rb
@@ -1,6 +1,6 @@
 # frozen_string_literal: true
 
-class AddDifficultyLevelIdToEvents < ActiveRecord::Migration
+class AddDifficultyLevelIdToEvents < ActiveRecord::Migration[4.2]
   def change
     add_column :events, :difficulty_level_id, :integer
   end

--- a/db/migrate/20140304192527_add_use_volunteers_to_conference.rb
+++ b/db/migrate/20140304192527_add_use_volunteers_to_conference.rb
@@ -1,6 +1,6 @@
 # frozen_string_literal: true
 
-class AddUseVolunteersToConference < ActiveRecord::Migration
+class AddUseVolunteersToConference < ActiveRecord::Migration[4.2]
   def change
     add_column :conferences, :use_volunteers, :boolean
   end

--- a/db/migrate/20140305102505_use_vdays_vpositions_defaults.rb
+++ b/db/migrate/20140305102505_use_vdays_vpositions_defaults.rb
@@ -1,6 +1,6 @@
 # frozen_string_literal: true
 
-class UseVdaysVpositionsDefaults < ActiveRecord::Migration
+class UseVdaysVpositionsDefaults < ActiveRecord::Migration[4.2]
   def up
     change_column :conferences, :use_vpositions, :boolean, default: false
     change_column :conferences, :use_vdays, :boolean, default: false

--- a/db/migrate/20140319143547_rename_video_to_media_on_events.rb
+++ b/db/migrate/20140319143547_rename_video_to_media_on_events.rb
@@ -1,6 +1,6 @@
 # frozen_string_literal: true
 
-class RenameVideoToMediaOnEvents < ActiveRecord::Migration
+class RenameVideoToMediaOnEvents < ActiveRecord::Migration[4.2]
   def up
     rename_column :events, :video_id, :media_id
     rename_column :events, :video_type, :media_type

--- a/db/migrate/20140401094729_add_schedule_public_to_call_for_papers.rb
+++ b/db/migrate/20140401094729_add_schedule_public_to_call_for_papers.rb
@@ -1,6 +1,6 @@
 # frozen_string_literal: true
 
-class AddSchedulePublicToCallForPapers < ActiveRecord::Migration
+class AddSchedulePublicToCallForPapers < ActiveRecord::Migration[4.2]
   def change
     add_column :call_for_papers, :schedule_public, :boolean
   end

--- a/db/migrate/20140414131028_add_video_to_conferences.rb
+++ b/db/migrate/20140414131028_add_video_to_conferences.rb
@@ -1,6 +1,6 @@
 # frozen_string_literal: true
 
-class AddVideoToConferences < ActiveRecord::Migration
+class AddVideoToConferences < ActiveRecord::Migration[4.2]
   def change
     add_column :conferences, :media_id, :string
     add_column :conferences, :media_type, :string

--- a/db/migrate/20140514140013_remove_rating_desc_from_cfp.rb
+++ b/db/migrate/20140514140013_remove_rating_desc_from_cfp.rb
@@ -1,6 +1,6 @@
 # frozen_string_literal: true
 
-class RemoveRatingDescFromCfp < ActiveRecord::Migration
+class RemoveRatingDescFromCfp < ActiveRecord::Migration[4.2]
   def up
     remove_column :call_for_papers, :rating_desc
   end

--- a/db/migrate/20140528072939_add_color_to_conference.rb
+++ b/db/migrate/20140528072939_add_color_to_conference.rb
@@ -1,6 +1,6 @@
 # frozen_string_literal: true
 
-class AddColorToConference < ActiveRecord::Migration
+class AddColorToConference < ActiveRecord::Migration[4.2]
   def change
     add_column :conferences, :color, :string, default: '#000000'
   end

--- a/db/migrate/20140528084706_add_description_to_conference.rb
+++ b/db/migrate/20140528084706_add_description_to_conference.rb
@@ -1,6 +1,6 @@
 # frozen_string_literal: true
 
-class AddDescriptionToConference < ActiveRecord::Migration
+class AddDescriptionToConference < ActiveRecord::Migration[4.2]
   def change
     add_column :conferences, :description, :text
   end

--- a/db/migrate/20140528115842_add_registration_description_to_conference.rb
+++ b/db/migrate/20140528115842_add_registration_description_to_conference.rb
@@ -1,6 +1,6 @@
 # frozen_string_literal: true
 
-class AddRegistrationDescriptionToConference < ActiveRecord::Migration
+class AddRegistrationDescriptionToConference < ActiveRecord::Migration[4.2]
   def change
     add_column :conferences, :registration_description, :text
   end

--- a/db/migrate/20140529133052_add_ticket_description_to_conference.rb
+++ b/db/migrate/20140529133052_add_ticket_description_to_conference.rb
@@ -1,6 +1,6 @@
 # frozen_string_literal: true
 
-class AddTicketDescriptionToConference < ActiveRecord::Migration
+class AddTicketDescriptionToConference < ActiveRecord::Migration[4.2]
   def change
     add_column :conferences, :ticket_description, :text
   end

--- a/db/migrate/20140529133228_add_description_to_supporter_level.rb
+++ b/db/migrate/20140529133228_add_description_to_supporter_level.rb
@@ -1,6 +1,6 @@
 # frozen_string_literal: true
 
-class AddDescriptionToSupporterLevel < ActiveRecord::Migration
+class AddDescriptionToSupporterLevel < ActiveRecord::Migration[4.2]
   def change
     add_column :supporter_levels, :description, :text
   end

--- a/db/migrate/20140529133339_add_ticket_price_to_supporter_level.rb
+++ b/db/migrate/20140529133339_add_ticket_price_to_supporter_level.rb
@@ -1,6 +1,6 @@
 # frozen_string_literal: true
 
-class AddTicketPriceToSupporterLevel < ActiveRecord::Migration
+class AddTicketPriceToSupporterLevel < ActiveRecord::Migration[4.2]
   def change
     add_column :supporter_levels, :ticket_price, :string
   end

--- a/db/migrate/20140530082708_remove_color_defaults.rb
+++ b/db/migrate/20140530082708_remove_color_defaults.rb
@@ -1,6 +1,6 @@
 # frozen_string_literal: true
 
-class RemoveColorDefaults < ActiveRecord::Migration
+class RemoveColorDefaults < ActiveRecord::Migration[4.2]
   def change
     change_column_default(:tracks, :color, nil)
     change_column_default(:conferences, :color, nil)

--- a/db/migrate/20140603092041_create_openids.rb
+++ b/db/migrate/20140603092041_create_openids.rb
@@ -1,6 +1,6 @@
 # frozen_string_literal: true
 
-class CreateOpenids < ActiveRecord::Migration
+class CreateOpenids < ActiveRecord::Migration[4.2]
   def change
     create_table :openids do |t|
       t.string :provider

--- a/db/migrate/20140604061951_create_lodgings.rb
+++ b/db/migrate/20140604061951_create_lodgings.rb
@@ -1,6 +1,6 @@
 # frozen_string_literal: true
 
-class CreateLodgings < ActiveRecord::Migration
+class CreateLodgings < ActiveRecord::Migration[4.2]
   def change
     create_table :lodgings do |t|
       t.string :name

--- a/db/migrate/20140604142949_remove_hard_deadline_from_call_for_papers.rb
+++ b/db/migrate/20140604142949_remove_hard_deadline_from_call_for_papers.rb
@@ -1,6 +1,6 @@
 # frozen_string_literal: true
 
-class RemoveHardDeadlineFromCallForPapers < ActiveRecord::Migration
+class RemoveHardDeadlineFromCallForPapers < ActiveRecord::Migration[4.2]
   def up
     remove_column :call_for_papers, :hard_deadline
   end

--- a/db/migrate/20140605055802_create_sponsorship_levels.rb
+++ b/db/migrate/20140605055802_create_sponsorship_levels.rb
@@ -1,6 +1,6 @@
 # frozen_string_literal: true
 
-class CreateSponsorshipLevels < ActiveRecord::Migration
+class CreateSponsorshipLevels < ActiveRecord::Migration[4.2]
   def change
     create_table :sponsorship_levels do |t|
       t.string :title

--- a/db/migrate/20140605115251_create_sponsors.rb
+++ b/db/migrate/20140605115251_create_sponsors.rb
@@ -1,6 +1,6 @@
 # frozen_string_literal: true
 
-class CreateSponsors < ActiveRecord::Migration
+class CreateSponsors < ActiveRecord::Migration[4.2]
   def change
     create_table :sponsors do |t|
       t.string :name

--- a/db/migrate/20140605125153_update_event_states.rb
+++ b/db/migrate/20140605125153_update_event_states.rb
@@ -1,6 +1,6 @@
 # frozen_string_literal: true
 
-class UpdateEventStates < ActiveRecord::Migration
+class UpdateEventStates < ActiveRecord::Migration[4.2]
   def change
     execute "UPDATE events SET state='new' WHERE state = 'review';"
   end

--- a/db/migrate/20140606102331_add_sponsor_description_to_conference.rb
+++ b/db/migrate/20140606102331_add_sponsor_description_to_conference.rb
@@ -1,6 +1,6 @@
 # frozen_string_literal: true
 
-class AddSponsorDescriptionToConference < ActiveRecord::Migration
+class AddSponsorDescriptionToConference < ActiveRecord::Migration[4.2]
   def change
     add_column :conferences, :sponsor_description, :text
   end

--- a/db/migrate/20140606102358_add_sponsor_email_to_conference.rb
+++ b/db/migrate/20140606102358_add_sponsor_email_to_conference.rb
@@ -1,6 +1,6 @@
 # frozen_string_literal: true
 
-class AddSponsorEmailToConference < ActiveRecord::Migration
+class AddSponsorEmailToConference < ActiveRecord::Migration[4.2]
   def change
     add_column :conferences, :sponsor_email, :string
   end

--- a/db/migrate/20140609172219_add_person_attributes_to_user.rb
+++ b/db/migrate/20140609172219_add_person_attributes_to_user.rb
@@ -1,6 +1,6 @@
 # frozen_string_literal: true
 
-class AddPersonAttributesToUser < ActiveRecord::Migration
+class AddPersonAttributesToUser < ActiveRecord::Migration[4.2]
   def change
     add_column :users, :name, :string
     add_column :users, :email_public, :boolean

--- a/db/migrate/20140610064046_create_photos.rb
+++ b/db/migrate/20140610064046_create_photos.rb
@@ -1,6 +1,6 @@
 # frozen_string_literal: true
 
-class CreatePhotos < ActiveRecord::Migration
+class CreatePhotos < ActiveRecord::Migration[4.2]
   def change
     create_table :photos do |t|
       t.text :description

--- a/db/migrate/20140610163947_create_event_users.rb
+++ b/db/migrate/20140610163947_create_event_users.rb
@@ -1,6 +1,6 @@
 # frozen_string_literal: true
 
-class CreateEventUsers < ActiveRecord::Migration
+class CreateEventUsers < ActiveRecord::Migration[4.2]
   class TempPerson < ActiveRecord::Base
     self.table_name = 'people'
   end

--- a/db/migrate/20140610165551_migrate_data_person_to_user.rb
+++ b/db/migrate/20140610165551_migrate_data_person_to_user.rb
@@ -1,6 +1,6 @@
 # frozen_string_literal: true
 
-class MigrateDataPersonToUser < ActiveRecord::Migration
+class MigrateDataPersonToUser < ActiveRecord::Migration[4.2]
   class TempPerson < ActiveRecord::Base
     self.table_name = 'people'
   end

--- a/db/migrate/20140610173021_change_person_id_to_user_id_in_registrations.rb
+++ b/db/migrate/20140610173021_change_person_id_to_user_id_in_registrations.rb
@@ -1,6 +1,6 @@
 # frozen_string_literal: true
 
-class ChangePersonIdToUserIdInRegistrations < ActiveRecord::Migration
+class ChangePersonIdToUserIdInRegistrations < ActiveRecord::Migration[4.2]
   class TempPerson < ActiveRecord::Base
     self.table_name = 'people'
   end

--- a/db/migrate/20140611123926_change_person_id_to_user_id_in_votes.rb
+++ b/db/migrate/20140611123926_change_person_id_to_user_id_in_votes.rb
@@ -1,6 +1,6 @@
 # frozen_string_literal: true
 
-class ChangePersonIdToUserIdInVotes < ActiveRecord::Migration
+class ChangePersonIdToUserIdInVotes < ActiveRecord::Migration[4.2]
   class TempPerson < ActiveRecord::Base
     self.table_name = 'people'
   end

--- a/db/migrate/20140612141123_add_color_to_event_type.rb
+++ b/db/migrate/20140612141123_add_color_to_event_type.rb
@@ -1,6 +1,6 @@
 # frozen_string_literal: true
 
-class AddColorToEventType < ActiveRecord::Migration
+class AddColorToEventType < ActiveRecord::Migration[4.2]
   def change
     add_column :event_types, :color, :string
   end

--- a/db/migrate/20140612181230_add_social_urls_to_conference.rb
+++ b/db/migrate/20140612181230_add_social_urls_to_conference.rb
@@ -1,6 +1,6 @@
 # frozen_string_literal: true
 
-class AddSocialUrlsToConference < ActiveRecord::Migration
+class AddSocialUrlsToConference < ActiveRecord::Migration[4.2]
   def change
     add_column :conferences, :twitter_url, :string
     add_column :conferences, :facebook_url, :string

--- a/db/migrate/20140613083115_add_photo_to_venue.rb
+++ b/db/migrate/20140613083115_add_photo_to_venue.rb
@@ -1,6 +1,6 @@
 # frozen_string_literal: true
 
-class AddPhotoToVenue < ActiveRecord::Migration
+class AddPhotoToVenue < ActiveRecord::Migration[4.2]
   def change
     add_column :venues, :photo_file_name, :string
     add_column :venues, :photo_content_type, :string

--- a/db/migrate/20140614171853_add_lodging_description_to_conference.rb
+++ b/db/migrate/20140614171853_add_lodging_description_to_conference.rb
@@ -1,6 +1,6 @@
 # frozen_string_literal: true
 
-class AddLodgingDescriptionToConference < ActiveRecord::Migration
+class AddLodgingDescriptionToConference < ActiveRecord::Migration[4.2]
   def change
     add_column :conferences, :lodging_description, :text
   end

--- a/db/migrate/20140614174354_add_website_link_to_lodging.rb
+++ b/db/migrate/20140614174354_add_website_link_to_lodging.rb
@@ -1,6 +1,6 @@
 # frozen_string_literal: true
 
-class AddWebsiteLinkToLodging < ActiveRecord::Migration
+class AddWebsiteLinkToLodging < ActiveRecord::Migration[4.2]
   def change
     add_column :lodgings, :website_link, :string
   end

--- a/db/migrate/20140616131731_add_make_conference_public_to_conference.rb
+++ b/db/migrate/20140616131731_add_make_conference_public_to_conference.rb
@@ -1,6 +1,6 @@
 # frozen_string_literal: true
 
-class AddMakeConferencePublicToConference < ActiveRecord::Migration
+class AddMakeConferencePublicToConference < ActiveRecord::Migration[4.2]
   def change
     add_column :conferences, :make_conference_public, :boolean, default: false
   end

--- a/db/migrate/20140616132153_create_targets.rb
+++ b/db/migrate/20140616132153_create_targets.rb
@@ -1,6 +1,6 @@
 # frozen_string_literal: true
 
-class CreateTargets < ActiveRecord::Migration
+class CreateTargets < ActiveRecord::Migration[4.2]
   def change
     create_table :targets do |t|
       t.integer :conference_id

--- a/db/migrate/20140616132456_create_campaigns.rb
+++ b/db/migrate/20140616132456_create_campaigns.rb
@@ -1,6 +1,6 @@
 # frozen_string_literal: true
 
-class CreateCampaigns < ActiveRecord::Migration
+class CreateCampaigns < ActiveRecord::Migration[4.2]
   def change
     create_table :campaigns do |t|
       t.integer :conference_id

--- a/db/migrate/20140617140018_add_checkboxes_for_splash_components_to_conference.rb
+++ b/db/migrate/20140617140018_add_checkboxes_for_splash_components_to_conference.rb
@@ -1,6 +1,6 @@
 # frozen_string_literal: true
 
-class AddCheckboxesForSplashComponentsToConference < ActiveRecord::Migration
+class AddCheckboxesForSplashComponentsToConference < ActiveRecord::Migration[4.2]
   def change
     add_column :conferences, :include_registrations_in_splash, :boolean, default: false
     add_column :conferences, :include_sponsors_in_splash, :boolean, default: false

--- a/db/migrate/20140617141918_add_include_cfp_in_splash_to_call_for_papers.rb
+++ b/db/migrate/20140617141918_add_include_cfp_in_splash_to_call_for_papers.rb
@@ -1,6 +1,6 @@
 # frozen_string_literal: true
 
-class AddIncludeCfpInSplashToCallForPapers < ActiveRecord::Migration
+class AddIncludeCfpInSplashToCallForPapers < ActiveRecord::Migration[4.2]
   def change
     add_column :call_for_papers, :include_cfp_in_splash, :boolean, default: false
   end

--- a/db/migrate/20140617145048_add_venue_checkboxes_to_venue.rb
+++ b/db/migrate/20140617145048_add_venue_checkboxes_to_venue.rb
@@ -1,6 +1,6 @@
 # frozen_string_literal: true
 
-class AddVenueCheckboxesToVenue < ActiveRecord::Migration
+class AddVenueCheckboxesToVenue < ActiveRecord::Migration[4.2]
   def change
     add_column :venues, :include_venue_in_splash, :boolean, default: false
     add_column :venues, :include_lodgings_in_splash, :boolean, default: false

--- a/db/migrate/20140620130306_add_banner_photo_to_conference.rb
+++ b/db/migrate/20140620130306_add_banner_photo_to_conference.rb
@@ -1,6 +1,6 @@
 # frozen_string_literal: true
 
-class AddBannerPhotoToConference < ActiveRecord::Migration
+class AddBannerPhotoToConference < ActiveRecord::Migration[4.2]
   def change
     add_column :conferences, :banner_photo_file_name, :string
     add_column :conferences, :banner_photo_content_type, :string

--- a/db/migrate/20140620134535_add_include_banner_in_splash_to_conference.rb
+++ b/db/migrate/20140620134535_add_include_banner_in_splash_to_conference.rb
@@ -1,6 +1,6 @@
 # frozen_string_literal: true
 
-class AddIncludeBannerInSplashToConference < ActiveRecord::Migration
+class AddIncludeBannerInSplashToConference < ActiveRecord::Migration[4.2]
   def change
     add_column :conferences, :include_banner_in_splash, :boolean, default: false
   end

--- a/db/migrate/20140623100942_create_visits.rb
+++ b/db/migrate/20140623100942_create_visits.rb
@@ -1,6 +1,6 @@
 # frozen_string_literal: true
 
-class CreateVisits < ActiveRecord::Migration
+class CreateVisits < ActiveRecord::Migration[4.2]
   def change
     create_table :visits do |t|
       t.uuid :visitor_id

--- a/db/migrate/20140623101032_create_ahoy_events.rb
+++ b/db/migrate/20140623101032_create_ahoy_events.rb
@@ -1,6 +1,6 @@
 # frozen_string_literal: true
 
-class CreateAhoyEvents < ActiveRecord::Migration
+class CreateAhoyEvents < ActiveRecord::Migration[4.2]
   def change
     create_table :ahoy_events  do |t|
       t.uuid :visit_id

--- a/db/migrate/20140623150541_drop_person_and_event_person_tables.rb
+++ b/db/migrate/20140623150541_drop_person_and_event_person_tables.rb
@@ -1,6 +1,6 @@
 # frozen_string_literal: true
 
-class DropPersonAndEventPersonTables < ActiveRecord::Migration
+class DropPersonAndEventPersonTables < ActiveRecord::Migration[4.2]
   def change
     drop_table :people
     drop_table :event_people

--- a/db/migrate/20140625112608_add_week_to_event.rb
+++ b/db/migrate/20140625112608_add_week_to_event.rb
@@ -1,6 +1,6 @@
 # frozen_string_literal: true
 
-class AddWeekToEvent < ActiveRecord::Migration
+class AddWeekToEvent < ActiveRecord::Migration[4.2]
   class Event < ActiveRecord::Base
   end
 

--- a/db/migrate/20140625114813_add_week_to_registration.rb
+++ b/db/migrate/20140625114813_add_week_to_registration.rb
@@ -1,6 +1,6 @@
 # frozen_string_literal: true
 
-class AddWeekToRegistration < ActiveRecord::Migration
+class AddWeekToRegistration < ActiveRecord::Migration[4.2]
   class Registration < ActiveRecord::Base
   end
 

--- a/db/migrate/20140627165718_add_instagram_url_to_conference.rb
+++ b/db/migrate/20140627165718_add_instagram_url_to_conference.rb
@@ -1,6 +1,6 @@
 # frozen_string_literal: true
 
-class AddInstagramUrlToConference < ActiveRecord::Migration
+class AddInstagramUrlToConference < ActiveRecord::Migration[4.2]
   def change
     add_column :conferences, :instagram_url, :string
   end

--- a/db/migrate/20140701123203_add_events_per_week_to_conference.rb
+++ b/db/migrate/20140701123203_add_events_per_week_to_conference.rb
@@ -1,6 +1,6 @@
 # frozen_string_literal: true
 
-class AddEventsPerWeekToConference < ActiveRecord::Migration
+class AddEventsPerWeekToConference < ActiveRecord::Migration[4.2]
   class TempVersion < ActiveRecord::Base
     self.table_name = 'versions'
     serialize :object_changes, HashWithIndifferentAccess

--- a/db/migrate/20140707120158_add_conference_dates_updates_to_email_settings.rb
+++ b/db/migrate/20140707120158_add_conference_dates_updates_to_email_settings.rb
@@ -1,6 +1,6 @@
 # frozen_string_literal: true
 
-class AddConferenceDatesUpdatesToEmailSettings < ActiveRecord::Migration
+class AddConferenceDatesUpdatesToEmailSettings < ActiveRecord::Migration[4.2]
   def change
     add_column :email_settings, :send_on_updated_conference_dates, :boolean, default: true
     add_column :email_settings, :updated_conference_dates_subject, :string

--- a/db/migrate/20140710130608_add_conference_registration_dates_updates_to_email_settings.rb
+++ b/db/migrate/20140710130608_add_conference_registration_dates_updates_to_email_settings.rb
@@ -1,6 +1,6 @@
 # frozen_string_literal: true
 
-class AddConferenceRegistrationDatesUpdatesToEmailSettings < ActiveRecord::Migration
+class AddConferenceRegistrationDatesUpdatesToEmailSettings < ActiveRecord::Migration[4.2]
   def change
     add_column :email_settings, :send_on_updated_conference_registration_dates, :boolean, default: true
     add_column :email_settings, :updated_conference_registration_dates_subject, :string

--- a/db/migrate/20140711072651_add_description_and_resource_to_roles.rb
+++ b/db/migrate/20140711072651_add_description_and_resource_to_roles.rb
@@ -1,6 +1,6 @@
 # frozen_string_literal: true
 
-class AddDescriptionAndResourceToRoles < ActiveRecord::Migration
+class AddDescriptionAndResourceToRoles < ActiveRecord::Migration[4.2]
   def change
     add_column :roles, :description, :string
     add_reference :roles, :resource, polymorphic: true

--- a/db/migrate/20140711113037_add_venue_update_to_email_settings.rb
+++ b/db/migrate/20140711113037_add_venue_update_to_email_settings.rb
@@ -1,6 +1,6 @@
 # frozen_string_literal: true
 
-class AddVenueUpdateToEmailSettings < ActiveRecord::Migration
+class AddVenueUpdateToEmailSettings < ActiveRecord::Migration[4.2]
   def change
     add_column :email_settings, :send_on_venue_update, :boolean, default: true
     add_column :email_settings, :venue_update_subject, :string

--- a/db/migrate/20140714141156_add_volunteer_fields_to_user.rb
+++ b/db/migrate/20140714141156_add_volunteer_fields_to_user.rb
@@ -1,6 +1,6 @@
 # frozen_string_literal: true
 
-class AddVolunteerFieldsToUser < ActiveRecord::Migration
+class AddVolunteerFieldsToUser < ActiveRecord::Migration[4.2]
   def change
     add_column :users, :mobile, :string
     add_column :users, :tshirt, :string

--- a/db/migrate/20140716115448_add_default_value_to_email_settings.rb
+++ b/db/migrate/20140716115448_add_default_value_to_email_settings.rb
@@ -1,6 +1,6 @@
 # frozen_string_literal: true
 
-class AddDefaultValueToEmailSettings < ActiveRecord::Migration
+class AddDefaultValueToEmailSettings < ActiveRecord::Migration[4.2]
   def up
     change_column :email_settings, :send_on_registration, :boolean, default: false
     change_column :email_settings, :send_on_accepted, :boolean, default: false

--- a/db/migrate/20140718103856_add_is_admin_to_users.rb
+++ b/db/migrate/20140718103856_add_is_admin_to_users.rb
@@ -1,6 +1,6 @@
 # frozen_string_literal: true
 
-class AddIsAdminToUsers < ActiveRecord::Migration
+class AddIsAdminToUsers < ActiveRecord::Migration[4.2]
   def change
     add_column :users, :is_admin, :boolean, default: false
   end

--- a/db/migrate/20140719160903_create_delayed_jobs.rb
+++ b/db/migrate/20140719160903_create_delayed_jobs.rb
@@ -1,6 +1,6 @@
 # frozen_string_literal: true
 
-class CreateDelayedJobs < ActiveRecord::Migration
+class CreateDelayedJobs < ActiveRecord::Migration[4.2]
   def self.up
     create_table :delayed_jobs, force: true do |table|
       table.integer  :priority, default: 0, null: false # Allows some jobs to jump to the front of the queue

--- a/db/migrate/20140724113107_add_call_for_papers_updates_to_email_settings.rb
+++ b/db/migrate/20140724113107_add_call_for_papers_updates_to_email_settings.rb
@@ -1,6 +1,6 @@
 # frozen_string_literal: true
 
-class AddCallForPapersUpdatesToEmailSettings < ActiveRecord::Migration
+class AddCallForPapersUpdatesToEmailSettings < ActiveRecord::Migration[4.2]
   def change
     add_column :email_settings, :send_on_call_for_papers_dates_updates, :boolean, default: false
     add_column :email_settings, :send_on_call_for_papers_schedule_public, :boolean, default: false

--- a/db/migrate/20140724153520_create_subscriptions.rb
+++ b/db/migrate/20140724153520_create_subscriptions.rb
@@ -1,6 +1,6 @@
 # frozen_string_literal: true
 
-class CreateSubscriptions < ActiveRecord::Migration
+class CreateSubscriptions < ActiveRecord::Migration[4.2]
   def change
     create_table :subscriptions do |t|
       t.belongs_to :user

--- a/db/migrate/20140730104658_migrate_roles_for_cancancan.rb
+++ b/db/migrate/20140730104658_migrate_roles_for_cancancan.rb
@@ -1,6 +1,6 @@
 # frozen_string_literal: true
 
-class MigrateRolesForCancancan < ActiveRecord::Migration
+class MigrateRolesForCancancan < ActiveRecord::Migration[4.2]
   def up
     # Store the number of existing roles
     old_roles = Role.count

--- a/db/migrate/20140731153332_create_contacts.rb
+++ b/db/migrate/20140731153332_create_contacts.rb
@@ -1,6 +1,6 @@
 # frozen_string_literal: true
 
-class CreateContacts < ActiveRecord::Migration
+class CreateContacts < ActiveRecord::Migration[4.2]
   def change
     create_table :contacts do |t|
       t.string :social_tag

--- a/db/migrate/20140731165107_move_conference_contact_details_to_contact.rb
+++ b/db/migrate/20140731165107_move_conference_contact_details_to_contact.rb
@@ -1,6 +1,6 @@
 # frozen_string_literal: true
 
-class MoveConferenceContactDetailsToContact < ActiveRecord::Migration
+class MoveConferenceContactDetailsToContact < ActiveRecord::Migration[4.2]
   class TempConference < ActiveRecord::Base
     self.table_name = 'conferences'
   end

--- a/db/migrate/20140801103645_create_commercials.rb
+++ b/db/migrate/20140801103645_create_commercials.rb
@@ -1,6 +1,6 @@
 # frozen_string_literal: true
 
-class CreateCommercials < ActiveRecord::Migration
+class CreateCommercials < ActiveRecord::Migration[4.2]
   def change
     create_table :commercials do |t|
       t.string :commercial_id

--- a/db/migrate/20140801164901_move_conference_media_to_commercial.rb
+++ b/db/migrate/20140801164901_move_conference_media_to_commercial.rb
@@ -1,6 +1,6 @@
 # frozen_string_literal: true
 
-class MoveConferenceMediaToCommercial < ActiveRecord::Migration
+class MoveConferenceMediaToCommercial < ActiveRecord::Migration[4.2]
   class TempConference < ActiveRecord::Base
     self.table_name = 'conferences'
   end

--- a/db/migrate/20140801170430_move_event_media_to_commercial.rb
+++ b/db/migrate/20140801170430_move_event_media_to_commercial.rb
@@ -1,6 +1,6 @@
 # frozen_string_literal: true
 
-class MoveEventMediaToCommercial < ActiveRecord::Migration
+class MoveEventMediaToCommercial < ActiveRecord::Migration[4.2]
   class TempEvent < ActiveRecord::Base
     self.table_name = 'events'
   end

--- a/db/migrate/20140804185823_create_registration_periods.rb
+++ b/db/migrate/20140804185823_create_registration_periods.rb
@@ -1,6 +1,6 @@
 # frozen_string_literal: true
 
-class CreateRegistrationPeriods < ActiveRecord::Migration
+class CreateRegistrationPeriods < ActiveRecord::Migration[4.2]
   def up
     create_table :registration_periods do |t|
       t.integer :conference_id

--- a/db/migrate/20140812065531_move_conference_registration_data_to_registration_periods.rb
+++ b/db/migrate/20140812065531_move_conference_registration_data_to_registration_periods.rb
@@ -1,6 +1,6 @@
 # frozen_string_literal: true
 
-class MoveConferenceRegistrationDataToRegistrationPeriods < ActiveRecord::Migration
+class MoveConferenceRegistrationDataToRegistrationPeriods < ActiveRecord::Migration[4.2]
   class TempConference < ActiveRecord::Base
     self.table_name = 'conferences'
   end

--- a/db/migrate/20140819124315_rename_supporter_level_to_ticket.rb
+++ b/db/migrate/20140819124315_rename_supporter_level_to_ticket.rb
@@ -1,6 +1,6 @@
 # frozen_string_literal: true
 
-class RenameSupporterLevelToTicket < ActiveRecord::Migration
+class RenameSupporterLevelToTicket < ActiveRecord::Migration[4.2]
   def up
     rename_table :supporter_levels, :tickets
   end

--- a/db/migrate/20140820093735_migrating_supporter_registrations_to_ticket_users.rb
+++ b/db/migrate/20140820093735_migrating_supporter_registrations_to_ticket_users.rb
@@ -1,6 +1,6 @@
 # frozen_string_literal: true
 
-class MigratingSupporterRegistrationsToTicketUsers < ActiveRecord::Migration
+class MigratingSupporterRegistrationsToTicketUsers < ActiveRecord::Migration[4.2]
   class TempSupporterRegistrations < ActiveRecord::Base
     self.table_name = 'supporter_registrations'
   end

--- a/db/migrate/20140820123503_assign_users_to_events.rb
+++ b/db/migrate/20140820123503_assign_users_to_events.rb
@@ -1,6 +1,6 @@
 # frozen_string_literal: true
 
-class AssignUsersToEvents < ActiveRecord::Migration
+class AssignUsersToEvents < ActiveRecord::Migration[4.2]
   class TempEvent < ActiveRecord::Base
     self.table_name = 'events'
   end

--- a/db/migrate/20140820124117_undo_wrong_migration20140801080705_add_users_to_events.rb
+++ b/db/migrate/20140820124117_undo_wrong_migration20140801080705_add_users_to_events.rb
@@ -1,6 +1,6 @@
 # frozen_string_literal: true
 
-class UndoWrongMigration20140801080705AddUsersToEvents < ActiveRecord::Migration
+class UndoWrongMigration20140801080705AddUsersToEvents < ActiveRecord::Migration[7.0]
   class TempEvent < ActiveRecord::Base
     self.table_name = 'events'
   end
@@ -20,7 +20,7 @@ class UndoWrongMigration20140801080705AddUsersToEvents < ActiveRecord::Migration
   end
 
   def up
-    if ActiveRecord::Migrator.get_all_versions.include? 20140801080705
+    if ApplicationRecord.connection.migration_context.get_all_versions.include? 20140801080705
       user_deleted = TempUser.find_by(email: 'deleted@localhost.osem')
 
       TempEvent.all.each do |event|

--- a/db/migrate/20140821103643_split_ticket_price_in_price_and_currency.rb
+++ b/db/migrate/20140821103643_split_ticket_price_in_price_and_currency.rb
@@ -1,6 +1,6 @@
 # frozen_string_literal: true
 
-class SplitTicketPriceInPriceAndCurrency < ActiveRecord::Migration
+class SplitTicketPriceInPriceAndCurrency < ActiveRecord::Migration[4.2]
   class TempTicket < ActiveRecord::Base
     self.table_name = 'tickets'
   end

--- a/db/migrate/20140825091222_create_splashpages.rb
+++ b/db/migrate/20140825091222_create_splashpages.rb
@@ -1,6 +1,6 @@
 # frozen_string_literal: true
 
-class CreateSplashpages < ActiveRecord::Migration
+class CreateSplashpages < ActiveRecord::Migration[4.2]
   def change
     create_table :splashpages do |t|
       t.integer :conference_id

--- a/db/migrate/20140825093132_move_splashpage_attributes_from_conference_to_splashpage.rb
+++ b/db/migrate/20140825093132_move_splashpage_attributes_from_conference_to_splashpage.rb
@@ -1,6 +1,6 @@
 # frozen_string_literal: true
 
-class MoveSplashpageAttributesFromConferenceToSplashpage < ActiveRecord::Migration
+class MoveSplashpageAttributesFromConferenceToSplashpage < ActiveRecord::Migration[4.2]
   class TempConference < ActiveRecord::Base
     self.table_name = 'conferences'
   end

--- a/db/migrate/20140930092923_move_sponsor_email_to_contact.rb
+++ b/db/migrate/20140930092923_move_sponsor_email_to_contact.rb
@@ -1,6 +1,6 @@
 # frozen_string_literal: true
 
-class MoveSponsorEmailToContact < ActiveRecord::Migration
+class MoveSponsorEmailToContact < ActiveRecord::Migration[4.2]
   class TempConference < ActiveRecord::Base
     self.table_name = 'conferences'
   end

--- a/db/migrate/20141031225545_add_require_handicapped_access_to_questions.rb
+++ b/db/migrate/20141031225545_add_require_handicapped_access_to_questions.rb
@@ -1,6 +1,6 @@
 # frozen_string_literal: true
 
-class AddRequireHandicappedAccessToQuestions < ActiveRecord::Migration
+class AddRequireHandicappedAccessToQuestions < ActiveRecord::Migration[4.2]
   class TempRegistration < ActiveRecord::Base
     self.table_name = 'registrations'
 

--- a/db/migrate/20141031225606_add_attending_with_partner_to_questions.rb
+++ b/db/migrate/20141031225606_add_attending_with_partner_to_questions.rb
@@ -1,6 +1,6 @@
 # frozen_string_literal: true
 
-class AddAttendingWithPartnerToQuestions < ActiveRecord::Migration
+class AddAttendingWithPartnerToQuestions < ActiveRecord::Migration[4.2]
   class TempRegistration < ActiveRecord::Base
     self.table_name = 'registrations'
 

--- a/db/migrate/20141031225620_add_staying_at_suggested_hotel_to_questions.rb
+++ b/db/migrate/20141031225620_add_staying_at_suggested_hotel_to_questions.rb
@@ -1,6 +1,6 @@
 # frozen_string_literal: true
 
-class AddStayingAtSuggestedHotelToQuestions < ActiveRecord::Migration
+class AddStayingAtSuggestedHotelToQuestions < ActiveRecord::Migration[4.2]
   class TempRegistration < ActiveRecord::Base
     self.table_name = 'registrations'
 

--- a/db/migrate/20141031225635_add_attending_social_events_to_questions.rb
+++ b/db/migrate/20141031225635_add_attending_social_events_to_questions.rb
@@ -1,6 +1,6 @@
 # frozen_string_literal: true
 
-class AddAttendingSocialEventsToQuestions < ActiveRecord::Migration
+class AddAttendingSocialEventsToQuestions < ActiveRecord::Migration[4.2]
   class TempRegistration < ActiveRecord::Base
     self.table_name = 'registrations'
 

--- a/db/migrate/20141103132913_add_username_to_users.rb
+++ b/db/migrate/20141103132913_add_username_to_users.rb
@@ -1,6 +1,6 @@
 # frozen_string_literal: true
 
-class AddUsernameToUsers < ActiveRecord::Migration
+class AddUsernameToUsers < ActiveRecord::Migration[4.2]
   def change
     add_column :users, :username, :string
     add_index :users, :username, unique: true

--- a/db/migrate/20141104131625_generate_username.rb
+++ b/db/migrate/20141104131625_generate_username.rb
@@ -1,6 +1,6 @@
 # frozen_string_literal: true
 
-class GenerateUsername < ActiveRecord::Migration
+class GenerateUsername < ActiveRecord::Migration[4.2]
   class TempUser < ActiveRecord::Base
     self.table_name = 'users'
   end
@@ -10,7 +10,7 @@ class GenerateUsername < ActiveRecord::Migration
       if user.username.blank?
         username = user.email.split('@')[0]
         username += user.id.to_s if TempUser.find_by(username: username)
-        user.update_attributes(username: username)
+        user.update(username: username)
       end
     end
   end

--- a/db/migrate/20141106141750_add_is_disabled_flag_to_user.rb
+++ b/db/migrate/20141106141750_add_is_disabled_flag_to_user.rb
@@ -1,6 +1,6 @@
 # frozen_string_literal: true
 
-class AddIsDisabledFlagToUser < ActiveRecord::Migration
+class AddIsDisabledFlagToUser < ActiveRecord::Migration[4.2]
   def change
     add_column :users, :is_disabled, :boolean, default: false
   end

--- a/db/migrate/20141109172204_set_room_public_default_to_false.rb
+++ b/db/migrate/20141109172204_set_room_public_default_to_false.rb
@@ -1,6 +1,6 @@
 # frozen_string_literal: true
 
-class SetRoomPublicDefaultToFalse < ActiveRecord::Migration
+class SetRoomPublicDefaultToFalse < ActiveRecord::Migration[4.2]
   def change
     change_column :rooms, :public, :boolean, default: false
   end

--- a/db/migrate/20141113134103_add_position_to_sponsorship_level.rb
+++ b/db/migrate/20141113134103_add_position_to_sponsorship_level.rb
@@ -1,6 +1,6 @@
 # frozen_string_literal: true
 
-class AddPositionToSponsorshipLevel < ActiveRecord::Migration
+class AddPositionToSponsorshipLevel < ActiveRecord::Migration[4.2]
   def change
     add_column :sponsorship_levels, :position, :integer
   end

--- a/db/migrate/20141117214230_move_banner_description_to_conference.rb
+++ b/db/migrate/20141117214230_move_banner_description_to_conference.rb
@@ -1,6 +1,6 @@
 # frozen_string_literal: true
 
-class MoveBannerDescriptionToConference < ActiveRecord::Migration
+class MoveBannerDescriptionToConference < ActiveRecord::Migration[4.2]
   class TempConference < ActiveRecord::Base
     self.table_name = 'conferences'
   end

--- a/db/migrate/20141117222919_drop_splash_descriptions_and_photo.rb
+++ b/db/migrate/20141117222919_drop_splash_descriptions_and_photo.rb
@@ -1,6 +1,6 @@
 # frozen_string_literal: true
 
-class DropSplashDescriptionsAndPhoto < ActiveRecord::Migration
+class DropSplashDescriptionsAndPhoto < ActiveRecord::Migration[4.2]
   def change
     remove_column :splashpages, :ticket_description
     remove_column :splashpages, :sponsor_description

--- a/db/migrate/20141118143700_add_address_fields_to_venue.rb
+++ b/db/migrate/20141118143700_add_address_fields_to_venue.rb
@@ -1,6 +1,6 @@
 # frozen_string_literal: true
 
-class AddAddressFieldsToVenue < ActiveRecord::Migration
+class AddAddressFieldsToVenue < ActiveRecord::Migration[4.2]
   def change
     add_column :venues, :street, :string
     add_column :venues, :postalcode, :integer

--- a/db/migrate/20141118150427_cleanup_venue.rb
+++ b/db/migrate/20141118150427_cleanup_venue.rb
@@ -1,6 +1,6 @@
 # frozen_string_literal: true
 
-class CleanupVenue < ActiveRecord::Migration
+class CleanupVenue < ActiveRecord::Migration[4.2]
   def change
     change_column :venues, :name, :string
     remove_column :venues, :offline_map_url, :string

--- a/db/migrate/20141118153918_change_venue_conference_association.rb
+++ b/db/migrate/20141118153918_change_venue_conference_association.rb
@@ -1,6 +1,6 @@
 # frozen_string_literal: true
 
-class ChangeVenueConferenceAssociation < ActiveRecord::Migration
+class ChangeVenueConferenceAssociation < ActiveRecord::Migration[4.2]
   class TempConference < ActiveRecord::Base
     self.table_name = 'conferences'
   end

--- a/db/migrate/20141118162030_change_lodging_association_to_conference.rb
+++ b/db/migrate/20141118162030_change_lodging_association_to_conference.rb
@@ -1,6 +1,6 @@
 # frozen_string_literal: true
 
-class ChangeLodgingAssociationToConference < ActiveRecord::Migration
+class ChangeLodgingAssociationToConference < ActiveRecord::Migration[4.2]
   class TempConference < ActiveRecord::Base
     self.table_name = 'conferences'
   end

--- a/db/migrate/20141120205757_remove_public_from_room.rb
+++ b/db/migrate/20141120205757_remove_public_from_room.rb
@@ -1,6 +1,6 @@
 # frozen_string_literal: true
 
-class RemovePublicFromRoom < ActiveRecord::Migration
+class RemovePublicFromRoom < ActiveRecord::Migration[4.2]
   def change
     remove_column :rooms, :public, :boolean, default: false
   end

--- a/db/migrate/20141121102656_remove_description_from_call_for_paper.rb
+++ b/db/migrate/20141121102656_remove_description_from_call_for_paper.rb
@@ -1,6 +1,6 @@
 # frozen_string_literal: true
 
-class RemoveDescriptionFromCallForPaper < ActiveRecord::Migration
+class RemoveDescriptionFromCallForPaper < ActiveRecord::Migration[4.2]
   def change
     remove_column :call_for_papers, :description, :text
   end

--- a/db/migrate/20141127161313_add_is_highlight_in_events.rb
+++ b/db/migrate/20141127161313_add_is_highlight_in_events.rb
@@ -1,6 +1,6 @@
 # frozen_string_literal: true
 
-class AddIsHighlightInEvents < ActiveRecord::Migration
+class AddIsHighlightInEvents < ActiveRecord::Migration[4.2]
   def change
     add_column :events, :is_highlight, :boolean, default: false
   end

--- a/db/migrate/20141128073306_migrate_data_remove_column_include_cfp_in_splash_add_column_include_cfp.rb
+++ b/db/migrate/20141128073306_migrate_data_remove_column_include_cfp_in_splash_add_column_include_cfp.rb
@@ -1,6 +1,6 @@
 # frozen_string_literal: true
 
-class MigrateDataRemoveColumnIncludeCfpInSplashAddColumnIncludeCfp < ActiveRecord::Migration
+class MigrateDataRemoveColumnIncludeCfpInSplashAddColumnIncludeCfp < ActiveRecord::Migration[4.2]
   class TempConference < ActiveRecord::Base
     self.table_name = 'conferences'
   end

--- a/db/migrate/20141130182139_drop_table_event_attachments.rb
+++ b/db/migrate/20141130182139_drop_table_event_attachments.rb
@@ -1,6 +1,6 @@
 # frozen_string_literal: true
 
-class DropTableEventAttachments < ActiveRecord::Migration
+class DropTableEventAttachments < ActiveRecord::Migration[4.2]
   def change
     drop_table :event_attachments
   end

--- a/db/migrate/20150304135935_add_created_atto_qanswer.rb
+++ b/db/migrate/20150304135935_add_created_atto_qanswer.rb
@@ -1,6 +1,6 @@
 # frozen_string_literal: true
 
-class AddCreatedAttoQanswer < ActiveRecord::Migration
+class AddCreatedAttoQanswer < ActiveRecord::Migration[4.2]
   def change
     add_column :qanswers, :created_at, :datetime
     add_column :qanswers, :updated_at, :datetime

--- a/db/migrate/20150415121038_add_description_to_event_type.rb
+++ b/db/migrate/20150415121038_add_description_to_event_type.rb
@@ -1,6 +1,6 @@
 # frozen_string_literal: true
 
-class AddDescriptionToEventType < ActiveRecord::Migration
+class AddDescriptionToEventType < ActiveRecord::Migration[4.2]
   def change
     add_column :event_types, :description, :string
   end

--- a/db/migrate/20150417050953_add_url_to_commercial.rb
+++ b/db/migrate/20150417050953_add_url_to_commercial.rb
@@ -1,6 +1,6 @@
 # frozen_string_literal: true
 
-class AddUrlToCommercial < ActiveRecord::Migration
+class AddUrlToCommercial < ActiveRecord::Migration[4.2]
   class TempCommercial < ActiveRecord::Base
     self.table_name = 'commercials'
   end

--- a/db/migrate/20150929142405_change_postalcode_format_in_venues.rb
+++ b/db/migrate/20150929142405_change_postalcode_format_in_venues.rb
@@ -1,6 +1,6 @@
 # frozen_string_literal: true
 
-class ChangePostalcodeFormatInVenues < ActiveRecord::Migration
+class ChangePostalcodeFormatInVenues < ActiveRecord::Migration[4.2]
   def up
     change_column :venues, :postalcode, :string
   end

--- a/db/migrate/20151005161518_rename_templates_in_email_settings.rb
+++ b/db/migrate/20151005161518_rename_templates_in_email_settings.rb
@@ -1,6 +1,6 @@
 # frozen_string_literal: true
 
-class RenameTemplatesInEmailSettings < ActiveRecord::Migration
+class RenameTemplatesInEmailSettings < ActiveRecord::Migration[4.2]
   def change
     rename_column :email_settings, :registration_email_template, :registration_body
     rename_column :email_settings, :accepted_email_template, :accepted_body

--- a/db/migrate/20151018152439_create_programs_table.rb
+++ b/db/migrate/20151018152439_create_programs_table.rb
@@ -1,6 +1,6 @@
 # frozen_string_literal: true
 
-class CreateProgramsTable < ActiveRecord::Migration
+class CreateProgramsTable < ActiveRecord::Migration[4.2]
   class TempConference < ActiveRecord::Base
     self.table_name = 'conferences'
   end

--- a/db/migrate/20151018154513_rename_conference_id_to_program_id_in_events_tracks_difficulty_levels.rb
+++ b/db/migrate/20151018154513_rename_conference_id_to_program_id_in_events_tracks_difficulty_levels.rb
@@ -1,6 +1,6 @@
 # frozen_string_literal: true
 
-class RenameConferenceIdToProgramIdInEventsTracksDifficultyLevels < ActiveRecord::Migration
+class RenameConferenceIdToProgramIdInEventsTracksDifficultyLevels < ActiveRecord::Migration[4.2]
   class TempConference < ActiveRecord::Base
     self.table_name = 'conferences'
   end

--- a/db/migrate/20151021113015_rename_email_settings_with_cfp_and_program.rb
+++ b/db/migrate/20151021113015_rename_email_settings_with_cfp_and_program.rb
@@ -1,6 +1,6 @@
 # frozen_string_literal: true
 
-class RenameEmailSettingsWithCfpAndProgram < ActiveRecord::Migration
+class RenameEmailSettingsWithCfpAndProgram < ActiveRecord::Migration[4.2]
   def change
     rename_column :email_settings, :send_on_call_for_papers_schedule_public, :send_on_program_schedule_public
     rename_column :email_settings, :call_for_papers_schedule_public_body, :program_schedule_public_body

--- a/db/migrate/20151031092713_change_conference_id_to_venue_id_in_rooms.rb
+++ b/db/migrate/20151031092713_change_conference_id_to_venue_id_in_rooms.rb
@@ -1,6 +1,6 @@
 # frozen_string_literal: true
 
-class ChangeConferenceIdToVenueIdInRooms < ActiveRecord::Migration
+class ChangeConferenceIdToVenueIdInRooms < ActiveRecord::Migration[4.2]
   class TempConference < ActiveRecord::Base
     self.table_name = 'conferences'
 

--- a/db/migrate/20160201221411_add_registration_limit_to_conferences.rb
+++ b/db/migrate/20160201221411_add_registration_limit_to_conferences.rb
@@ -1,6 +1,6 @@
 # frozen_string_literal: true
 
-class AddRegistrationLimitToConferences < ActiveRecord::Migration
+class AddRegistrationLimitToConferences < ActiveRecord::Migration[4.2]
   def change
     add_column :conferences, :registration_limit, :integer, default: 0
   end

--- a/db/migrate/20160226133808_rename_roles_users_to_users_roles.rb
+++ b/db/migrate/20160226133808_rename_roles_users_to_users_roles.rb
@@ -1,6 +1,6 @@
 # frozen_string_literal: true
 
-class RenameRolesUsersToUsersRoles < ActiveRecord::Migration
+class RenameRolesUsersToUsersRoles < ActiveRecord::Migration[4.2]
   def change
     rename_table :roles_users, :users_roles
   end

--- a/db/migrate/20160309182642_remove_social_events_table.rb
+++ b/db/migrate/20160309182642_remove_social_events_table.rb
@@ -1,6 +1,6 @@
 # frozen_string_literal: true
 
-class RemoveSocialEventsTable < ActiveRecord::Migration
+class RemoveSocialEventsTable < ActiveRecord::Migration[4.2]
   class TempConference < ActiveRecord::Base
     self.table_name = 'conferences'
 

--- a/db/migrate/20160309182655_remove_dietary_choices_table.rb
+++ b/db/migrate/20160309182655_remove_dietary_choices_table.rb
@@ -1,6 +1,6 @@
 # frozen_string_literal: true
 
-class RemoveDietaryChoicesTable < ActiveRecord::Migration
+class RemoveDietaryChoicesTable < ActiveRecord::Migration[4.2]
   class TempDietaryChoice < ActiveRecord::Base
     self.table_name = 'dietary_choices'
 

--- a/db/migrate/20160309183052_remove_html_export_path_from_conferences.rb
+++ b/db/migrate/20160309183052_remove_html_export_path_from_conferences.rb
@@ -1,6 +1,6 @@
 # frozen_string_literal: true
 
-class RemoveHtmlExportPathFromConferences < ActiveRecord::Migration
+class RemoveHtmlExportPathFromConferences < ActiveRecord::Migration[4.2]
   def change
     remove_column :conferences, :html_export_path, :string
   end

--- a/db/migrate/20160320220630_add_languages_to_program.rb
+++ b/db/migrate/20160320220630_add_languages_to_program.rb
@@ -1,6 +1,6 @@
 # frozen_string_literal: true
 
-class AddLanguagesToProgram < ActiveRecord::Migration
+class AddLanguagesToProgram < ActiveRecord::Migration[4.2]
   def change
     add_column :programs, :languages, :string
   end

--- a/db/migrate/20160323154504_add_max_attendees_to_events.rb
+++ b/db/migrate/20160323154504_add_max_attendees_to_events.rb
@@ -1,6 +1,6 @@
 # frozen_string_literal: true
 
-class AddMaxAttendeesToEvents < ActiveRecord::Migration
+class AddMaxAttendeesToEvents < ActiveRecord::Migration[4.2]
   def change
     add_column :events, :max_attendees, :integer
   end

--- a/db/migrate/20160326075326_add_attended_to_events_registrations.rb
+++ b/db/migrate/20160326075326_add_attended_to_events_registrations.rb
@@ -1,6 +1,6 @@
 # frozen_string_literal: true
 
-class AddAttendedToEventsRegistrations < ActiveRecord::Migration
+class AddAttendedToEventsRegistrations < ActiveRecord::Migration[4.2]
   def change
     add_column :events_registrations, :attended, :boolean, default: false, null: false
   end

--- a/db/migrate/20160403214841_add_id_and_created_at_to_events_registrations.rb
+++ b/db/migrate/20160403214841_add_id_and_created_at_to_events_registrations.rb
@@ -1,6 +1,6 @@
 # frozen_string_literal: true
 
-class AddIdAndCreatedAtToEventsRegistrations < ActiveRecord::Migration
+class AddIdAndCreatedAtToEventsRegistrations < ActiveRecord::Migration[4.2]
   def change
     add_column :events_registrations, :id, :primary_key
     add_column :events_registrations, :created_at, :datetime

--- a/db/migrate/20160427101444_remove_photos.rb
+++ b/db/migrate/20160427101444_remove_photos.rb
@@ -1,6 +1,6 @@
 # frozen_string_literal: true
 
-class RemovePhotos < ActiveRecord::Migration
+class RemovePhotos < ActiveRecord::Migration[4.2]
   def change
     drop_table :photos do |t|
       t.text :description

--- a/db/migrate/20160427104236_add_pictures.rb
+++ b/db/migrate/20160427104236_add_pictures.rb
@@ -1,6 +1,6 @@
 # frozen_string_literal: true
 
-class AddPictures < ActiveRecord::Migration
+class AddPictures < ActiveRecord::Migration[4.2]
   def change
     add_column :conferences, :picture, :string
     add_column :lodgings, :picture, :string

--- a/db/migrate/20160427104237_add_blind_voting_to_programs.rb
+++ b/db/migrate/20160427104237_add_blind_voting_to_programs.rb
@@ -1,6 +1,6 @@
 # frozen_string_literal: true
 
-class AddBlindVotingToPrograms < ActiveRecord::Migration
+class AddBlindVotingToPrograms < ActiveRecord::Migration[4.2]
   def change
     add_column :programs, :blind_voting, :boolean, default: false
   end

--- a/db/migrate/20160427104238_add_voting_dates_to_program.rb
+++ b/db/migrate/20160427104238_add_voting_dates_to_program.rb
@@ -1,6 +1,6 @@
 # frozen_string_literal: true
 
-class AddVotingDatesToProgram < ActiveRecord::Migration
+class AddVotingDatesToProgram < ActiveRecord::Migration[4.2]
   def change
     add_column :programs, :voting_start_date, :datetime
     add_column :programs, :voting_end_date, :datetime

--- a/db/migrate/20160524050538_add_conference_id_to_versions.rb
+++ b/db/migrate/20160524050538_add_conference_id_to_versions.rb
@@ -1,6 +1,6 @@
 # frozen_string_literal: true
 
-class AddConferenceIdToVersions < ActiveRecord::Migration
+class AddConferenceIdToVersions < ActiveRecord::Migration[4.2]
   def change
     add_column :versions, :conference_id, :integer
   end

--- a/db/migrate/20160524104006_remove_unused_logo_columns_and_use_difficulty_levels_from_conferences.rb
+++ b/db/migrate/20160524104006_remove_unused_logo_columns_and_use_difficulty_levels_from_conferences.rb
@@ -1,6 +1,6 @@
 # frozen_string_literal: true
 
-class RemoveUnusedLogoColumnsAndUseDifficultyLevelsFromConferences < ActiveRecord::Migration
+class RemoveUnusedLogoColumnsAndUseDifficultyLevelsFromConferences < ActiveRecord::Migration[4.2]
   def up
     remove_column :conferences, :logo_updated_at
     remove_column :conferences, :logo_file_size

--- a/db/migrate/20160524104501_remove_unused_logo_columns_from_sponsors.rb
+++ b/db/migrate/20160524104501_remove_unused_logo_columns_from_sponsors.rb
@@ -1,6 +1,6 @@
 # frozen_string_literal: true
 
-class RemoveUnusedLogoColumnsFromSponsors < ActiveRecord::Migration
+class RemoveUnusedLogoColumnsFromSponsors < ActiveRecord::Migration[4.2]
   def up
     remove_column :sponsors, :logo_updated_at
     remove_column :sponsors, :logo_file_size

--- a/db/migrate/20160524104805_remove_logo_and_progress_and_time_slots_from_events.rb
+++ b/db/migrate/20160524104805_remove_logo_and_progress_and_time_slots_from_events.rb
@@ -1,6 +1,6 @@
 # frozen_string_literal: true
 
-class RemoveLogoAndProgressAndTimeSlotsFromEvents < ActiveRecord::Migration
+class RemoveLogoAndProgressAndTimeSlotsFromEvents < ActiveRecord::Migration[4.2]
   def up
     remove_column :events, :logo_file_name
     remove_column :events, :logo_updated_at

--- a/db/migrate/20160606040848_create_payments.rb
+++ b/db/migrate/20160606040848_create_payments.rb
@@ -1,6 +1,6 @@
 # frozen_string_literal: true
 
-class CreatePayments < ActiveRecord::Migration
+class CreatePayments < ActiveRecord::Migration[4.2]
   def change
     create_table :payments do |t|
       t.string :last4

--- a/db/migrate/20160610073948_add_payment_id_to_ticket_purchases.rb
+++ b/db/migrate/20160610073948_add_payment_id_to_ticket_purchases.rb
@@ -1,6 +1,6 @@
 # frozen_string_literal: true
 
-class AddPaymentIdToTicketPurchases < ActiveRecord::Migration
+class AddPaymentIdToTicketPurchases < ActiveRecord::Migration[4.2]
   def change
     add_column :ticket_purchases, :payment_id, :integer
   end

--- a/db/migrate/20160614145614_add_id_to_users_roles.rb
+++ b/db/migrate/20160614145614_add_id_to_users_roles.rb
@@ -1,6 +1,6 @@
 # frozen_string_literal: true
 
-class AddIdToUsersRoles < ActiveRecord::Migration
+class AddIdToUsersRoles < ActiveRecord::Migration[4.2]
   def change
     add_column :users_roles, :id, :primary_key
   end

--- a/db/migrate/20160624151257_remove_unused_photo_columns_from_venues.rb
+++ b/db/migrate/20160624151257_remove_unused_photo_columns_from_venues.rb
@@ -1,6 +1,6 @@
 # frozen_string_literal: true
 
-class RemoveUnusedPhotoColumnsFromVenues < ActiveRecord::Migration
+class RemoveUnusedPhotoColumnsFromVenues < ActiveRecord::Migration[4.2]
   def up
     remove_column :venues, :photo_updated_at
     remove_column :venues, :photo_file_size

--- a/db/migrate/20160704091928_create_schedules.rb
+++ b/db/migrate/20160704091928_create_schedules.rb
@@ -1,6 +1,6 @@
 # frozen_string_literal: true
 
-class CreateSchedules < ActiveRecord::Migration
+class CreateSchedules < ActiveRecord::Migration[5.0]
   def change
     create_table :schedules do |t|
       t.belongs_to :program, index: true

--- a/db/migrate/20160704092023_create_event_schedules.rb
+++ b/db/migrate/20160704092023_create_event_schedules.rb
@@ -1,6 +1,6 @@
 # frozen_string_literal: true
 
-class CreateEventSchedules < ActiveRecord::Migration
+class CreateEventSchedules < ActiveRecord::Migration[5.0]
   def change
     create_table :event_schedules do |t|
       t.belongs_to :event, index: true

--- a/db/migrate/20160815094215_add_times_to_conferences.rb
+++ b/db/migrate/20160815094215_add_times_to_conferences.rb
@@ -1,6 +1,6 @@
 # frozen_string_literal: true
 
-class AddTimesToConferences < ActiveRecord::Migration
+class AddTimesToConferences < ActiveRecord::Migration[5.0]
   def change
     add_column :conferences, :start_hour, :integer, default: 9
     add_column :conferences, :end_hour, :integer, default: 20

--- a/db/migrate/20160815140302_add_index_to_event_schedule.rb
+++ b/db/migrate/20160815140302_add_index_to_event_schedule.rb
@@ -1,6 +1,6 @@
 # frozen_string_literal: true
 
-class AddIndexToEventSchedule < ActiveRecord::Migration
+class AddIndexToEventSchedule < ActiveRecord::Migration[5.0]
   def change
     add_index :event_schedules, [:event_id, :schedule_id], unique: true
   end

--- a/db/migrate/20170129075434_create_resources_table.rb
+++ b/db/migrate/20170129075434_create_resources_table.rb
@@ -1,6 +1,6 @@
 # frozen_string_literal: true
 
-class CreateResourcesTable < ActiveRecord::Migration
+class CreateResourcesTable < ActiveRecord::Migration[5.0]
   def change
     create_table :resources do |t|
       t.string :name

--- a/db/migrate/20170213145807_change_email_public_from_users.rb
+++ b/db/migrate/20170213145807_change_email_public_from_users.rb
@@ -1,6 +1,6 @@
 # frozen_string_literal: true
 
-class ChangeEmailPublicFromUsers < ActiveRecord::Migration
+class ChangeEmailPublicFromUsers < ActiveRecord::Migration[5.0]
   def up
     change_column_default :users, :email_public, true
   end

--- a/db/migrate/20170302145716_add_schedule_interval_to_programs.rb
+++ b/db/migrate/20170302145716_add_schedule_interval_to_programs.rb
@@ -1,6 +1,6 @@
 # frozen_string_literal: true
 
-class AddScheduleIntervalToPrograms < ActiveRecord::Migration
+class AddScheduleIntervalToPrograms < ActiveRecord::Migration[5.0]
   def change
     add_column :programs, :schedule_interval, :integer, default: 15, null: false
   end

--- a/db/migrate/20170419132148_add_week_to_ticket_purchases.rb
+++ b/db/migrate/20170419132148_add_week_to_ticket_purchases.rb
@@ -1,6 +1,6 @@
 # frozen_string_literal: true
 
-class AddWeekToTicketPurchases < ActiveRecord::Migration
+class AddWeekToTicketPurchases < ActiveRecord::Migration[5.0]
   class TmpTicketPurchase < ActiveRecord::Base
     self.table_name = 'ticket_purchases'
   end

--- a/db/migrate/20170529215453_create_organizations.rb
+++ b/db/migrate/20170529215453_create_organizations.rb
@@ -1,6 +1,6 @@
 # frozen_string_literal: true
 
-class CreateOrganizations < ActiveRecord::Migration
+class CreateOrganizations < ActiveRecord::Migration[5.0]
   def change
     create_table :organizations do |t|
       t.string :name, null: false

--- a/db/migrate/20170531094819_move_conferences_to_organizations.rb
+++ b/db/migrate/20170531094819_move_conferences_to_organizations.rb
@@ -1,6 +1,6 @@
 # frozen_string_literal: true
 
-class MoveConferencesToOrganizations < ActiveRecord::Migration
+class MoveConferencesToOrganizations < ActiveRecord::Migration[5.0]
   class TempConference < ActiveRecord::Base
     self.table_name = 'conferences'
   end


### PR DESCRIPTION
…ions

**Checklist**

- [ x] I have read the [Contribution & Best practices Guide](https://github.com/openSUSE/osem/blob/master/CONTRIBUTING.md).
- [x ] My branch is up-to-date with the upstream `master` branch.
- [ ] The tests pass locally with my changes.
- [ ] I have added tests that prove my fix is effective or that my feature works(if appropriate).
- [ ] I have added necessary documentation (if appropriate).

This merge request adds a version into `ActiveRecord::Migration` for old migrations to avoid the related exception. 
Also, old rails methods used in migrations are replaced with your new versions.

Relationed issues:
https://github.com/openSUSE/osem/issues/3099
https://github.com/openSUSE/osem/pull/2665
-

**Changes proposed in this pull request:**

changes `ActiveRecord::Migration` to `ActiveRecord::Migration[compatible version]` in migration files;

changes use of `update_attributes` to `update` into migration;

changes `get_all_versions`to the current version into the migration file

-
