### PR TITLE
Set `nofollow` on user-generated links

### DIFF
--- a/app/helpers/format_helper.rb
+++ b/app/helpers/format_helper.rb
@@ -202,7 +202,7 @@ module FormatHelper
       safe_links_only: true
     }
     markdown = Redcarpet::Markdown.new(Redcarpet::Render::HTML.new(render_options), markdown_options)
-    sanitize(markdown.render(text))
+    sanitize(sanitize(markdown.render(text)), scrubber: Loofah::Scrubbers::NoFollow.new)
   end
 
   def markdown_hint(text='')

--- a/spec/helpers/format_helper_spec.rb
+++ b/spec/helpers/format_helper_spec.rb
@@ -24,5 +24,10 @@ describe FormatHelper, type: :helper do
     it 'removes unallowed elements' do
       expect(markdown('<em>*<style>a</style>*</em>', false)).to eq "<p><em><em>a</em></em></p>\n"
     end
+
+    it 'sets nofollow on links' do
+      expect(markdown('[a](https://example.com/)'))
+        .to eq "<p><a href=\"https://example.com/\" rel=\"nofollow\">a</a></p>\n"
+    end
   end
 end

--- a/spec/helpers/format_helper_spec.rb
+++ b/spec/helpers/format_helper_spec.rb
@@ -16,5 +16,13 @@ describe FormatHelper, type: :helper do
     it 'should return HTML for header markdown' do
       expect(markdown('# this is my header')).to eq "<h1>this is my header</h1>\n"
     end
+
+    it 'escapes input HTML' do
+      expect(markdown('<em>*a*</em>')).to eq "<p>&lt;em&gt;<em>a</em>&lt;/em&gt;</p>\n"
+    end
+
+    it 'removes unallowed elements' do
+      expect(markdown('<em>*<style>a</style>*</em>', false)).to eq "<p><em><em>a</em></em></p>\n"
+    end
   end
 end


### PR DESCRIPTION
### Checklist

- [x] I have read the [Contribution & Best practices Guide](https://github.com/openSUSE/osem/blob/master/CONTRIBUTING.md).
- [x] My branch is up-to-date with the upstream `master` branch.
- [x] The tests pass locally with my changes.
- [x] I have added tests that prove my fix is effective or that my feature works.
- [ ] I have added necessary documentation (if appropriate).

### Short description of what this resolves

To disincentivize [spamdexing](https://en.wikipedia.org/wiki/Spamdexing#Using_world-writable_pages), links in user-generated content should be disavowed by annotation with [`rel="nofollow"`](https://en.wikipedia.org/wiki/Nofollow) attributes. Automated spam has already [targeted OSEM](https://github.com/SeaGL/organization/issues/274) in the wild.

### Changes proposed in this pull request

Pass rendered markdown through the [`NoFollow`](https://rubydoc.info/github/flavorjones/loofah/main/Loofah/Scrubbers/NoFollow) scrubber already available in Rails.

Ideally this would be done during markdown rendering or in a single sanitization pass; see the unresolved discussion at vmg/redcarpet#720.