### PR TITLE
Expire voting fragment caches

### DIFF
--- a/app/models/vote.rb
+++ b/app/models/vote.rb
@@ -2,7 +2,7 @@
 
 class Vote < ApplicationRecord
   belongs_to :user
-  belongs_to :event
+  belongs_to :event, touch: true
 
   validates :user_id, uniqueness: { scope: :event_id }
 

--- a/app/views/admin/events/_datatable_row.haml
+++ b/app/views/admin/events/_datatable_row.haml
@@ -1,4 +1,4 @@
-- cache ['admin', conference_id, program, event] do
+- cache ['admin', conference_id, program, event, current_user] do
   %tr{ id: "event-#{event.id}" }
     %td
       = event.id

--- a/app/views/admin/events/_proposal.html.haml
+++ b/app/views/admin/events/_proposal.html.haml
@@ -1,4 +1,4 @@
-- cache ['admin/event', @conference, @program, @event] do
+- cache ['admin/event', @conference, @program, @event, current_user] do
   .row
     .col-md-12
       %h3

--- a/spec/factories/users.rb
+++ b/spec/factories/users.rb
@@ -50,6 +50,16 @@ FactoryBot.define do
       end
     end
 
+    factory :cfp_user do
+      transient do
+        resource { create(:resource) }
+      end
+
+      after :create do |user, evaluator|
+        user.add_role :cfp, evaluator.resource
+      end
+    end
+
     trait :disabled do
       is_disabled { true }
     end

--- a/spec/features/voting_spec.rb
+++ b/spec/features/voting_spec.rb
@@ -1,0 +1,59 @@
+# frozen_string_literal: true
+
+require 'spec_helper'
+
+def have_rating(rating, max)
+  have_selector('.rating.bright', count: rating)
+    .and have_selector('.rating:not(.bright)', count: max - rating)
+end
+
+def cast_vote(rating, before:, after:)
+  # Index shows existing rating but not user’s vote
+  visit admin_conference_program_events_path(conference.short_title)
+  within("#event-#{event.id}") do
+    expect(page).to have_rating(before, 5)
+    expect(page).to have_text('Not rated')
+  end
+
+  # Event page shows existing rating but not user’s vote
+  click_on event.title
+  within('tr', text: 'Rating') { expect(page).to have_rating(before, 5) }
+  within('tr', text: 'Your vote') { expect(page).to have_rating(0, 5) }
+
+  # Voting dynamically updates the page
+  within('tr', text: 'Your vote') { page.find(".rating:nth-of-type(#{rating})").click }
+  within('tr', text: 'Rating') { expect(page).to have_rating(after, 5) }
+  within('tr', text: 'Your vote') { expect(page).to have_rating(rating, 5) }
+
+  # Index shows updated rating and vote
+  visit admin_conference_program_events_path(conference.short_title)
+  within("#event-#{event.id}") do
+    expect(page).to have_rating(after, 5)
+    expect(page).to have_text("You voted: #{rating}/5")
+  end
+
+  # Re-rendered event page shows updated rating and vote
+  click_on event.title
+  within('tr', text: 'Rating') { expect(page).to have_rating(after, 5) }
+  within('tr', text: 'Your vote') { expect(page).to have_rating(rating, 5) }
+end
+
+feature 'Voting' do
+  let(:conference) { create(:conference) }
+  let!(:event) { create(:event, program: conference.program) }
+  let(:voter1) { create(:cfp_user, resource: conference) }
+  let(:voter2) { create(:cfp_user, resource: conference) }
+
+  before :each do
+    conference.program.update_attribute :rating, 5
+  end
+
+  scenario 'multiple users casting votes', feature: true, js: true do
+    sign_in voter1
+    cast_vote 3, before: 0, after: 3
+    sign_out
+
+    sign_in voter2
+    cast_vote 5, before: 3, after: 4
+  end
+end


### PR DESCRIPTION
### Checklist

- [x] I have read the [Contribution & Best practices Guide](https://github.com/openSUSE/osem/blob/master/CONTRIBUTING.md).
- [x] My branch is up-to-date with the upstream `master` branch.
- [x] The tests pass locally with my changes.
- [x] I have added tests that prove my fix is effective or that my feature works.
- [ ] I have added necessary documentation (if appropriate).

### Short description of what this resolves

#1989 added fragment caching of event ratings and user voting records, but didn’t fully identify the fragments’ dependencies. As reported in #2767, the result is that event ratings can appear to not update and users can be shown the voting records of other users.

To replicate the problem, un-disable caching in tests—

```patch
--- a/config/environments/test.rb
+++ b/config/environments/test.rb
@@ -27 +26,0 @@
-  config.action_controller.perform_caching = false
@@ -29 +27,0 @@
-  config.cache_store = :null_store
```

—and then run `spec/features/voting_spec.rb`.

### Changes proposed in this pull request

Continuing the work [started](https://github.com/snap-cloud/snapcon/commit/cb87b85a761f938e91b75f90f6f849f048814aca) by @cycomachead, test for the problematic behavior and add the missing cache dependencies.

### Other considerations

I briefly looked into always [opting in to caching](https://stackoverflow.com/q/5035982) for these tests but didn’t find a clean solution.