### PR TITLE
Correct invalid table markup

### DIFF
--- a/app/views/admin/booths/index.html.haml
+++ b/app/views/admin/booths/index.html.haml
@@ -56,46 +56,48 @@
     - if @booths.any?
       %table.datatable
         %thead
-          %th
-            %b ID
-          %th
-            %b Logo
-          %th
-            %b Title
-          %th
-            %b Submitter
-          %th
-            %b Responsibles
-          %th
-            %b State
-          %th
-            %b Actions
-        - @booths.each do |booth|
           %tr
-            %td
-              = booth.id
-            %td
-              - if booth.logo_link
-                = image_tag(booth.picture.thumb.url, width: '20%')
-            %td
-              = link_to booth.title, admin_conference_booth_path(@conference.short_title, booth)
-            %td
-              = link_to booth.submitter.name, admin_user_path(booth.submitter) if booth.submitter
-            %td
-              .responsibles
-                - booth.responsibles.each_with_index do |responsible, i|
-                  = link_to responsible.name, admin_user_path(responsible)
-                  = ", " unless i == booth.responsibles.length - 1
-            %td
-              .btn-group
-                %button{ type: 'button', class: 'btn btn-link dropdown-toggle', 'data-toggle' => 'dropdown' }
-                  = booth.state.humanize
-                  %span.caret
-                %ul.dropdown-menu{ role: 'menu' }
-                  = render 'change_state_dropdown', booth: booth
+            %th
+              %b ID
+            %th
+              %b Logo
+            %th
+              %b Title
+            %th
+              %b Submitter
+            %th
+              %b Responsibles
+            %th
+              %b State
+            %th
+              %b Actions
+        %tbody
+          - @booths.each do |booth|
+            %tr
               %td
-                = link_to 'Edit', edit_admin_conference_booth_path(@conference.short_title, booth.id),
-                class: 'btn btn-primary'
+                = booth.id
+              %td
+                - if booth.logo_link
+                  = image_tag(booth.picture.thumb.url, width: '20%')
+              %td
+                = link_to booth.title, admin_conference_booth_path(@conference.short_title, booth)
+              %td
+                = link_to booth.submitter.name, admin_user_path(booth.submitter) if booth.submitter
+              %td
+                .responsibles
+                  - booth.responsibles.each_with_index do |responsible, i|
+                    = link_to responsible.name, admin_user_path(responsible)
+                    = ", " unless i == booth.responsibles.length - 1
+              %td
+                .btn-group
+                  %button{ type: 'button', class: 'btn btn-link dropdown-toggle', 'data-toggle' => 'dropdown' }
+                    = booth.state.humanize
+                    %span.caret
+                  %ul.dropdown-menu{ role: 'menu' }
+                    = render 'change_state_dropdown', booth: booth
+                %td
+                  = link_to 'Edit', edit_admin_conference_booth_path(@conference.short_title, booth.id),
+                  class: 'btn btn-primary'
 .row
   .col-md-12.text-right
     - if can? :create, Booth

--- a/app/views/admin/cfps/index.html.haml
+++ b/app/views/admin/cfps/index.html.haml
@@ -10,12 +10,13 @@
     .col-md-12
       %table.table.table-hover#tickets
         %thead
-          %th Type
-          %th Start Date
-          %th End Date
-          %th Description
-          %th Days Left
-          %th Actions
+          %tr
+            %th Type
+            %th Start Date
+            %th End Date
+            %th Description
+            %th Days Left
+            %th Actions
         %tbody
           - @program.cfps.each do |cfp|
             %tr

--- a/app/views/admin/difficulty_levels/index.html.haml
+++ b/app/views/admin/difficulty_levels/index.html.haml
@@ -8,10 +8,11 @@
   .col-md-12
     %table.table.table-hover#difficulty_levels
       %thead
-        %th Title
-        %th Description
-        %th Color
-        %th Actions
+        %tr
+          %th Title
+          %th Description
+          %th Color
+          %th Actions
       %tbody
         - @conference.program.difficulty_levels.each do |difficulty_level|
           %tr

--- a/app/views/admin/event_types/index.html.haml
+++ b/app/views/admin/event_types/index.html.haml
@@ -8,12 +8,13 @@
   .col-md-12
     %table.table.table-hover#event_types
       %thead
-        %th Title
-        %th Description
-        %th Length
-        %th Abstract Length
-        %th Color
-        %th Actions
+        %tr
+          %th Title
+          %th Description
+          %th Length
+          %th Abstract Length
+          %th Color
+          %th Actions
       %tbody
         - @conference.program.event_types.each do |event_type|
           %tr

--- a/app/views/admin/events/index.html.haml
+++ b/app/views/admin/events/index.html.haml
@@ -58,44 +58,46 @@
     .margin-event-table
       %table.datatable
         %thead
-          %th
-            %b ID
-          %th
-            %b Title
-          - if @program.rating_enabled?
+          %tr
             %th
-              %b Rating
-          %th
-            %b Submitter
-          %th
-            %b Speakers
-          - if @program.languages.present?
+              %b ID
             %th
-              %b Language
-          %th
-            %b Requires Registration
-          %th
-            %b Highlight
-          %th
-            %b Type
-          %th
-            %b Track
-          %th
-            %b Difficulty
-          %th
-            %b State
-          %th
-            .fa-solid.fa-comment
-          %th Add Survey
-        - @events.each do |event|
-          = render 'datatable_row',
-            event: event,
-            conference_id: @conference.short_title,
-            program: @program,
-            rating_enabled: @program.rating_enabled?,
-            show_votes: @program.show_voting?,
-            max_rating: @program.rating,
-            event_types: @event_types,
-            tracks: @tracks,
-            difficulty_levels: @difficulty_levels,
-            email_settings: @conference.email_settings
+              %b Title
+            - if @program.rating_enabled?
+              %th
+                %b Rating
+            %th
+              %b Submitter
+            %th
+              %b Speakers
+            - if @program.languages.present?
+              %th
+                %b Language
+            %th
+              %b Requires Registration
+            %th
+              %b Highlight
+            %th
+              %b Type
+            %th
+              %b Track
+            %th
+              %b Difficulty
+            %th
+              %b State
+            %th
+              .fa-solid.fa-comment
+            %th Add Survey
+        %tbody
+          - @events.each do |event|
+            = render 'datatable_row',
+              event: event,
+              conference_id: @conference.short_title,
+              program: @program,
+              rating_enabled: @program.rating_enabled?,
+              show_votes: @program.show_voting?,
+              max_rating: @program.rating,
+              event_types: @event_types,
+              tracks: @tracks,
+              difficulty_levels: @difficulty_levels,
+              email_settings: @conference.email_settings

--- a/app/views/admin/events/registrations.html.haml
+++ b/app/views/admin/events/registrations.html.haml
@@ -18,12 +18,13 @@
     .well
       %table.datatable#registrations
         %thead
-          %th
-          %th Name
-          %th Email
-          %th Created At
-          %th Attended
-          %th Attended Conference
+          %tr
+            %th
+            %th Name
+            %th Email
+            %th Created At
+            %th Attended
+            %th Attended Conference
         %tbody
           - @event_registrations.each.with_index(1) do |event_registration, index|
             %tr

--- a/app/views/admin/events/show.html.haml
+++ b/app/views/admin/events/show.html.haml
@@ -20,9 +20,10 @@
       .col-md-12
         %table.datatable
           %thead
-            %th ID
-            %th Description
-            %th Actions
+            %tr
+              %th ID
+              %th Description
+              %th Actions
           %tbody
             - @versions.each do |version|
               %tr

--- a/app/views/admin/organizations/_users_with_org_admin_role.haml
+++ b/app/views/admin/organizations/_users_with_org_admin_role.haml
@@ -3,11 +3,12 @@
 - if users.present?
   %table.datatable#users
     %thead
-      %th Name
-      %th Email
-      - if ( can? :unassign_org_admins, organization )
-        %th
-          Actions
+      %tr
+        %th Name
+        %th Email
+        - if ( can? :unassign_org_admins, organization )
+          %th
+            Actions
     %tbody
       - users.each do |user|
         %tr

--- a/app/views/admin/organizations/index.html.haml
+++ b/app/views/admin/organizations/index.html.haml
@@ -11,11 +11,12 @@
   .col-md-12
     %table.datatable
       %thead
-        %th Name
-        %th Upcoming Conferences
-        %th Past Conferences
-        %th Code of Conduct?
-        %th Actions
+        %tr
+          %th Name
+          %th Upcoming Conferences
+          %th Past Conferences
+          %th Code of Conduct?
+          %th Actions
       %tbody
         - @organizations.each do |organization|
           %tr{ id: "organization-#{organization.id}" }

--- a/app/views/admin/physical_tickets/index.html.haml
+++ b/app/views/admin/physical_tickets/index.html.haml
@@ -18,11 +18,12 @@
       .col-md-12
         %table.datatable#tickets
           %thead
-            %th ID
-            %th Type
-            %th User
-            %th Paid
-            %th Actions
+            %tr
+              %th ID
+              %th Type
+              %th User
+              %th Paid
+              %th Actions
           %tbody
             - @physical_tickets.each do |physical_ticket|
               = render "physical_ticket", physical_ticket: physical_ticket,

--- a/app/views/admin/questions/show.html.haml
+++ b/app/views/admin/questions/show.html.haml
@@ -13,10 +13,11 @@
 
       %table.datatable#question_users
         %thead
-          %th Name
-          %th Username
-          %th Email
-          %th Answer
+          %tr
+            %th Name
+            %th Username
+            %th Email
+            %th Answer
         %tbody
           - @registrations.each do |registration|
             %tr

--- a/app/views/admin/reports/_all_events.html.haml
+++ b/app/views/admin/reports/_all_events.html.haml
@@ -10,15 +10,16 @@
 .col-md-12
   %table.datatable
     %thead
-      %th ID
-      %th Title
-      %th Speakers Registered
-      %th Speakers Biographies
-      %th Commercial
-      %th Subtitle
-      %th Difficulty Level
-      - if @program.tracks.any?
-        %th Track
+      %tr
+        %th ID
+        %th Title
+        %th Speakers Registered
+        %th Speakers Biographies
+        %th Commercial
+        %th Subtitle
+        %th Difficulty Level
+        - if @program.tracks.any?
+          %th Track
     %tbody
       - @events.each do |event|
         %tr

--- a/app/views/admin/reports/_events_with_requirements.html.haml
+++ b/app/views/admin/reports/_events_with_requirements.html.haml
@@ -9,13 +9,14 @@
 .col-md-12
   %table.datatable
     %thead
-      %th ID
-      %th Title
-      %th Speaker(s)
-      %th Requirements
-      %th Room
-      %th Date
-      %th Time
+      %tr
+        %th ID
+        %th Title
+        %th Speaker(s)
+        %th Requirements
+        %th Room
+        %th Date
+        %th Time
     %tbody
       - @events_with_requirements.each do |event|
         %tr

--- a/app/views/admin/reports/_events_without_commercials.html.haml
+++ b/app/views/admin/reports/_events_without_commercials.html.haml
@@ -9,9 +9,10 @@
 .col-md-12
   %table.datatable
     %thead
-      %th ID
-      %th Title
-      %th Speaker(s)
+      %tr
+        %th ID
+        %th Title
+        %th Speaker(s)
     %tbody
       - @events_missing_commercial.each do |event|
         %tr

--- a/app/views/admin/reports/_missing_speakers.html.haml
+++ b/app/views/admin/reports/_missing_speakers.html.haml
@@ -9,12 +9,13 @@
 .col-md-12
   %table.datatable
     %thead
-      %th Speaker Name
-      %th Registered?
-      %th Event
-      %th Room
-      %th Date
-      %th Time
+      %tr
+        %th Speaker Name
+        %th Registered?
+        %th Event
+        %th Room
+        %th Date
+        %th Time
     %tbody
       - @missing_event_speakers.each do |event_user|
         - speaker = event_user.user

--- a/app/views/admin/resources/index.html.haml
+++ b/app/views/admin/resources/index.html.haml
@@ -9,10 +9,11 @@
     .col-md-12
       %table.datatable
         %thead
-          %th Name
-          %th Left( Left/Total )
-          %th Used
-          %th Actions
+          %tr
+            %th Name
+            %th Left( Left/Total )
+            %th Used
+            %th Actions
         %tbody
           - @conference.resources.each do |resource|
             %tr

--- a/app/views/admin/roles/index.html.haml
+++ b/app/views/admin/roles/index.html.haml
@@ -9,11 +9,12 @@
   .col-md-12
     %table.table.table-bordered.table-striped.table-hover#roles
       %thead
-        %th ID
-        %th Name
-        %th Description
-        %th Users
-        %th Actions
+        %tr
+          %th ID
+          %th Name
+          %th Description
+          %th Users
+          %th Actions
       %tbody
         - @roles.each do |role|
           %tr

--- a/app/views/admin/rooms/index.html.haml
+++ b/app/views/admin/rooms/index.html.haml
@@ -10,9 +10,10 @@
     .col-md-12
       %table.table.table-hover#rooms
         %thead
-          %th Name
-          %th Capacity
-          %th Actions
+          %tr
+            %th Name
+            %th Capacity
+            %th Actions
         %tbody
           - @rooms.each_with_index do |room, index|
             %tr

--- a/app/views/admin/schedules/index.html.haml
+++ b/app/views/admin/schedules/index.html.haml
@@ -16,9 +16,10 @@
         .col-md-12
           %table.table.table-hover
             %thead
-              %th Schedule
-              %th Selected
-              %th Actions
+              %tr
+                %th Schedule
+                %th Selected
+                %th Actions
             %tbody
               - @schedules.where(track: nil).each do |schedule|
                 %tr
@@ -59,10 +60,11 @@
         .col-md-12
           %table.table.table-hover
             %thead
-              %th Schedule
-              %th Track
-              %th Selected
-              %th Actions
+              %tr
+                %th Schedule
+                %th Track
+                %th Selected
+                %th Actions
             %tbody
               - @schedules.where.not(track: nil).each do |schedule|
                 %tr

--- a/app/views/admin/sponsors/index.html.haml
+++ b/app/views/admin/sponsors/index.html.haml
@@ -9,12 +9,13 @@
     .col-md-12
       %table.table.table-hover#sponsors
         %thead
-          %th Logo
-          %th Name
-          %th Description
-          %th URL
-          %th Level
-          %th Actions
+          %tr
+            %th Logo
+            %th Name
+            %th Description
+            %th URL
+            %th Level
+            %th Actions
         %tbody
           - @conference.sponsors.each do |sponsor|
             %tr

--- a/app/views/admin/sponsorship_levels/index.html.haml
+++ b/app/views/admin/sponsorship_levels/index.html.haml
@@ -9,9 +9,10 @@
     .col-md-12
       %table.table.table-hover#sponsorship_levels
         %thead
-          %th Title
-          %th Position
-          %th Actions
+          %tr
+            %th Title
+            %th Position
+            %th Actions
         %tbody
           - @conference.sponsorship_levels.each_with_index do |sponsorship_level, index|
             %tr

--- a/app/views/admin/surveys/_survey_replies.html.haml
+++ b/app/views/admin/surveys/_survey_replies.html.haml
@@ -7,8 +7,9 @@
       - if survey_question.survey_replies.any?
         %table.table
           %thead
-            %th User Email
-            %th Reply
+            %tr
+              %th User Email
+              %th Reply
           %tbody
             - survey_question.survey_replies.reload.each do |reply|
               %tr

--- a/app/views/admin/surveys/index.html.haml
+++ b/app/views/admin/surveys/index.html.haml
@@ -13,13 +13,14 @@
     .col-md-12
       %table.table.table-hover.datatable#surveys
         %thead
-          %th Title
-          %th # of questions
-          %th # of submissions
-          %th When
-          %th Start Date
-          %th End Date
-          %th Actions
+          %tr
+            %th Title
+            %th # of questions
+            %th # of submissions
+            %th When
+            %th Start Date
+            %th End Date
+            %th Actions
         %tbody
           - @surveys.each_with_index do |survey, index|
             %tr

--- a/app/views/admin/tickets/index.html.haml
+++ b/app/views/admin/tickets/index.html.haml
@@ -10,12 +10,13 @@
     .col-md-12
       %table.datatable#tickets
         %thead
-          %th Title
-          %th Price
-          %th Sold
-          %th Turnover
-          %th Registration Ticket
-          %th Actions
+          %tr
+            %th Title
+            %th Price
+            %th Sold
+            %th Turnover
+            %th Registration Ticket
+            %th Actions
         %tbody
           - @conference.tickets.each do |ticket|
             %tr

--- a/app/views/admin/tickets/show.html.haml
+++ b/app/views/admin/tickets/show.html.haml
@@ -14,12 +14,13 @@
   .col-md-12
     %table.datatable
       %thead
-        %th #
-        %th Name
-        %th Quantity
-        %th E-Mail
-        %th Affiliation
-        %th Paid
+        %tr
+          %th #
+          %th Name
+          %th Quantity
+          %th E-Mail
+          %th Affiliation
+          %th Paid
       %tbody
         - @ticket.buyers.each_with_index do |buyer, index|
           %tr

--- a/app/views/admin/tracks/index.html.haml
+++ b/app/views/admin/tracks/index.html.haml
@@ -35,16 +35,17 @@
     - if @tracks.any?
       %table.datatable#tracks
         %thead
-          %th ID
-          %th Name
-          %th Description
-          %th Room
-          %th Start Date
-          %th End Date
-          %th Submitter
-          %th Included in Cfp
-          %th State
-          %th Actions
+          %tr
+            %th ID
+            %th Name
+            %th Description
+            %th Room
+            %th Start Date
+            %th End Date
+            %th Submitter
+            %th Included in Cfp
+            %th State
+            %th Actions
         %tbody
           - @tracks.each do |track|
             %tr

--- a/app/views/admin/tracks/show.html.haml
+++ b/app/views/admin/tracks/show.html.haml
@@ -109,11 +109,12 @@
       .col-md-12
         %table.datatable
           %thead
-            %th Title
-            %th Type
-            %th Submitter
-            %th State
-            %th Time
+            %tr
+              %th Title
+              %th Type
+              %th Submitter
+              %th State
+              %th Time
           %tbody
             - @track.events.each_with_index do |event|
               %tr

--- a/app/views/admin/users/_event_registrations.html.haml
+++ b/app/views/admin/users/_event_registrations.html.haml
@@ -7,10 +7,11 @@
     .well
       %table.datatable#event_registrations
         %thead
-          %th ID
-          %th Conference
-          %th Title
-          %th Attended
+          %tr
+            %th ID
+            %th Conference
+            %th Title
+            %th Attended
         %tbody
           - @user.events_registrations.each do |event_registration|
             - event = event_registration.event

--- a/app/views/admin/users/_submissions.html.haml
+++ b/app/views/admin/users/_submissions.html.haml
@@ -6,13 +6,14 @@
     .well
       %table.datatable#submissions
         %thead
-          %th ID
-          %th Conference
-          %th Title
-          %th State
-          %th Type
-          %th Rating
-          %th Created At
+          %tr
+            %th ID
+            %th Conference
+            %th Title
+            %th State
+            %th Type
+            %th Rating
+            %th Created At
         %tbody
           - @user.events.each do |event|
             %tr

--- a/app/views/admin/users/index.html.haml
+++ b/app/views/admin/users/index.html.haml
@@ -12,13 +12,14 @@
   .col-md-12.table-responsive
     %table.datatable#users{ data: { source: admin_users_path(format: :json) } }
       %thead
-        %th{ width: '0' } ID
-        %th{ width: '0' } Confirmed?
-        %th{ width: '0' } Email
-        %th{ width: '50%' } Name
-        %th{ width: '0' } Conferences Attended
-        %th{ width: '50%' } Roles
-        %th{ width: '0' } Actions
+        %tr
+          %th{ width: '0' } ID
+          %th{ width: '0' } Confirmed?
+          %th{ width: '0' } Email
+          %th{ width: '50%' } Name
+          %th{ width: '0' } Conferences Attended
+          %th{ width: '50%' } Roles
+          %th{ width: '0' } Actions
       %tbody
 
 :javascript

--- a/app/views/admin/volunteers/_volunteers_table.html.haml
+++ b/app/views/admin/volunteers/_volunteers_table.html.haml
@@ -1,13 +1,14 @@
 .well
   %table.table.table-striped.table-bordered.table-hover#volunteerstable
     %thead
-      %th First Name
-      %th Last Name
-      %th Email
-      %th Mobile
-      %th Languages
-      %th Experience
-      %th Tshirt Size
+      %tr
+        %th First Name
+        %th Last Name
+        %th Email
+        %th Mobile
+        %th Languages
+        %th Experience
+        %th Tshirt Size
     %tbody
       - @volunteers.each do |volunteer|
         %tr

--- a/app/views/booths/index.html.haml
+++ b/app/views/booths/index.html.haml
@@ -8,43 +8,45 @@
     .margin-booth-table
       %table.table.table-striped.table-hover
         %thead
-          %th
-            %b State
-          %th
-            %b Logo
-          %th
-            %b Title
-          %th
-            %b Actions
-        - @booths.each do |booth|
           %tr
-            %td{ style: "padding:20px 8px 20px 8px;" }
-              - if (booth.state == 'to_accept' || booth.state == 'to_reject')
-                - show_state = 'new'
-              - else
-                - show_state = booth.state
-              %span{ title: show_state, class: "fa #{status_icon(booth)}" }
-            %td
-              - if booth.logo_link
-                = image_tag(booth.picture.thumb.url, width: '20%')
-            %td
-              = link_to booth.title, conference_booth_path(@conference.short_title, booth)
-            %td
-              -if can? :edit, booth
-                = link_to 'Edit', edit_conference_booth_path(@conference.short_title, booth.id),
-                  class: 'btn btn-default'
-              - if booth.transition_possible? :withdraw
-                = link_to 'Withdraw',
-                  withdraw_conference_booth_path(@conference.short_title, booth),
-                  method: :patch, class: 'btn btn-mini btn-warning', id: "withdraw_booth_#{booth.id}",
-                  data: { confirm: 'Are you sure you really want to withdraw this request?' }
-              - if booth.transition_possible? :confirm
-                = link_to 'Confirm',
-                  confirm_conference_booth_path(@conference.short_title, booth),
-                  method: :patch, class: 'btn btn-mini btn-success', id: "confirm_booth_#{booth.id}"
-              - if booth.transition_possible? :restart
-                = link_to 'Re-submit',
-                  restart_conference_booth_path(@conference.short_title, booth),
-                  method: :patch, class: 'btn btn-mini btn-success', id: "restart_booth_#{booth.id}"
+            %th
+              %b State
+            %th
+              %b Logo
+            %th
+              %b Title
+            %th
+              %b Actions
+        %tbody
+          - @booths.each do |booth|
+            %tr
+              %td{ style: "padding:20px 8px 20px 8px;" }
+                - if (booth.state == 'to_accept' || booth.state == 'to_reject')
+                  - show_state = 'new'
+                - else
+                  - show_state = booth.state
+                %span{ title: show_state, class: "fa #{status_icon(booth)}" }
+              %td
+                - if booth.logo_link
+                  = image_tag(booth.picture.thumb.url, width: '20%')
+              %td
+                = link_to booth.title, conference_booth_path(@conference.short_title, booth)
+              %td
+                -if can? :edit, booth
+                  = link_to 'Edit', edit_conference_booth_path(@conference.short_title, booth.id),
+                    class: 'btn btn-default'
+                - if booth.transition_possible? :withdraw
+                  = link_to 'Withdraw',
+                    withdraw_conference_booth_path(@conference.short_title, booth),
+                    method: :patch, class: 'btn btn-mini btn-warning', id: "withdraw_booth_#{booth.id}",
+                    data: { confirm: 'Are you sure you really want to withdraw this request?' }
+                - if booth.transition_possible? :confirm
+                  = link_to 'Confirm',
+                    confirm_conference_booth_path(@conference.short_title, booth),
+                    method: :patch, class: 'btn btn-mini btn-success', id: "confirm_booth_#{booth.id}"
+                - if booth.transition_possible? :restart
+                  = link_to 'Re-submit',
+                    restart_conference_booth_path(@conference.short_title, booth),
+                    method: :patch, class: 'btn btn-mini btn-success', id: "restart_booth_#{booth.id}"
     .pull-right
       = link_to "Add #{(t'booth').capitalize }", new_conference_booth_path(@conference.short_title), class: 'button btn btn-primary'

--- a/app/views/physical_tickets/index.html.haml
+++ b/app/views/physical_tickets/index.html.haml
@@ -13,10 +13,11 @@
       - if @physical_tickets.present?
         %table.table.table-bordered.table-striped.table-hover#roles
           %thead
-            %th ID
-            %th Type
-            %th User
-            %th Actions
+            %tr
+              %th ID
+              %th Type
+              %th User
+              %th Actions
           %tbody
             - @physical_tickets.each do |physical_ticket|
               %tr

--- a/app/views/proposals/registrations.html.haml
+++ b/app/views/proposals/registrations.html.haml
@@ -15,12 +15,13 @@
       .well
         %table.datatable#registrations
           %thead
-            %th
-            %th Name
-            %th Email
-            %th Created AT
-            %th Attended
-            %th Attended Conference
+            %tr
+              %th
+              %th Name
+              %th Email
+              %th Created AT
+              %th Attended
+              %th Attended Conference
           %tbody
             - @event.events_registrations.each.with_index(1) do |event_registration, index|
               %tr

--- a/app/views/ticket_purchases/index.html.haml
+++ b/app/views/ticket_purchases/index.html.haml
@@ -10,11 +10,12 @@
       - if @unpaid_ticket_purchases.present?
         %table.table.table-bordered.table-striped.table-hover#roles
           %thead
-            %th ID
-            %th Type
-            %th Quantity
-            %th Date
-            %th Actions
+            %tr
+              %th ID
+              %th Type
+              %th Quantity
+              %th Date
+              %th Actions
           %tbody
             - @unpaid_ticket_purchases.each do |ticket_purchase|
               %tr

--- a/spec/features/event_types_spec.rb
+++ b/spec/features/event_types_spec.rb
@@ -13,7 +13,7 @@ feature EventType do
       visit admin_conference_program_event_types_path(
                 conference_id: conference.short_title)
 
-      within('table#event_types') do
+      within('table#event_types > tbody') do
         expect(page.assert_selector('tr', count: 2)).to be true
       end
 
@@ -30,7 +30,7 @@ feature EventType do
       page.find('#flash')
       # Validations
       expect(flash).to eq('Event type successfully created.')
-      within('table#event_types') do
+      within('table#event_types > tbody') do
         expect(page.has_content?('Party')).to be true
         expect(page.has_content?('13042')).to be true
         expect(page.has_content?('#E4E4E4')).to be true
@@ -44,7 +44,7 @@ feature EventType do
       page.find('#flash')
       expect(flash).to eq('Event type successfully deleted.')
 
-      within('table#event_types') do
+      within('table#event_types > tbody') do
         expect(page.assert_selector('tr', count: 2)).to be true
         expect(page.has_content?('Party')).to be false
       end

--- a/spec/features/roles_spec.rb
+++ b/spec/features/roles_spec.rb
@@ -127,7 +127,7 @@ feature Role do
       scenario 'successfully removes role organization_admin' do
         click_link('Admins', href: admins_admin_organization_path(organization.id))
 
-        first('tr').find('.btn-danger').click
+        first('tbody > tr').find('.btn-danger').click
         organization_admin.reload
         expect(organization_admin.has_cached_role?('organization_admin', organization)).to be false
       end


### PR DESCRIPTION
### Checklist

- [x] I have read the [Contribution & Best practices Guide](https://github.com/openSUSE/osem/blob/master/CONTRIBUTING.md).
- [x] My branch is up-to-date with the upstream `master` branch.
- [x] The tests pass locally with my changes.
- [x] I have added tests that prove my fix is effective or that my feature works.
- [ ] I have added necessary documentation (if appropriate).

### Short description of what this resolves

Many views nest `th` elements directly within `thead`, but [`thead` may only contain `tr` elements](https://html.spec.whatwg.org/multipage/tables.html#the-thead-element).

Related: #1472

### Changes proposed in this pull request

Add the required `tr` elements. While we’re at it, add a few implicit `tbody` elements for consistency.

(Best viewed with [whitespace hidden](https://github.com/openSUSE/osem/pull/3133/files?w=1))