### PR TITLE
Fix bug in naming of Sentry release

### DIFF
--- a/config/initializers/sentry.rb
+++ b/config/initializers/sentry.rb
@@ -14,7 +14,7 @@ Sentry.init do |config|
   # Unless someone has set a variable of course...
   osem_version_from_file = nil
   version_file = File.expand_path('../../tmp/restart.txt', __dir__)
-  osem_version_from_file = File.new(version_file).atime.to_i if File.file?(version_file)
+  osem_version_from_file = File.new(version_file).atime.strftime('%s') if File.file?(version_file)
   osem_version = ENV.fetch('OSEM_SENTRY_RELEASE', osem_version_from_file)
   config.release = osem_version if osem_version
 end


### PR DESCRIPTION


### Checklist

- [x] I have read the [Contribution & Best practices Guide](https://github.com/openSUSE/osem/blob/master/CONTRIBUTING.md).
- [x] My branch is up-to-date with the upstream `master` branch.
- [x] The tests pass locally with my changes.
- [ ] I have added tests that prove my fix is effective or that my feature works (if appropriate).
- [ ] I have added necessary documentation (if appropriate).

### Short description of what this resolves

In #3299 sentry-ruby was updated past 5.10 which introduces getsentry/sentry-ruby#2004, resulting in:

    ArgumentError: expect the argument to be a String or NilClass, got Integer (1646633480)
    /osem/config/initializers/sentry.rb:19

### Changes proposed in this pull request

Generate a String instead of Integer.