### PR TITLE
Avoid 500 when event type length is blank

### DIFF
--- a/app/models/event_type.rb
+++ b/app/models/event_type.rb
@@ -22,9 +22,13 @@ class EventType < ApplicationRecord
 
   ##
   # Check if length is a divisor of program schedule cell size. Used as validation.
+  # Skipped when length is missing or non-numeric so that the numericality
+  # validator can produce a proper error instead of crashing.
   #
   def length_step
-    errors.add(:length, "must be a divisor of #{program.schedule_interval}") if program && length % program.schedule_interval != 0
+    return unless program && length.is_a?(Numeric)
+
+    errors.add(:length, "must be a divisor of #{program.schedule_interval}") if length % program.schedule_interval != 0
   end
 
   def capitalize_color

--- a/spec/models/event_type_spec.rb
+++ b/spec/models/event_type_spec.rb
@@ -44,6 +44,13 @@ describe EventType do
       it 'is not valid when length is not multiple of LENGTH_STEP' do
         expect(build(:event_type, program: conference.program, length: 37)).not_to be_valid
       end
+
+      it 'is not valid when length is blank and does not raise during validation' do
+        event_type = build(:event_type, program: conference.program, length: nil)
+        expect { event_type.valid? }.not_to raise_error
+        expect(event_type).not_to be_valid
+        expect(event_type.errors[:length]).to be_present
+      end
     end
   end
 end


### PR DESCRIPTION
**Checklist**

- [x] I have read the [Contribution & Best practices Guide](https://github.com/openSUSE/osem/blob/master/CONTRIBUTING.md).
- [x] My branch is up-to-date with the upstream \`master\` branch.
- [x] The tests pass locally with my changes.
- [x] I have added tests that prove my fix is effective or that my feature works(if appropriate).
- [ ] I have added necessary documentation (if appropriate).

**Short description of what this resolves/which [issues](https://github.com/openSUSE/osem/issues) does this fix?:**

- Fixes #3137: Submitting the event-type edit form with an empty *Length* field returned a 500 Internal Server Error instead of a regular validation failure.

**Changes proposed in this pull request:**

- Guard the \`EventType#length_step\` validator so that the divisor check is only performed once the value is numeric. With a blank length the \`numericality\` validator now produces the usual \"is not a number\" error and the form renders normally instead of raising \`NoMethodError\`.
- Add a model spec covering the blank length case.