### PR TITLE
Docs: fix Gemfile authentication comment

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -36,7 +36,7 @@ gem 'mini_magick'
 # for internationalizing
 gem 'rails-i18n'
 
-# as authentification framework
+# as authentication framework
 gem 'devise'
 gem 'devise_ichain_authenticatable'
 


### PR DESCRIPTION
This PR fixes a spelling mistake in a developer-facing Gemfile comment.

It changes `authentification` to `authentication` in `Gemfile`.
