### PR TITLE
Restore views for `Admin::EventsController#new`, `Admin::UsersController#edit`

### DIFF
--- a/app/views/admin/events/new.html.haml
+++ b/app/views/admin/events/new.html.haml
@@ -1,0 +1,10 @@
+.row
+  .col-md-12
+    .page-header
+      %h1
+        New Event
+.row
+  .col-md-8
+    = form_for(@event, url: @url) do |f|
+      = render partial: 'proposals/form', locals: { f: f }
+    = render partial: 'shared/user_selectize'

--- a/app/views/admin/users/_form.html.haml
+++ b/app/views/admin/users/_form.html.haml
@@ -1,0 +1,44 @@
+= form_for [:admin, @user] do |f|
+  %h4 Basic Information
+  - unless @user.new_record?
+    .pull-right
+      %b
+        Confirmed?
+      - if can? :toggle_confirmation, @user
+        = check_box_tag @user.id, @user.id, @user.confirmed?,
+          url: "#{toggle_confirmation_admin_user_path(@user.id)}?user[to_confirm]=",
+          class: 'switch-checkbox',
+          readonly: false
+      - else
+        = check_box_tag @user.id, @user.id, @user.confirmed?,
+          url: "#{toggle_confirmation_admin_user_path(@user.id)}?user[to_confirm]=",
+          class: 'switch-checkbox',
+          readonly: true
+  .checkbox
+    %label
+      = f.check_box :is_admin
+      Is admin
+    %span.help-block An admin can create a new conference, manage users and make other users admins.
+  .form-group
+    = f.label :name
+    = f.text_field :name, class: 'form-control'
+  - if @user.new_record?
+    .form-group
+      = label_tag :username
+      = text_field_tag :username, class: 'form-control'
+  .form-group
+    = f.label :email, required: true
+    %abbr{title: 'This field is required'} *
+    = f.email_field :email, required: true, class: 'form-control'
+  - if @user.new_record?
+    .form-group
+      = f.label :password
+      = f.password_field :password, class: 'form-control'
+  .form-group
+    = f.label :affiliation
+    = f.text_field :affiliation, class: 'form-control'
+  .form-group
+    = f.label :biography
+    = f.text_area :biography, rows: 10, data: { provide: 'markdown' }, class: 'form-control'
+    %span.help-block= markdown_hint
+  = f.submit nil,  class: 'btn btn-primary'

--- a/app/views/admin/users/edit.html.haml
+++ b/app/views/admin/users/edit.html.haml
@@ -1,0 +1,1 @@
+= render partial: 'form'

--- a/app/views/proposals/_form.html.haml
+++ b/app/views/proposals/_form.html.haml
@@ -13,6 +13,7 @@
     = f.label :subtitle
     = f.text_field :subtitle, class: 'form-control'
   .form-group
+    %label{for: 'users_selectize-selectized'} Speakers
     = f.select :speaker_ids, f.object.speakers.pluck(:username, :id), {}, {  multiple: true, class: "form-control", id: "users_selectize", placeholder: "Speakers" }
     %span.help-block
       The people responsible for the event, beside you. You can only select existing users.
@@ -63,7 +64,8 @@
         Require participants to register to your event
   - if display_registration && action_is_edit
     .form-group
-      = f.number_field :max_attendees
+      = f.label :max_attendees
+      = f.number_field :max_attendees,  class: 'form-control'
       %span.help-block
         - message = @event.room ? "Value must be between 1 and #{@event.room.size}" : 'Check room capacity after scheduling.'
         = 'The maximum number of participants. ' + message

--- a/app/views/proposals/_form.html.haml
+++ b/app/views/proposals/_form.html.haml
@@ -1,5 +1,8 @@
-- action_is_edit = @event.persisted?
-- display_registration = current_user&.is_admin? || @program.cfp&.enable_registrations?
+:ruby
+  action_is_edit = @event.persisted?
+  user_is_admin = current_user&.is_admin?
+  display_details = user_is_admin || action_is_edit
+  display_registration = user_is_admin || @program.cfp&.enable_registrations?
 
 %h4
   Proposal Information
@@ -8,7 +11,7 @@
   = f.label :title
   %abbr{title: 'This field is required'} *
   = f.text_field :title, autofocus: true, required: true, class: 'form-control'
-- if action_is_edit
+- if display_details
   .form-group
     = f.label :subtitle
     = f.text_field :subtitle, class: 'form-control'
@@ -32,7 +35,7 @@
   = f.select :language, @languages, { include_blank: false}, { class: 'select-help-toggle form-control' }
 = render 'shared/select_help_text', f: f, for: :event_type_id, options: @conference.program.event_types do |event_type|
   = event_type.description
-- if action_is_edit
+- if display_details
   - if @conference.program.difficulty_levels.any?
     = f.label :difficulty_level
     = f.select :difficulty_level_id, @conference.program.difficulty_levels.map{|level| [level.title, level.id ] }, {include_blank: false}, { class: 'select-help-toggle form-control' }
@@ -53,7 +56,7 @@
     %span#abstract-maximum-word-count
       250
     words.
-  - if display_registration && action_is_edit
+  - if display_registration && display_details
     %h4
       Event Registration
     %hr
@@ -62,14 +65,14 @@
       %label
         = f.check_box :require_registration
         Require participants to register to your event
-  - if display_registration && action_is_edit
+  - if display_registration && display_details
     .form-group
       = f.label :max_attendees
       = f.number_field :max_attendees,  class: 'form-control'
       %span.help-block
         - message = @event.room ? "Value must be between 1 and #{@event.room.size}" : 'Check room capacity after scheduling.'
         = 'The maximum number of participants. ' + message
-  - if action_is_edit && current_user.has_any_role?(:admin, { name: :organizer, resource: @conference }, { name: :cfp, resource: @conference })
+  - if display_details && current_user.has_any_role?(:admin, { name: :organizer, resource: @conference }, { name: :cfp, resource: @conference })
     .checkbox
       %label
         = f.check_box :is_highlight

--- a/spec/features/proposals_spec.rb
+++ b/spec/features/proposals_spec.rb
@@ -27,6 +27,15 @@ feature Event do
       sign_in organizer
     end
 
+    scenario 'adds a proposal', feature: true, js: true do
+      visit admin_conference_program_events_path(conference.short_title)
+      click_on 'Add Event'
+      fill_in 'Title', with: 'Organizer-Created Proposal'
+      fill_in 'Abstract', with: 'This proposal was created by an organizer.'
+      click_button 'Create Proposal'
+      expect(flash).to eq('Event was successfully submitted.')
+    end
+
     scenario 'rejects a proposal', feature: true, js: true do
       visit admin_conference_program_events_path(conference.short_title)
       expect(page).to have_content 'Example Proposal'

--- a/spec/features/user_spec.rb
+++ b/spec/features/user_spec.rb
@@ -3,12 +3,24 @@
 require 'spec_helper'
 
 feature User do
+  let(:admin) { create(:admin) }
+  let!(:user) { create(:user) }
 
   shared_examples 'admin ability' do
-
+    scenario 'edits a user', feature: true, js: true do
+      visit admin_users_path
+      within "tr#user_#{user.id}" do
+        click_on 'Edit'
+      end
+      fill_in 'Name', with: 'Edited Name'
+      click_button 'Update User'
+      expect(flash).to include('Updated Edited Name')
+    end
   end
 
   describe 'admin' do
+    before { sign_in admin }
+
     it_behaves_like 'admin ability', :admin
   end
 end


### PR DESCRIPTION
### Checklist

- [x] I have read the [Contribution & Best practices Guide](https://github.com/openSUSE/osem/blob/master/CONTRIBUTING.md).
- [x] My branch is up-to-date with the upstream `master` branch.
- [x] The tests pass locally with my changes.
- [x] I have added tests that prove my fix is effective or that my feature works.
- [ ] I have added necessary documentation (if appropriate).

### Short description of what this resolves

#2975

### Changes proposed in this pull request

While #3073 and #3092 also attempt to solve this issue, both introduce UI changes that are out of scope of the task of merely undoing the inadvertent deletion. I suggest that the forms first be restored to their original condition and then the remaining UI changes be discussed in their respective issues.

| Deleted ([`3bbbdb4`](https://github.com/openSUSE/osem/tree/3bbbdb4aae9d4be9ce1bba35fc7586988261d5a9)) | Restored ([`e00eecc`](https://github.com/openSUSE/osem/pull/3129/commits/e00eecca2599be087c208dc87e90ad30a828d813)) |
| - | - |
| ![3bbbdb4 /admin/users/2/edit](https://user-images.githubusercontent.com/1844746/189781274-2f8dae35-f695-4970-8ce2-604430558bfd.png) | ![e00eecc /admin/users/2/edit](https://user-images.githubusercontent.com/1844746/222020881-04d1ccae-0341-49c5-a28e-2e0bb5ff796b.png) |
| ![3bbbdb4 /admin/conferences/example/program/events/new](https://user-images.githubusercontent.com/1844746/189781297-0db42865-ecd6-4c1d-b42a-e153d7796818.png) | ![e00eecc /admin/conferences/example/program/events/new](https://user-images.githubusercontent.com/1844746/222020908-fe9a4395-36e1-4347-bf88-25bd7e15cb7e.png) |