### PR TITLE
Fix bug in initial scheduling of events

### DIFF
--- a/app/assets/javascripts/osem-schedule.js
+++ b/app/assets/javascripts/osem-schedule.js
@@ -46,7 +46,7 @@ var Schedule = {
       room_id: new_parent.attr("room_id"),
       start_time: (new_parent.attr("date") + ' ' + new_parent.attr("hour"))
     }};
-    if(event_schedule_id != null){
+    if(event_schedule_id){
       type = 'PUT';
       my_url += ('/' + event_schedule_id);
     }


### PR DESCRIPTION
Resolves inability to schedule a nonscheduled event:

    ActionController::RoutingError: No route matches [PUT] "/admin/conferences/…/event_schedules"

`event_schedule_id` represents the absence of a schedule as either an empty string or undefined, not as null.

Fixes #3551