### PR TITLE
Allow runtime configuration of Sentry tracing sample rate

### DIFF
--- a/config/initializers/sentry.rb
+++ b/config/initializers/sentry.rb
@@ -4,7 +4,7 @@ Sentry.init do |config|
 
   # To activate performance monitoring, set one of these options.
   # We recommend adjusting the value in production:
-  config.traces_sample_rate = 0.5
+  config.traces_sample_rate = ENV.fetch('OSEM_SENTRY_TRACES_SAMPLE_RATE', '0.5').to_f
   # or
   # config.traces_sampler = lambda do |context|
   #  true


### PR DESCRIPTION
### Checklist

- [x] I have read the [Contribution & Best practices Guide](https://github.com/openSUSE/osem/blob/master/CONTRIBUTING.md).
- [x] My branch is up-to-date with the upstream `master` branch.
- [x] The tests pass locally with my changes.
- [ ] I have added tests that prove my fix is effective or that my feature works.
- [ ] I have added necessary documentation (if appropriate).

### Short description of what this resolves

Sentry’s [tracing sample rate](https://docs.sentry.io/platforms/ruby/guides/rails/configuration/options/#tracing-options) may need to be adjusted for each environment.

### Changes proposed in this pull request

Allow configuring it via the environment variable `OSEM_SENTRY_TRACES_SAMPLE_RATE`.