### PR TITLE
Evaluate the CFP period in the conference timezone

### DIFF
--- a/app/models/cfp.rb
+++ b/app/models/cfp.rb
@@ -63,7 +63,7 @@ class Cfp < ApplicationRecord
     end_date.strftime('%W').to_i
   end
 
-  def remaining_days(date = Date.today)
+  def remaining_days(date = conference_today)
     result = (end_date - date).to_i
     result > 0 ? result : 0
   end
@@ -75,7 +75,7 @@ class Cfp < ApplicationRecord
   # * +false+ -> If the CFP is not set or today isn't in the CFP period.
   # * +true+ -> If today is in the CFP period.
   def open?
-    (start_date..end_date).cover?(Date.current)
+    (start_date..end_date).cover?(conference_today)
   end
 
   ##
@@ -106,6 +106,16 @@ class Cfp < ApplicationRecord
   end
 
   private
+
+  ##
+  # The current date in the conference timezone, so that the CFP opens and
+  # closes when the conference says it does rather than when the server does.
+  #
+  # ====Returns
+  # * +Date+ -> Today in the conference timezone
+  def conference_today
+    Time.find_zone(program.conference.timezone).today
+  end
 
   def before_end_of_conference
     if program&.conference&.end_date && end_date && (end_date > program.conference.end_date)

--- a/spec/models/cfp_spec.rb
+++ b/spec/models/cfp_spec.rb
@@ -131,25 +131,57 @@ describe Cfp do
   end
 
   describe '#open?' do
+    # The CFP period is evaluated in the conference timezone, which the factory
+    # randomises, so anchor the dates in that timezone as well.
+    let(:today) { Time.find_zone(conference.timezone).today }
+
     context 'returns false' do
       it 'when start and end dates are in the past' do
-        cfp.start_date = Date.current - 3
-        cfp.end_date = Date.current - 1
+        cfp.start_date = today - 3
+        cfp.end_date = today - 1
         expect(cfp.open?).to be(false)
       end
 
       it 'when start and end dates are in the future' do
-        cfp.start_date = Date.current + 1
-        cfp.end_date = Date.current + 3
+        cfp.start_date = today + 1
+        cfp.end_date = today + 3
         expect(cfp.open?).to be(false)
       end
     end
 
     context 'returns true' do
       it 'when start date is in the past and end date is in the future' do
-        cfp.start_date = Date.current - 1
-        cfp.end_date = Date.current + 1
+        cfp.start_date = today - 1
+        cfp.end_date = today + 1
         expect(cfp.open?).to be(true)
+      end
+    end
+
+    context 'when the conference timezone is ahead of the server' do
+      # 2026-06-01 23:30 UTC is already 2026-06-02 11:30 in Auckland, so the
+      # server and the conference disagree about which day it is.
+      before do
+        cfp.program.conference.update_attribute(:timezone, 'Pacific/Auckland')
+        Timecop.freeze(Time.utc(2026, 6, 1, 23, 30))
+      end
+
+      after { Timecop.return }
+
+      it 'is open on a day that has started for the conference but not for the server' do
+        cfp.start_date = Date.new(2026, 6, 2)
+        cfp.end_date = Date.new(2026, 6, 2)
+        expect(cfp.open?).to be(true)
+      end
+
+      it 'is closed on a day that has ended for the conference but not for the server' do
+        cfp.start_date = Date.new(2026, 6, 1)
+        cfp.end_date = Date.new(2026, 6, 1)
+        expect(cfp.open?).to be(false)
+      end
+
+      it 'counts the remaining days from the conference date' do
+        cfp.end_date = Date.new(2026, 6, 5)
+        expect(cfp.remaining_days).to eq(3)
       end
     end
   end


### PR DESCRIPTION
Fixes #2769.

`Cfp#open?` compared the CFP period against `Date.current`, which resolves in the server timezone rather than the conference's. `Cfp#remaining_days` had the same defect one step worse — it defaulted to `Date.today`, which ignores `Time.zone` entirely.

So for any conference whose timezone differs from the server's, the call for papers opened and closed at the wrong moment. With the server on UTC and the conference in `Pacific/Auckland` (UTC+12), during the first 12 hours of the 2nd the conference is on the 2nd while the server is still on the 1st, so a CFP starting on the 2nd was still reported closed, and a CFP ending on the 1st stayed open. It opened late and closed late, by the size of the offset. The "N days remaining" counter shown on the CFP pages was off by one over the same window.

Both now resolve today in the conference timezone, via a private `conference_today` that reuses the `Time.find_zone(timezone)` idiom already used by `Conference#current_conference_day`.

I fixed `remaining_days` alongside `open?` because it is the same bug reached through a different method — it is displayed next to the CFP state in `admin/cfps`, `conferences/_call_for_*` and `proposals/_encouragement_text`, so leaving it on the server clock would keep showing a counter that disagrees with `open?`.

### Tests

`spec/models/cfp_spec.rb` gains a context that pins the conference to `Pacific/Auckland` and freezes the clock at `2026-06-01 23:30 UTC` — 11:30 on the 2nd in Auckland — so the server and the conference disagree about the date. It covers both directions: a CFP for the 2nd is open (the server would call it closed), a CFP for the 1st is closed (the server would call it open), and `remaining_days` counts from the conference's date. All three fail on `master`.

The existing `#open?` examples anchored their dates to `Date.current` while the conference factory assigns a random timezone (`Faker::Address.time_zone`), so they would have become intermittently flaky once the comparison moved to the conference clock. They now anchor to the same timezone they assert against.

Timecop was already declared in the `Gemfile` for this purpose but not yet used anywhere.

I do not have a working Ruby/PostgreSQL environment on this machine, so I have not run the suite locally — I am relying on CI here and will follow up on anything it reports.
