### PR TITLE
Display track description on event proposal form

### DIFF
--- a/app/assets/javascripts/osem.js
+++ b/app/assets/javascripts/osem.js
@@ -145,7 +145,7 @@ function word_count(text, divId, maxcount) {
 /* Wait for the DOM to be ready before attaching events to the elements */
 $( document ).ready(function() {
     /* Set the minimum and maximum proposal abstract word length */
-    $("#event_event_type_id").change(function () {
+    function updateEventTypeRequirements() {
         var $selected = $("#event_event_type_id option:selected")
         var max = $selected.data("max-words");
         var min = $selected.data("min-words");
@@ -153,8 +153,9 @@ $( document ).ready(function() {
         $("#abstract-maximum-word-count").text(max);
         $("#abstract-minimum-word-count").text(min);
         word_count($('#event_abstract').get(0), 'abstract-count', max);
-    })
-        .trigger('change');
+    }
+    $("#event_event_type_id").change(updateEventTypeRequirements);
+    updateEventTypeRequirements();
 
     /* Count the proposal abstract length */
     $("#event_abstract").on('input', function() {

--- a/app/views/proposals/_form.html.haml
+++ b/app/views/proposals/_form.html.haml
@@ -19,7 +19,9 @@
   - if @program.tracks.confirmed.cfp_active.any?
     .form-group
       = f.label :track_id, 'Track'
-      = f.select :track_id, @program.tracks.confirmed.cfp_active.pluck(:name, :id), { include_blank: '(Please select)' }, { class: 'form-control' }
+      = f.select :track_id, @program.tracks.confirmed.cfp_active.pluck(:name, :id), { include_blank: '(Please select)' }, { class: 'form-control select-help-toggle' }
+      = render 'shared/select_help_text', f: f, for: :track_id, include_blank: true, options: @program.tracks.confirmed.cfp_active do |track|
+        = markdown(track.description)
 .form-group
   = f.label :event_type_id, 'Type'
   = f.select :event_type_id, event_type_select_options(@conference.program.event_types), { include_blank: false }, { class: 'select-help-toggle form-control' }

--- a/app/views/proposals/_form.html.haml
+++ b/app/views/proposals/_form.html.haml
@@ -27,16 +27,14 @@
   .form-group
   = f.label :language
   = f.select :language, @languages, { include_blank: false}, { class: 'select-help-toggle form-control' }
-- @conference.program.event_types.each do |event_type|
-  %span{ class: 'help-block select-help-text event_event_type_id collapse', id: "#{event_type.id}-help" }
-    = event_type.description
+= render 'shared/select_help_text', f: f, for: :event_type_id, options: @conference.program.event_types do |event_type|
+  = event_type.description
 - if action_is_edit
   - if @conference.program.difficulty_levels.any?
     = f.label :difficulty_level
     = f.select :difficulty_level_id, @conference.program.difficulty_levels.map{|level| [level.title, level.id ] }, {include_blank: false}, { class: 'select-help-toggle form-control' }
-    - @conference.program.difficulty_levels.each do |difficulty_level|
-      %span{ class: 'help-block select-help-text collapse event_difficulty_level_id', id: "#{difficulty_level.id}-help" }
-        = difficulty_level.description
+    = render 'shared/select_help_text', f: f, for: :difficulty_level_id, options: @conference.program.difficulty_levels do |difficulty_level|
+      = difficulty_level.description
 .form-group
   = f.label :abstract
   = f.text_area :abstract, required: true, rows: 5, data: { provide: 'markdown' }, class: 'form-control'

--- a/app/views/shared/_select_help_text.html.haml
+++ b/app/views/shared/_select_help_text.html.haml
@@ -1,0 +1,10 @@
+:ruby
+  include_blank ||= false
+  select_id = field_id(f.object_name, local_assigns[:for])
+  value = f.object.send(local_assigns[:for])
+
+- options.each_with_index do |option, i|
+  - selected = value.present? ? option.id == value : !include_blank && i == 0
+
+  %span.help-block.select-help-text.collapse{ id: "#{option.id}-help", class: [select_id, ('in' if selected)] }
+    = yield option

--- a/spec/factories/event_types.rb
+++ b/spec/factories/event_types.rb
@@ -6,6 +6,7 @@ FactoryBot.define do
   factory :event_type do
     title { 'Example Event Type' }
     length { 30 }
+    description { 'This event type is an example.' }
     minimum_abstract_length { 0 }
     maximum_abstract_length { 500 }
     color { '#ffffff' }

--- a/spec/features/proposals_spec.rb
+++ b/spec/features/proposals_spec.rb
@@ -68,7 +68,7 @@ feature Event do
       @event.accept!(@options)
     end
 
-    scenario 'not signed_in user submits proposal' do
+    scenario 'not signed_in user submits proposal', js: true do
       expected_count_event = Event.count + 1
       expected_count_user = User.count + 1
 
@@ -80,7 +80,9 @@ feature Event do
         fill_in 'user_password_confirmation', with: 'testuserpassword'
       end
       fill_in 'event_title', with: 'Example Proposal'
+      expect(page).to have_selector '.in', text: 'Presentation in lecture format'
       select('Example Event Type', from: 'event[event_type_id]')
+      expect(page).to have_selector '.in', text: 'This event type is an example.'
       fill_in 'event_abstract', with: 'Lorem ipsum abstract'
 
       click_button 'Create Proposal'
@@ -102,7 +104,7 @@ feature Event do
       expect(page).to have_content 'Proposal Information'
     end
 
-    scenario 'update a proposal' do
+    scenario 'update a proposal', js: true do
       conference = create(:conference)
       create(:cfp, program: conference.program)
       proposal = create(:event, program: conference.program)
@@ -113,6 +115,7 @@ feature Event do
 
       fill_in 'event_subtitle', with: 'My event subtitle'
       select('Easy', from: 'event[difficulty_level_id]')
+      expect(page).to have_selector '.in', text: 'Events are understandable for everyone without knowledge of the topic.'
 
       click_button 'Update Proposal'
       page.find('#flash')
@@ -125,11 +128,10 @@ feature Event do
 
       visit conference_program_proposals_path(conference.short_title)
       click_link 'New Proposal'
-      expect(page).to have_selector(".in[id='#{find_field('event[event_type_id]').value}-help']") # End of animation
 
       fill_in 'event_title', with: 'Example Proposal'
       select('Example Event Type', from: 'event[event_type_id]')
-      expect(page).to have_selector(".in[id='#{find_field('event[event_type_id]').value}-help']") # End of animation
+      expect(page).to have_selector '.in', text: 'This event type is an example.'
 
       fill_in 'event_abstract', with: 'Lorem ipsum abstract'
       expect(page).to have_text('You have used 3 words')

--- a/spec/features/proposals_spec.rb
+++ b/spec/features/proposals_spec.rb
@@ -106,6 +106,9 @@ feature Event do
 
     scenario 'update a proposal', js: true do
       conference = create(:conference)
+      create :track, program:     conference.program,
+                     name:        'Example Track',
+                     description: 'This track is an *example*.'
       create(:cfp, program: conference.program)
       proposal = create(:event, program: conference.program)
 
@@ -114,6 +117,8 @@ feature Event do
       visit edit_conference_program_proposal_path(proposal.program.conference.short_title, proposal)
 
       fill_in 'event_subtitle', with: 'My event subtitle'
+      select 'Example Track', from: 'Track'
+      expect(page).to have_selector '.in', text: 'This track is an example.'
       select('Easy', from: 'event[difficulty_level_id]')
       expect(page).to have_selector '.in', text: 'Events are understandable for everyone without knowledge of the topic.'
 


### PR DESCRIPTION
### Checklist

- [x] I have read the [Contribution & Best practices Guide](https://github.com/openSUSE/osem/blob/master/CONTRIBUTING.md).
- [x] My branch is up-to-date with the upstream `master` branch.
- [x] The tests pass locally with my changes.
- [x] I have added tests that prove my fix is effective or that my feature works.
- [ ] I have added necessary documentation (if appropriate).

### Short description of what this resolves

1. The help text for the difficulty level field doesn’t appear until the value has been changed. (The event type field is also affected, but this is mitigated by an incidental [synthetic change event](https://github.com/openSUSE/osem/blob/master/app/assets/javascripts/osem.js#L157).)

2. CfP respondents don’t have a way to see the descriptions of available tracks.

### Changes proposed in this pull request

1. Render help text with the correct initial visibility.

3. Show the track description as help text:

    > <img src="https://user-images.githubusercontent.com/1844746/224437086-0faa8290-b9ba-47e0-8ab9-05fd4fe5db63.png" width="370" alt="screenshot" />