### PR TITLE
Corrections to proposal help text

### DIFF
--- a/app/assets/javascripts/osem.js
+++ b/app/assets/javascripts/osem.js
@@ -145,7 +145,7 @@ function word_count(text, divId, maxcount) {
 /* Wait for the DOM to be ready before attaching events to the elements */
 $( document ).ready(function() {
     /* Set the minimum and maximum proposal abstract word length */
-    function updateEventTypeRequirements() {
+    $("#event_event_type_id").change(function () {
         var $selected = $("#event_event_type_id option:selected")
         var max = $selected.data("max-words");
         var min = $selected.data("min-words");
@@ -153,9 +153,7 @@ $( document ).ready(function() {
         $("#abstract-maximum-word-count").text(max);
         $("#abstract-minimum-word-count").text(min);
         word_count($('#event_abstract').get(0), 'abstract-count', max);
-    }
-    $("#event_event_type_id").change(updateEventTypeRequirements);
-    updateEventTypeRequirements();
+    });
 
     /* Count the proposal abstract length */
     $("#event_abstract").on('input', function() {

--- a/app/helpers/event_types_helper.rb
+++ b/app/helpers/event_types_helper.rb
@@ -8,6 +8,13 @@ module EventTypesHelper
   # ====Returns
   # * +String+ -> number of registrations / max allowed registrations
   def event_type_select_options(event_types = {})
-    event_types.map { |type| ["#{type.title} - #{show_time(type.length)}", type.id] }
+    event_types.map do |type|
+      content = "#{type.title} - #{show_time(type.length)}"
+      value = type.id
+      attributes = { data: { min_words: type.minimum_abstract_length,
+                             max_words: type.maximum_abstract_length } }
+
+      [content, value, attributes]
+    end
   end
 end

--- a/app/views/proposals/_form.html.haml
+++ b/app/views/proposals/_form.html.haml
@@ -4,6 +4,8 @@
   display_details = user_is_admin || action_is_edit
   display_registration = user_is_admin || @program.cfp&.enable_registrations?
 
+  event_type = @event.event_type || @conference.program.event_types.first
+
 %h4
   Proposal Information
 %hr
@@ -50,11 +52,9 @@
     You have used
     %span#abstract-count= @event.abstract_word_count
     words.  Abstracts must be between
-    %span#abstract-minimum-word-count
-      0
+    %span#abstract-minimum-word-count= event_type.minimum_abstract_length
     and
-    %span#abstract-maximum-word-count
-      250
+    %span#abstract-maximum-word-count= event_type.maximum_abstract_length
     words.
   - if display_registration && display_details
     %h4

--- a/app/views/proposals/_form.html.haml
+++ b/app/views/proposals/_form.html.haml
@@ -48,7 +48,7 @@
     = markdown_hint('[Tips to improve your presentations.](http://blog.hubspot.com/blog/tabid/6307/bid/5975/10-Rules-to-Instantly-Improve-Your-Presentations.aspx)')
   %p
     You have used
-    %span#abstract-count = @event.abstract_word_count
+    %span#abstract-count= @event.abstract_word_count
     words.  Abstracts must be between
     %span#abstract-minimum-word-count
       0

--- a/spec/factories/event_types.rb
+++ b/spec/factories/event_types.rb
@@ -8,7 +8,7 @@ FactoryBot.define do
     length { 30 }
     description { 'This event type is an example.' }
     minimum_abstract_length { 0 }
-    maximum_abstract_length { 500 }
+    maximum_abstract_length { 123 }
     color { '#ffffff' }
     program
   end


### PR DESCRIPTION
### Checklist

- [x] I have read the [Contribution & Best practices Guide](https://github.com/openSUSE/osem/blob/master/CONTRIBUTING.md).
- [x] My branch is up-to-date with the upstream `master` branch.
- [x] The tests pass locally with my changes.
- [x] I have added tests that prove my fix is effective or that my feature works.
- [ ] I have added necessary documentation (if appropriate).

### Short description of what this resolves

Three interconnected issues related to help text on the proposal form:

1. The proposal form ignores the [length requirements](https://github.com/openSUSE/osem/blob/bd937534d35bc63e18e8a0b6bc2d56d1a7cab38d/db/schema.rb#L214-L215) of event types. It always displays a [hard-coded](https://github.com/openSUSE/osem/blob/bd937534d35bc63e18e8a0b6bc2d56d1a7cab38d/app/views/proposals/_form.html.haml#L52-L58) value:

    > Abstracts must be between 0 and 250 words.

2. The static proposal form contains unevaluated view code:

    > You have used = @event.abstract_word_count words.

3. [#3138](https://github.com/openSUSE/osem/pull/3138) introduced a JavaScript error on pages that don’t contain the proposal form:

        Uncaught TypeError: text is undefined
          at word_count (app/assets/javascripts/osem.js:134)

### Changes proposed in this pull request

1. Restore the [length requirement data](https://github.com/openSUSE/osem/blob/350b1ebbbe11f42899a9e743e1dbcbdfd0516746/app/views/proposals/new.html.haml#L36) accidentally lost in #2914.

2. Correct the [malformed](https://github.com/openSUSE/osem/blob/bd937534d35bc63e18e8a0b6bc2d56d1a7cab38d/app/views/proposals/_form.html.haml#L51) Haml.

3. The purpose of the [code that triggers the error](https://github.com/openSUSE/osem/blob/bd937534d35bc63e18e8a0b6bc2d56d1a7cab38d/app/assets/javascripts/osem.js#L158) is to immediately overwrite server-rendered content on the client. Ideally the server should just render the correct content in the first place. So do that, and remove the now unnecessary client side render.