### PR TITLE
Don’t automatically select a difficulty level

### DIFF
--- a/app/views/proposals/_form.html.haml
+++ b/app/views/proposals/_form.html.haml
@@ -33,7 +33,7 @@
 - if action_is_edit
   - if @conference.program.difficulty_levels.any?
     = f.label :difficulty_level
-    = f.select :difficulty_level_id, @conference.program.difficulty_levels.map{|level| [level.title, level.id ] }, {include_blank: false}, { class: 'select-help-toggle form-control' }
+    = f.select :difficulty_level_id, @conference.program.difficulty_levels.map{|level| [level.title, level.id ] }, {include_blank: '(Please select)'}, { class: 'select-help-toggle form-control' }
     - @conference.program.difficulty_levels.each do |difficulty_level|
       %span{ class: 'help-block select-help-text collapse event_difficulty_level_id', id: "#{difficulty_level.id}-help" }
         = difficulty_level.description


### PR DESCRIPTION
### Checklist

- [x] I have read the [Contribution & Best practices Guide](https://github.com/openSUSE/osem/blob/master/CONTRIBUTING.md).
- [x] My branch is up-to-date with the upstream `master` branch.
- [x] The tests pass locally with my changes.
- [ ] I have added tests that prove my fix is effective or that my feature works (if appropriate).
- [ ] I have added necessary documentation (if appropriate).

### Short description of what this resolves

Opening and saving the proposal form is not idempotent; when no difficulty level has yet been chosen by the submitter, the form automatically selects the first difficulty level.

- This UI behavior is easy to overlook when intending to edit only other fields, resulting inadvertent selection and miscommunication to reviewers.
- In effect this behaves as a required field, but in a subtle and surprising way. If it’s intended for this field to be required, it [should be](https://github.com/openSUSE/osem/pull/677#issuecomment-112004676) grouped with the other required fields on the first step.

### Changes proposed in this pull request

Allow the field to remain unfilled.