### PR TITLE
Move text out of Font Awesome icons

### DIFF
--- a/app/views/proposals/_tooltip.html.haml
+++ b/app/views/proposals/_tooltip.html.haml
@@ -3,28 +3,28 @@
   - if can? :create, @conference.registrations.new
     %li{'class'=>class_for_todo(progress_status['registered'])}
       %span{'class'=>icon_for_todo(progress_status['registered'])}
-        - if progress_status['registered']
-          Speaker(s) registered to the conference
-        - else
-          = link_to 'Speaker(s) not registered to the conference', new_conference_conference_registration_path(event.program.conference.short_title)
+      - if progress_status['registered']
+        Speaker(s) registered to the conference
+      - else
+        = link_to 'Speaker(s) not registered to the conference', new_conference_conference_registration_path(event.program.conference.short_title)
   %li{'class'=>class_for_todo(progress_status['biographies'])}
     %span{'class'=>icon_for_todo(progress_status['biographies'])}
-      - if progress_status['biographies']
-        Speakers have filled out their biographies
-      - elsif current_user.biography.blank? && event.speakers.include?(current_user)
-        = link_to 'Fill out your biography', edit_user_path(current_user)
-      - else
-        Speakers' biographies missing
+    - if progress_status['biographies']
+      Speakers have filled out their biographies
+    - elsif current_user.biography.blank? && event.speakers.include?(current_user)
+      = link_to 'Fill out your biography', edit_user_path(current_user)
+    - else
+      Speakers' biographies missing
   %li{'class'=>class_for_todo(progress_status['subtitle'])}
     %span{'class'=>icon_for_todo(progress_status['subtitle'])}
-      = link_to 'Add a subtitle', edit_conference_program_proposal_path(event.program.conference.short_title, event)
+    = link_to 'Add a subtitle', edit_conference_program_proposal_path(event.program.conference.short_title, event)
   %li{'class'=>class_for_todo(progress_status['commercials'])}
     %span{'class'=>icon_for_todo(progress_status['commercials'])}
-      = link_to 'Add a commercial', edit_conference_program_proposal_path(event.program.conference.short_title, event, anchor: 'commercials-content')
+    = link_to 'Add a commercial', edit_conference_program_proposal_path(event.program.conference.short_title, event, anchor: 'commercials-content')
   - unless progress_status['track'].nil?
     %li{'class'=>class_for_todo(progress_status['track'])}
       %span{'class'=>icon_for_todo(progress_status['track'])}
-        = link_to 'Add a track', edit_conference_program_proposal_path(event.program.conference.short_title, event)
+      = link_to 'Add a track', edit_conference_program_proposal_path(event.program.conference.short_title, event)
   %li{'class'=>class_for_todo(progress_status['difficulty_level'])}
     %span{'class'=>icon_for_todo(progress_status['difficulty_level'])}
-      = link_to 'Add a difficulty level', edit_conference_program_proposal_path(event.program.conference.short_title, event)
+    = link_to 'Add a difficulty level', edit_conference_program_proposal_path(event.program.conference.short_title, event)


### PR DESCRIPTION
### Checklist

- [x] I have read the [Contribution & Best practices Guide](https://github.com/openSUSE/osem/blob/master/CONTRIBUTING.md).
- [x] My branch is up-to-date with the upstream `master` branch.
- [x] The tests pass locally with my changes.
- [ ] I have added tests that prove my fix is effective or that my feature works (if appropriate).
- [ ] I have added necessary documentation (if appropriate).

### Short description of what this resolves

Font Awesome icon elements are [intended to be empty](https://fontawesome.com/docs/web/add-icons/how-to#add-icons-to-html). In this todo list, icon elements wrap around the adjacent text, causing the text to be displayed in an irregular font:

> <img src="https://user-images.githubusercontent.com/1844746/224440601-0f247400-e2b6-4ede-a095-67e953897540.png" width="512" alt="screenshot" />

### Changes proposed in this pull request

Move the text out of the icon elements:

> <img src="https://user-images.githubusercontent.com/1844746/224440621-43c43090-8fe2-4860-9963-75f095f659ea.png" width="512" alt="screenshot" />
