### PR TITLE
Test: clean up spec description typos

### DIFF
--- a/spec/controllers/admin/cfps_controller_spec.rb
+++ b/spec/controllers/admin/cfps_controller_spec.rb
@@ -11,14 +11,14 @@ describe Admin::CfpsController do
   before { sign_in(organizer) }
 
   describe 'POST #create' do
-    it 'successes' do
+    it 'succeeds' do
       post :create, params: { conference_id: conference.short_title, cfp: { cfp_type: 'events', start_date: today, end_date: today + 6.days, description: 'We call for papers, or tabak, or you know what!' } }
       expect(flash[:notice]).to match('Call for papers successfully created.')
     end
   end
 
   describe 'POST #update' do
-    it 'successes' do
+    it 'succeeds' do
       patch :update, params: { conference_id: conference.short_title, id: cfp.id, cfp: { end_date: today + 10.days } }
       expect(flash[:notice]).to match('Call for papers successfully updated.')
     end

--- a/spec/controllers/admin/rooms_controller_spec.rb
+++ b/spec/controllers/admin/rooms_controller_spec.rb
@@ -50,7 +50,7 @@ describe Admin::RoomsController do
     end
 
     describe 'POST #create' do
-      context 'saves successfuly' do
+      context 'saves successfully' do
         before do
           post :create, params: { room: attributes_for(:room), conference_id: conference.short_title }
         end

--- a/spec/controllers/admin/sponsorship_levels_controller_spec.rb
+++ b/spec/controllers/admin/sponsorship_levels_controller_spec.rb
@@ -48,7 +48,7 @@ describe Admin::SponsorshipLevelsController do
     end
 
     describe 'POST #create' do
-      context 'saves successfuly' do
+      context 'saves successfully' do
         before(:each, run: true) do
           post :create, params: { sponsorship_level: attributes_for(:sponsorship_level),
                                   conference_id:     conference.short_title }

--- a/spec/controllers/admin/tracks_controller_spec.rb
+++ b/spec/controllers/admin/tracks_controller_spec.rb
@@ -62,7 +62,7 @@ describe Admin::TracksController do
   end
 
   describe 'POST #create' do
-    context 'saves successfuly' do
+    context 'saves successfully' do
       before :each do
         post :create, params: { track: attributes_for(:track), conference_id: conference.short_title }
       end

--- a/spec/controllers/admin/users_controller_spec.rb
+++ b/spec/controllers/admin/users_controller_spec.rb
@@ -55,7 +55,7 @@ describe Admin::UsersController do
   end
 
   describe 'POST #create' do
-    context 'saves successfuly' do
+    context 'saves successfully' do
       before do
         post :create, params: { user: attributes_for(:user) }
       end

--- a/spec/controllers/tracks_controller_spec.rb
+++ b/spec/controllers/tracks_controller_spec.rb
@@ -60,7 +60,7 @@ describe TracksController do
   end
 
   describe 'POST #create' do
-    context 'saves successfuly' do
+    context 'saves successfully' do
       before :each do
         post :create, params: { track: attributes_for(:track, :self_organized, short_name: 'my_track'), conference_id: conference.short_title }
       end

--- a/spec/features/ticket_purchases_spec.rb
+++ b/spec/features/ticket_purchases_spec.rb
@@ -22,7 +22,7 @@ feature Registration do
 
     context 'who is not registered' do
 
-      scenario 'purchases and pays for a ticket succcessfully', feature: true, js: true do
+      scenario 'purchases and pays for a ticket successfully', feature: true, js: true do
         skip 'broken'
 
         visit root_path
@@ -132,7 +132,7 @@ feature Registration do
         expect(current_path).to eq(conference_tickets_path(conference.short_title))
       end
 
-      scenario 'purchases one registration ticket of a different types' do
+      scenario 'purchases one registration ticket of different types' do
         visit root_path
         click_link 'Register'
 
@@ -152,7 +152,7 @@ feature Registration do
 
     context 'who is registered' do
 
-      scenario 'unregisters from conference, but ticket purchases dont delete', feature: true, js: true do
+      scenario "unregisters from conference, but ticket purchases don't delete", feature: true, js: true do
         skip 'broken'
 
         visit root_path


### PR DESCRIPTION
## Description:

This PR fixes editorial typos in spec descriptions and context labels.

It updates wording in controller specs and in `spec/features/ticket_purchases_spec.rb` without changing test behavior.

## Validation:
- [x] `bundle exec rubocop -c /tmp/osem-rubocop-33.yml --except Layout/EndOfLine spec/controllers/admin/cfps_controller_spec.rb spec/controllers/admin/rooms_controller_spec.rb spec/controllers/admin/sponsorship_levels_controller_spec.rb spec/controllers/admin/tracks_controller_spec.rb spec/controllers/admin/users_controller_spec.rb spec/controllers/tracks_controller_spec.rb spec/features/ticket_purchases_spec.rb`
- [x] `bundle exec rspec spec/controllers/admin/cfps_controller_spec.rb spec/controllers/admin/rooms_controller_spec.rb spec/controllers/admin/sponsorship_levels_controller_spec.rb spec/controllers/admin/tracks_controller_spec.rb spec/controllers/admin/users_controller_spec.rb spec/controllers/tracks_controller_spec.rb`
- [x] `bundle exec rspec --dry-run spec/features/ticket_purchases_spec.rb`
- [x] `ruby -c spec/features/ticket_purchases_spec.rb`
