### PR TITLE
Adapt to osem/base:latest using openSUSE Leap 15.6

### DIFF
--- a/Dockerfile.production
+++ b/Dockerfile.production
@@ -1,20 +1,28 @@
 FROM registry.opensuse.org/opensuse/infrastructure/dale/containers/osem/base:latest
 
+EXPOSE 5000
+
 ENV RAILS_ENV=production
+ENV RAILS_SERVE_STATIC_FILES=true
 
 # Add our files
 COPY --chown=1000:1000 . /osem/
 
-# Install bundler & foreman
-RUN gem install bundler -v "$(grep -A 1 "BUNDLED WITH" /osem/Gemfile.lock | tail -n 1)"; \
-    gem install foreman
+# Install foreman
+RUN gem install foreman
 
 USER osem
 WORKDIR /osem/
 
+RUN rm -rf /osem/public/system/sponsors; mkdir -p /osem/public/system/sponsors; \
+    rm -rf /osem/public/assets; mkdir -p /osem/public/assets; \
+    rm -rf /osem/log; mkdir -p /osem/public/assets
+
 # Install our bundle
-RUN bundle config set --local without 'test development'
-RUN bundle install --jobs=3 --retry=3
+RUN bundle config set --local without 'test development'; \
+    bundle config set --local path 'vendor/bundle'; \
+    bundle config build.nokogiri --use-system-libraries; \
+    bundle install --jobs=4 --retry=3
 
 # Generate assets
 RUN bundle exec rake assets:precompile

--- a/INSTALL.md
+++ b/INSTALL.md
@@ -37,11 +37,11 @@ There are too many to list, here are a few we have seen OSEM deployed to:
 
 We recommend to run OSEM in production with [mod\_passenger](https://www.phusionpassenger.com/download/#open_source)
 and the [apache web-server](https://www.apache.org/). There are tons of guides on how to deploy rails apps on various
-base operating systems. [Check Google](https://encrypted.google.com/search?hl=en&q=ruby%20on%20rails%20apache%20passenger). Of course there are also other options for the application server and reverse proxy, pick your poison.
+base operating systems, [check DuckDuckGo](https://duckduckgo.com/?t=h_&q=ruby+on+rails+apache+passenger). Of course there are also other options for the application server and reverse proxy, pick your poison.
 
 ## Deploy via docker/docker-compose
 
-There is a rudimentary docker-compose configuration for production usage (`docker-compose.yml.production-example`). It brings [OSEM up](http://0.0.0.0:8080) on port 8080. It uses persistent storage volumes for all the data users might create. You can start it with
+There is a rudimentary docker-compose configuration for production usage (`docker-compose.yml.production-example`). It brings OSEM up on port 80. It uses persistent storage volumes for all the data your users might create. You can start it with
 
 1. Configure OSEM (at least `SECRET_KEY_BASE`)
    ```
@@ -54,12 +54,13 @@ There is a rudimentary docker-compose configuration for production usage (`docke
    ```
 1. Setup the database (only once)
    ```
-   docker-compose -f docker-compose.yml.production-example run --rm production_web bundle exec rake db:bootstrap
+   docker-compose -f docker-compose.yml.production-example run --rm osem bundle exec rake db:setup
    ```
 1. Start the services
    ```
    docker-compose -f docker-compose.yml.production-example up
    ```
+1. Visit http://0.0.0.0
 
 ## Configuration
 OSEM is configured through environment variables and falls back to sensible defaults. See the [dotenv.example](https://github.com/openSUSE/osem/blob/master/dotenv.example) for all possible configuration options. However here is a list of things you most likely want to configure because otherwise things will not work as expected.

--- a/docker-compose.yml.production-example
+++ b/docker-compose.yml.production-example
@@ -1,24 +1,25 @@
 services:
-  production_database:
-    image: postgres:12-alpine
+  postgres:
+    image: postgres:16-alpine
     environment:
       PGDATA: /var/lib/postgresql/data/pgdata
+      POSTGRES_USER: osem
       POSTGRES_PASSWORD: mysecretpassword
     volumes:
       - osem_production_database:/var/lib/postgresql/data/pgdata
-  production_web:
+  osem:
     build:
       context: .
       dockerfile: Dockerfile.production
     depends_on:
-      - production_database
+      - postgres
     ports:
-      - 8080:3000
+      - 80:5000
     env_file: .env.production # see dotenv.example file
     environment:
-     OSEM_DB_HOST: production_database
-     RAILS_SERVE_STATIC_FILES: 'true'
-    command: foreman start -p 3000
+     OSEM_DB_HOST: postgres
+     OSEM_DB_USER: osem
+     OSEM_DB_PASSWORD: mysecretpassword
     volumes:
       - osem_production_web_data:/osem/public/system
       - osem_production_web_assets:/osem/public/assets


### PR DESCRIPTION
- No need to manually install bundler anymore
- bundle to vendor/bundle
- build nokogiri against system libraries
- expose the port foreman is using
- serve static files

Fixes #2511

