### PR TITLE
Fix: correct volunteer T-shirt wording

### DIFF
--- a/app/views/admin/volunteers/_volunteers_table.html.haml
+++ b/app/views/admin/volunteers/_volunteers_table.html.haml
@@ -8,7 +8,7 @@
         %th Mobile
         %th Languages
         %th Experience
-        %th Tshirt Size
+        %th T-shirt Size
     %tbody
       - @volunteers.each do |volunteer|
         %tr

--- a/app/views/devise/registrations/_volunteeruser.html.haml
+++ b/app/views/devise/registrations/_volunteeruser.html.haml
@@ -1,6 +1,6 @@
 = u.input :mobile,  label: 'Mobile No (Include country code)', input_html: {placeholder: 'Eg. +336812345679'}, hint: 'Only visible to org team & volunteer coordinator'
 
-= u.input :tshirt, label: "Tshirt Size", collection: [["Choose", nil],["XS","XS"],["S","S"],["M", "M"], ["L", "L"], ["XL", "XL"], ["XXL", "XXL"], ["XXXL", "XXXL"], ["Girl-S","Girl-s"], ["Girl-M","Girl-M"], ["Girl-L","Girl-L"], ["Girl-XL","Girl-XL"]]
+= u.input :tshirt, label: "T-shirt Size", collection: [["Choose", nil],["XS","XS"],["S","S"],["M", "M"], ["L", "L"], ["XL", "XL"], ["XXL", "XXL"], ["XXXL", "XXXL"], ["Girl-S","Girl-S"], ["Girl-M","Girl-M"], ["Girl-L","Girl-L"], ["Girl-XL","Girl-XL"]]
 
 = u.input :languages, label: "Which languages do you speak", hint: "Start from the one you speak best and use 2 letter symbolization, eg. EN, GR, DE"
 


### PR DESCRIPTION
This PR corrects volunteer facing T-shirt wording in the registration form and volunteer admin table.

It changes `Tshirt Size` to `T-shirt Size` and normalizes `Girl-s` to `Girl-S`.